### PR TITLE
test(cactus-web): Add tests for disabled checkboxes

### DIFF
--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -57,6 +57,7 @@
     "@types/storybook__react": "^4.0.1",
     "@types/styled-components": "^4.1.14",
     "@types/styled-system": "^4.1.0",
+    "@types/user-event": "^1.4.0",
     "babel-jest": "^24.7.1",
     "babel-loader": "^8.0.5",
     "jest": "^24.7.1",
@@ -66,7 +67,8 @@
     "react-testing-library": "^6.1.2",
     "rollup-plugin-commonjs": "^9.3.4",
     "styled-components": "^4.1.2",
-    "typescript": "^3.4.3"
+    "typescript": "^3.4.3",
+    "user-event": "^2.0.1"
   },
   "peerDependencies": {
     "react": "^16.8.3",

--- a/modules/cactus-web/src/CheckBox/CheckBox.test.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { cleanup, render, fireEvent } from 'react-testing-library'
+import userEvent from 'user-event'
 import CheckBox from './CheckBox'
 import cactusTheme from '@repay/cactus-theme'
 import { ThemeProvider } from 'styled-components'
@@ -63,7 +64,27 @@ describe('component: CheckBox', () => {
     expect(onBlur).toHaveBeenCalled()
   })
 
-  /* TODO: Change events are still being fired when clicked even when disabled. There is a PR for the user-event library
-  that should be included in v2 since it is a breaking change. We'll have to stay on the lookout for that version
-  and finish these tests afterward https://github.com/Gpx/user-event/pull/97 */
+  test('should not trigger onChange event', () => {
+    const onChange = jest.fn()
+    const { getByTestId } = render(
+      <ThemeProvider theme={cactusTheme}>
+        <CheckBox id="checked" onChange={onChange} data-testid="will-not-check" disabled />
+      </ThemeProvider>
+    )
+
+    userEvent.click(getByTestId('will-not-check'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  test('should not trigger onFocus event', () => {
+    const onFocus = jest.fn()
+    const { getByTestId } = render(
+      <ThemeProvider theme={cactusTheme}>
+        <CheckBox id="checked" onFocus={onFocus} data-testid="will-not-check" disabled />
+      </ThemeProvider>
+    )
+
+    userEvent.click(getByTestId('will-not-check'))
+    expect(onFocus).not.toHaveBeenCalled()
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,6 +2355,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/user-event@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@types/user-event/-/user-event-1.4.0.tgz#6633337050e4509e6d2c7a8b19737bacab1e31c3"
+  integrity sha512-Jni9x2qNpSjuTCeYoHE1j2JL/1Lhx6rbNbEzjtCdTY1XuZRgU3c1tKHSsqbR/xTqB46cl/DFRalLkFeLRiKuwg==
+
 "@types/vfile-message@*":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/vfile-message/-/vfile-message-1.0.1.tgz#e1e9895cc6b36c462d4244e64e6d0b6eaf65355a"
@@ -4820,6 +4825,16 @@ dom-serializer@0:
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
+
+dom-testing-library@3.19.3:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.19.3.tgz#fba399987be1bdd57b07c4bc3ef46c3c084b26d9"
+  integrity sha512-oiI+oq91iO/Vpp+pt8PqfqLfBK074FH0eprhoFNvBCvJOk7vL4ozbe/yj/kEEGR6kiT4F3MAam19AX1fdGFjrA==
+  dependencies:
+    "@babel/runtime" "^7.3.4"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    pretty-format "^24.5.0"
+    wait-for-expect "^1.1.0"
 
 dom-testing-library@^3.19.0:
   version "3.19.1"
@@ -11748,6 +11763,13 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+user-event@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/user-event/-/user-event-2.0.1.tgz#cb70e358de6ce435baa306a5d7caf41f9ca9afe1"
+  integrity sha512-L/GnWRAVxikEaOrlkPh3ajmz03kqO0EchxLqr1+d3LMh9+bT6DMd/384qctHe8EOnGAPYNiG50/mQP5KGtJSpQ==
+  dependencies:
+    dom-testing-library "3.19.3"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Updating our checkbox tests to use `user-event`, which recently published a fix for the issue of triggering events even when the checkbox is disabled