### PR TITLE
chore(cactus-web): Show how to manage checkbox state using props

### DIFF
--- a/modules/cactus-web/src/CheckBox/CheckBox.story.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.story.tsx
@@ -8,5 +8,15 @@ const checkBoxStories = storiesOf('CheckBox', module)
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
 checkBoxStories.add('Basic Usage', () => (
-  <CheckBox id="test" disabled={boolean('disabled', false)} {...eventLoggers} />
+  <CheckBox id="test" name="kaneki" disabled={boolean('disabled', false)} {...eventLoggers} />
+))
+
+checkBoxStories.add('Controlling Value Through Props', () => (
+  <CheckBox
+    id="test"
+    name="touka"
+    disabled={boolean('disabled', false)}
+    checked={boolean('checked', false)}
+    {...eventLoggers}
+  />
 ))


### PR DESCRIPTION
Just adding a story showing that you can manage the `checked` prop on our checkbox