### PR TITLE
fix(cactus-icons): text & text+icon button improvements

### DIFF
--- a/modules/cactus-web/src/IconButton/IconButton.story.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.story.tsx
@@ -3,93 +3,47 @@ import { storiesOf } from '@storybook/react'
 import { boolean, select } from '@storybook/addon-knobs/react'
 import { actions } from '@storybook/addon-actions'
 import IconButton, { IconButtonVariants, IconButtonSizes } from './IconButton'
-import Add from '@repay/cactus-icons/i/actions-add'
-import NavLeft from '@repay/cactus-icons/i/navigation-chevron-left'
-import Trophy from '@repay/cactus-icons/i/status-trophy'
 import DarkMode from '../storySupport/DarkMode'
+import * as icons from '@repay/cactus-icons/i'
 
 const iconButtonVariants: IconButtonVariants[] = ['standard', 'action']
 const iconButtonSizes: IconButtonSizes[] = ['tiny', 'small', 'medium', 'large']
+type IconName = keyof typeof icons
+const iconNames: IconName[] = Object.keys(icons) as IconName[]
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
 const iconButtonStories = storiesOf('IconButton', module)
 
-iconButtonStories.add('Add Button', () => (
-  <IconButton
-    variant={select('variant', iconButtonVariants, 'standard')}
-    iconSize={select('size', iconButtonSizes, 'medium')}
-    disabled={boolean('disabled', false)}
-    label="add"
-    {...eventLoggers}
-  >
-    <Add />
-  </IconButton>
-))
-
-iconButtonStories.add('Inverse Add Button', () => (
-  <DarkMode>
+iconButtonStories.add('Basic Usage', () => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName]
+  return (
     <IconButton
       variant={select('variant', iconButtonVariants, 'standard')}
       iconSize={select('size', iconButtonSizes, 'medium')}
       disabled={boolean('disabled', false)}
       label="add"
-      inverse
       {...eventLoggers}
     >
-      <Add />
+      <Icon />
     </IconButton>
-  </DarkMode>
-))
+  )
+  })
 
-iconButtonStories.add('Nav Left Button', () => (
-  <IconButton
-    variant={select('variant', iconButtonVariants, 'standard')}
-    iconSize={select('size', iconButtonSizes, 'medium')}
-    disabled={boolean('disabled', false)}
-    label="back"
-    {...eventLoggers}
-  >
-    <NavLeft />
-  </IconButton>
-))
-
-iconButtonStories.add('Inverse Nav Left Button', () => (
-  <DarkMode>
-    <IconButton
-      variant={select('variant', iconButtonVariants, 'standard')}
-      iconSize={select('size', iconButtonSizes, 'medium')}
-      disabled={boolean('disabled', false)}
-      label="back"
-      inverse
-      {...eventLoggers}
-    >
-      <NavLeft />
-    </IconButton>
-  </DarkMode>
-))
-
-iconButtonStories.add('Trophy Button', () => (
-  <IconButton
-    variant={select('variant', iconButtonVariants, 'standard')}
-    iconSize={select('size', iconButtonSizes, 'medium')}
-    disabled={boolean('disabled', false)}
-    label="you win"
-    {...eventLoggers}
-  >
-    <Trophy />
-  </IconButton>
-))
-
-iconButtonStories.add('Inverse Trophy Button', () => (
-  <DarkMode>
-    <IconButton
-      variant={select('variant', iconButtonVariants, 'standard')}
-      iconSize={select('size', iconButtonSizes, 'medium')}
-      disabled={boolean('disabled', false)}
-      label="you win"
-      inverse
-      {...eventLoggers}
-    >
-      <Trophy />
-    </IconButton>
-  </DarkMode>
-))
+iconButtonStories.add('Inverse Colors', () => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName]
+  return (
+    <DarkMode>
+      <IconButton
+        variant={select('variant', iconButtonVariants, 'standard')}
+        iconSize={select('size', iconButtonSizes, 'medium')}
+        disabled={boolean('disabled', false)}
+        label="add"
+        inverse
+        {...eventLoggers}
+      >
+        <Icon />
+      </IconButton>
+    </DarkMode>
+  )
+})

