### PR TITLE
feat(cactus-web): Text icon buttons

### DIFF
--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "new": "node scripts/make-component.js",
     "test": "jest",
-    "debug": "node --inspect-brk ./node_modules/.bin/jest --runInBand --testNamePattern=\"IconButton.test.tsx\"",
     "tdd": "jest --watch",
     "test:ci": "yarn test:types && yarn test",
     "test:types": "tsc -p ./tsconfig.json --noEmit",

--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -71,6 +71,7 @@ const disabled: FlattenInterpolation<ThemeProps<CactusTheme>> = css`
   background-color: ${p => p.theme.colors.lightGray};
   border-color: ${p => p.theme.colors.lightGray};
   cursor: not-allowed;
+  text-decoration: line-through;
 `
 
 const variantOrDisabled = (

--- a/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
@@ -76,6 +76,8 @@ exports[`component: Button should render disabled variant 1`] = `
   background-color: hsl(0,0%,90%);
   border-color: hsl(0,0%,90%);
   cursor: not-allowed;
+  -webkit-text-decoration: line-through;
+  text-decoration: line-through;
 }
 
 <button
@@ -133,6 +135,8 @@ exports[`component: Button should render inverse disabled variant 1`] = `
   background-color: hsl(0,0%,90%);
   border-color: hsl(0,0%,90%);
   cursor: not-allowed;
+  -webkit-text-decoration: line-through;
+  text-decoration: line-through;
 }
 
 <button

--- a/modules/cactus-web/src/TextButton/TextButton.story.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.story.tsx
@@ -4,10 +4,14 @@ import { text, boolean, select } from '@storybook/addon-knobs/react'
 import { actions } from '@storybook/addon-actions'
 import TextButton, { TextButtonVariants } from './TextButton'
 import DarkMode from '../storySupport/DarkMode'
+import Add from '@repay/cactus-icons/i/actions-add'
+import NavLeft from '@repay/cactus-icons/i/navigation-chevron-left'
+import Trophy from '@repay/cactus-icons/i/status-trophy'
 
 const textButtonVariants: TextButtonVariants[] = ['standard', 'action']
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
 const textButtonStories = storiesOf('TextButton', module)