--- a/modules/cactus-web/src/IconButton/IconButton.story.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.story.tsx
@@ -27,7 +27,7 @@ iconButtonStories.add('Basic Usage', () => {
       <Icon />
     </IconButton>
   )
-  })
+})
 
 iconButtonStories.add('Inverse Colors', () => {
   const iconName: IconName = select('icon', iconNames, 'ActionsAdd')

--- a/modules/cactus-web/src/TextButton/TextButton.story.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.story.tsx
@@ -4,11 +4,11 @@ import { text, boolean, select } from '@storybook/addon-knobs/react'
 import { actions } from '@storybook/addon-actions'
 import TextButton, { TextButtonVariants } from './TextButton'
 import DarkMode from '../storySupport/DarkMode'
-import Add from '@repay/cactus-icons/i/actions-add'
-import NavLeft from '@repay/cactus-icons/i/navigation-chevron-left'
-import Trophy from '@repay/cactus-icons/i/status-trophy'
+import * as icons from '@repay/cactus-icons'
 
 const textButtonVariants: TextButtonVariants[] = ['standard', 'action']
+type IconName = keyof typeof icons
+const iconNames: IconName[] = Object.keys(icons) as IconName[]
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
 const textButtonStories = storiesOf('TextButton', module)
 const textIconButtonStories = storiesOf('Text+Icon Button', module)
@@ -36,77 +36,35 @@ textButtonStories.add('Inverse Colors', () => (
   </DarkMode>
 ))
 
-textIconButtonStories.add('Add Button', () => (
-  <TextButton
-    variant={select('variant', textButtonVariants, 'standard')}
-    disabled={boolean('disabled', false)}
-    {...eventLoggers}
-  >
-    <Add />
-    {text('children', 'Add')}
-  </TextButton>
-))
-
-textIconButtonStories.add('Inverse Add Button', () => (
-  <DarkMode>
+textIconButtonStories.add('Basic Usage', () => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName]
+  return (
     <TextButton
       variant={select('variant', textButtonVariants, 'standard')}
       disabled={boolean('disabled', false)}
-      inverse
       {...eventLoggers}
     >
-      <Add />
+      <Icon />
       {text('children', 'Add')}
     </TextButton>
-  </DarkMode>
-))
+  )
+})
 
-textIconButtonStories.add('Back Button', () => (
-  <TextButton
-    variant={select('variant', textButtonVariants, 'standard')}
-    disabled={boolean('disabled', false)}
-    {...eventLoggers}
-  >
-    <NavLeft />
-    {text('children', 'Back')}
-  </TextButton>
-))
-
-textIconButtonStories.add('Inverse Back Button', () => (
-  <DarkMode>
-    <TextButton
-      variant={select('variant', textButtonVariants, 'standard')}
-      disabled={boolean('disabled', false)}
-      inverse
-      {...eventLoggers}
-    >
-      <NavLeft />
-      {text('children', 'Back')}
-    </TextButton>
-  </DarkMode>
-))
-
-textIconButtonStories.add('Trophy Button', () => (
-  <TextButton
-    variant={select('variant', textButtonVariants, 'standard')}
-    disabled={boolean('disabled', false)}
-    {...eventLoggers}
-  >
-    <Trophy />
-    {text('children', 'You win!')}
-  </TextButton>
-))
-
-textIconButtonStories.add('Inverse Trophy Button', () => (
-  <DarkMode>
-    <TextButton
-      variant={select('variant', textButtonVariants, 'standard')}
-      disabled={boolean('disabled', false)}
-      inverse
-      {...eventLoggers}
-    >
-      <Trophy />
-      {text('children', 'You win!')}
-    </TextButton>
-  </DarkMode>
-))
+textIconButtonStories.add('Inverse Colors', () => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName]
+  return (
+    <DarkMode>
+      <TextButton
+        variant={select('variant', textButtonVariants, 'standard')}
+        disabled={boolean('disabled', false)}
+        inverse
+        {...eventLoggers}
+      >
+        <Icon />
+        {text('children', 'Add')}
+      </TextButton>
+    </DarkMode>
+  )
+})

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -62,6 +62,10 @@ const TextButton = styled.button<TextButtonProps>`
   :focus {
     text-decoration: ${p => (p.disabled ? 'none' : 'underline')};
   }
+  svg {
+    display: inline-block;
+    margin-top: -4px;
+  }
   ${variantOrDisabled}
 `
 

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -54,10 +54,10 @@ const TextButton = styled.button<TextButtonProps>`
   background-color: transparent;
   :hover {
     cursor: ${p => (p.disabled ? 'auto' : 'pointer')};
-    text-decoration: ${p => (p.disabled ? 'none' : 'underline')};
+    text-decoration: ${p => (!p.disabled && 'underline')};
   }
   :focus {
-    text-decoration: ${p => (p.disabled ? 'none' : 'underline')};
+    text-decoration: ${p => (!p.disabled && 'underline')};
   }
   svg {
     display: inline-block;

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -13,11 +13,9 @@ type VariantMap = { [K in TextButtonVariants]: FlattenInterpolation<ThemeProps<C
 
 const variantMap: VariantMap = {
   action: css`
-    font-weight: 300;
     color: ${p => p.theme.colors.callToAction};
   `,
   standard: css`