+const textIconButtonStories = storiesOf('Text+Icon Button', module)
 
 textButtonStories.add('Basic Usage', () => (
   <TextButton
@@ -28,6 +32,81 @@ textButtonStories.add('Inverse Colors', () => (
       {...eventLoggers}
     >
       {text('children', 'An Inverse Text Button')}
+    </TextButton>
+  </DarkMode>
+))
+
+textIconButtonStories.add('Add Button', () => (
+  <TextButton
+    variant={select('variant', textButtonVariants, 'standard')}
+    disabled={boolean('disabled', false)}
+    {...eventLoggers}
+  >
+    <Add />
+    {text('children', 'Add')}
+  </TextButton>
+))
+
+textIconButtonStories.add('Inverse Add Button', () => (
+  <DarkMode>
+    <TextButton
+      variant={select('variant', textButtonVariants, 'standard')}
+      disabled={boolean('disabled', false)}
+      inverse
+      {...eventLoggers}
+    >
+      <Add />
+      {text('children', 'Add')}
+    </TextButton>
+  </DarkMode>
+))
+
+textIconButtonStories.add('Back Button', () => (
+  <TextButton
+    variant={select('variant', textButtonVariants, 'standard')}
+    disabled={boolean('disabled', false)}
+    {...eventLoggers}
+  >
+    <NavLeft />
+    {text('children', 'Back')}
+  </TextButton>
+))
+
+textIconButtonStories.add('Inverse Back Button', () => (
+  <DarkMode>
+    <TextButton
+      variant={select('variant', textButtonVariants, 'standard')}
+      disabled={boolean('disabled', false)}
+      inverse
+      {...eventLoggers}
+    >
+      <NavLeft />
+      {text('children', 'Back')}
+    </TextButton>
+  </DarkMode>
+))
+
+textIconButtonStories.add('Trophy Button', () => (
+  <TextButton
+    variant={select('variant', textButtonVariants, 'standard')}
+    disabled={boolean('disabled', false)}
+    {...eventLoggers}
+  >
+    <Trophy />
+    {text('children', 'You win!')}
+  </TextButton>
+))
+
+textIconButtonStories.add('Inverse Trophy Button', () => (
+  <DarkMode>
+    <TextButton
+      variant={select('variant', textButtonVariants, 'standard')}
+      disabled={boolean('disabled', false)}
+      inverse
+      {...eventLoggers}
+    >
+      <Trophy />
+      {text('children', 'You win!')}
     </TextButton>
   </DarkMode>
 ))

--- a/modules/cactus-web/src/TextButton/TextButton.test.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, fireEvent } from 'react-testing-library'
 import TextButton from './TextButton'
 import cactusTheme from '@repay/cactus-theme'
 import { ThemeProvider } from 'styled-components'
+import { StatusCheck } from '@repay/cactus-icons'
 
 afterEach(cleanup)
 
@@ -109,5 +110,31 @@ describe('component: TextButton', () => {
 
     fireEvent.click(getByTestId('not-clicked'))
     expect(onClick).not.toHaveBeenCalled()
+  })
+
+  test('should render a text+icon button', () => {
+    const textIconButton = render(
+      <ThemeProvider theme={cactusTheme}>
+        <TextButton>
+          <StatusCheck />
+          Check check
+        </TextButton>
+      </ThemeProvider>
+    )
+
+    expect(textIconButton.asFragment()).toMatchSnapshot()
+  })
+
+  test('should render a disabled text+icon button', () => {
+    const textIconButton = render(
+      <ThemeProvider theme={cactusTheme}>
+        <TextButton>
+          <StatusCheck />
+          Check check
+        </TextButton>
+      </ThemeProvider>
+    )
+
+    expect(textIconButton.asFragment()).toMatchSnapshot()
   })
 })

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -35,6 +35,7 @@ const inverseVariantMap: VariantMap = {
 
 const disabled: FlattenInterpolation<ThemeProps<CactusTheme>> = css`
   color: ${p => p.theme.colors.mediumGray};
+  text-decoration: line-through;
 `
 
 const variantOrDisabled = (

--- a/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -31,6 +31,100 @@ exports[`component: TextButton should default to standard variant 1`] = `
 </DocumentFragment>
 `;
 
+exports[`component: TextButton should render a disabled text+icon button 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  border: none;
+  padding: 0px;
+  outline: none;
+  background-color: transparent;
+  font-weight: 300;
+  color: hsl(200,96%,11%);
+}
+
+.c0:hover {
+  cursor: pointer;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1 {
+  vertical-align: middle;
+  width: 1em;
+}
+
+<button
+    class="c0"
+  >
+    <svg
+      class="c1"
+      fill="currentcolor"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <path
+        d="M9.814 19.74a1.18 1.18 0 0 1-.787-.302l-5.64-5.088a1.173 1.173 0 1 1 1.573-1.743l4.72 4.257 9.233-11.427a1.173 1.173 0 1 1 1.826 1.476L10.727 19.304a1.181 1.181 0 0 1-.913.436"
+      />
+    </svg>
+    Check check
+  </button>
+</DocumentFragment>
+`;
+
+exports[`component: TextButton should render a text+icon button 1`] = `
+<DocumentFragment>
+  .c0 {
+  font-size: 18px;
+  border: none;
+  padding: 0px;
+  outline: none;
+  background-color: transparent;
+  font-weight: 300;
+  color: hsl(200,96%,11%);
+}
+
+.c0:hover {
+  cursor: pointer;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c0:focus {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1 {
+  vertical-align: middle;
+  width: 1em;
+}
+
+<button
+    class="c0"
+  >
+    <svg
+      class="c1"
+      fill="currentcolor"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <path
+        d="M9.814 19.74a1.18 1.18 0 0 1-.787-.302l-5.64-5.088a1.173 1.173 0 1 1 1.573-1.743l4.72 4.257 9.233-11.427a1.173 1.173 0 1 1 1.826 1.476L10.727 19.304a1.181 1.181 0 0 1-.913.436"
+      />
+    </svg>
+    Check check
+  </button>
+</DocumentFragment>
+`;
+
 exports[`component: TextButton should render call to action variant 1`] = `
 <DocumentFragment>
   .c0 {

--- a/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -71,6 +71,8 @@ exports[`component: TextButton should render disabled variant 1`] = `
   outline: none;
   background-color: transparent;
   color: hsl(0,0%,70%);
+  -webkit-text-decoration: line-through;
+  text-decoration: line-through;
 }
 
 .c0:hover {
@@ -133,6 +135,8 @@ exports[`component: TextButton should render inverse disabled variant 1`] = `
   outline: none;
   background-color: transparent;
   color: hsl(0,0%,70%);
+  -webkit-text-decoration: line-through;
+  text-decoration: line-through;
 }
 
 .c0:hover {


### PR DESCRIPTION
I branched off of the `icon-buttons` branch, so that should be reviewed and merged first. (#20)

I noticed that I didn't add a strikethrough on disabled buttons, so there's a commit in here to do that as well.

Text+Icon buttons didn't require a new component; you can just put an icon inside `TextButton` along with some text to achieve the effect, so I just added onto the `TextButton` stories/tests