-    font-weight: 300;
     color: ${p => p.theme.colors.darkContrast};
   `,
 }
@@ -28,7 +26,6 @@ const inverseVariantMap: VariantMap = {
     color: ${p => p.theme.colors.callToAction};
   `,
   standard: css`
-    font-weight: 700;
     color: ${p => p.theme.colors.white};
   `,
 }

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -54,10 +54,10 @@ const TextButton = styled.button<TextButtonProps>`
   background-color: transparent;
   :hover {
     cursor: ${p => (p.disabled ? 'auto' : 'pointer')};
-    text-decoration: ${p => (!p.disabled && 'underline')};
+    text-decoration: ${p => !p.disabled && 'underline'};
   }
   :focus {
-    text-decoration: ${p => (!p.disabled && 'underline')};
+    text-decoration: ${p => !p.disabled && 'underline'};
   }
   svg {
     display: inline-block;

--- a/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -187,13 +187,6 @@ exports[`component: TextButton should render disabled variant 1`] = `
 
 .c0:hover {
   cursor: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c0 svg {
@@ -261,13 +254,6 @@ exports[`component: TextButton should render inverse disabled variant 1`] = `
 
 .c0:hover {
   cursor: auto;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c0 svg {

--- a/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -23,6 +23,11 @@ exports[`component: TextButton should default to standard variant 1`] = `
   text-decoration: underline;
 }
 
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
+}
+
 <button
     class="c0"
   >
@@ -52,6 +57,11 @@ exports[`component: TextButton should render a disabled text+icon button 1`] = `
 .c0:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
 }
 
 .c1 {
@@ -101,6 +111,11 @@ exports[`component: TextButton should render a text+icon button 1`] = `
   text-decoration: underline;
 }
 
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
+}
+
 .c1 {
   vertical-align: middle;
   width: 1em;
@@ -148,6 +163,11 @@ exports[`component: TextButton should render call to action variant 1`] = `
   text-decoration: underline;
 }
 
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
+}
+
 <button
     class="c0"
   >
@@ -178,6 +198,11 @@ exports[`component: TextButton should render disabled variant 1`] = `
 .c0:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
 }
 
 <button
@@ -212,6 +237,11 @@ exports[`component: TextButton should render inverse call to action variant 1`] 
   text-decoration: underline;
 }
 
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
+}
+
 <button
     class="c0"
   >
@@ -242,6 +272,11 @@ exports[`component: TextButton should render inverse disabled variant 1`] = `
 .c0:focus {
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
 }
 
 <button
@@ -276,6 +311,11 @@ exports[`component: TextButton should render inverse standard variant 1`] = `
   text-decoration: underline;
 }
 
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
+}
+
 <button
     class="c0"
   >
@@ -305,6 +345,11 @@ exports[`component: TextButton should render standard variant 1`] = `
 .c0:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
 }
 
 <button

--- a/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`component: TextButton should default to standard variant 1`] = `
   padding: 0px;
   outline: none;
   background-color: transparent;
-  font-weight: 300;
   color: hsl(200,96%,11%);
 }
 
@@ -44,7 +43,6 @@ exports[`component: TextButton should render a disabled text+icon button 1`] = `
   padding: 0px;
   outline: none;
   background-color: transparent;
-  font-weight: 300;
   color: hsl(200,96%,11%);
 }
 
@@ -96,7 +94,6 @@ exports[`component: TextButton should render a text+icon button 1`] = `
   padding: 0px;
   outline: none;
   background-color: transparent;
-  font-weight: 300;
   color: hsl(200,96%,11%);
 }
 
@@ -148,7 +145,6 @@ exports[`component: TextButton should render call to action variant 1`] = `
   padding: 0px;
   outline: none;
   background-color: transparent;
-  font-weight: 300;
   color: hsl(200,96%,35%);
 }
 
@@ -296,7 +292,6 @@ exports[`component: TextButton should render inverse standard variant 1`] = `
   padding: 0px;
   outline: none;
   background-color: transparent;
-  font-weight: 700;
   color: hsl(0,0%,100%);
 }
 
@@ -332,7 +327,6 @@ exports[`component: TextButton should render standard variant 1`] = `
   padding: 0px;
   outline: none;
   background-color: transparent;
-  font-weight: 300;
   color: hsl(200,96%,11%);
 }
 


### PR DESCRIPTION
1. Fixed alignment for text+icon buttons
2. Fixed font weight on standard inverse text buttons. (I also found that 300 is *not* the default font weight, so I removed that so it would default correctly.)
3. Refactored icon button and text+icon button stories to include an icon dropdown just like the one in the icon module's story.
4. Fixed a bug in which the strikethrough would be replaced by an underline when hovering over a disabled text button.