### PR TITLE
fix(cactus-web): Size & position toggle icons appropriately

### DIFF
--- a/modules/cactus-web/src/Label/__snapshots__/Label.test.tsx.snap
+++ b/modules/cactus-web/src/Label/__snapshots__/Label.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`component: Label should render a label component 1`] = `
   font-size: 18px;
   height: 28px;
   font-weight: 400;
-  color: hsl(200,10%,35%);
+  color: hsl(200,10%,20%);
 }
 
 <label

--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -54,14 +54,14 @@ interface ToggleButtonProps {
 }
 
 const StyledX = styled(NavigationClose)`
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: ${p => p.theme.colors.white};
 `
 
 const StyledCheck = styled(StatusCheck)`
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: ${p => p.theme.colors.white};
 `
 
@@ -71,8 +71,8 @@ const ToggleButton = styled.button<ToggleButtonProps>`
   height: 20px;
   border-radius: 10px;
   outline: none;
-  background-color: ${p => p.theme.colors.base};
-  border: 1px solid ${p => p.theme.colors.base};
+  background-color: ${p => p.theme.colors.darkestContrast};
+  border: 1px solid ${p => p.theme.colors.darkestContrast};
   cursor: ${p => (p.disabled ? 'cursor' : 'pointer')};
 
   ::after {
@@ -106,16 +106,16 @@ const ToggleButton = styled.button<ToggleButtonProps>`
 
   ${StyledX} {
     position: absolute;
-    top: 0;
-    left: 20px;
+    top: 1px;
+    left: 22px;
     opacity: 1;
     transition: opacity 0.3s;
   }
 
   ${StyledCheck} {
     position: absolute;
-    top: 0;
-    left: 4px;
+    top: 1px;
+    left: 5px;
     opacity: 0;
     transition: opacity 0.3s;
   }

--- a/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -8,14 +8,14 @@ exports[`component: Toggle should initialize value to false 1`] = `
 }
 
 .c2 {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: hsl(0,0%,100%);
 }
 
 .c5 {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: hsl(0,0%,100%);
 }
 
@@ -25,8 +25,8 @@ exports[`component: Toggle should initialize value to false 1`] = `
   height: 20px;
   border-radius: 10px;
   outline: none;
-  background-color: hsl(200,96%,11%);
-  border: 1px solid hsl(200,96%,11%);
+  background-color: hsl(200,10%,20%);
+  border: 1px solid hsl(200,10%,20%);
   cursor: pointer;
 }
 
@@ -65,8 +65,8 @@ exports[`component: Toggle should initialize value to false 1`] = `
 
 .c0 .c1 {
   position: absolute;
-  top: 0;
-  left: 20px;
+  top: 1px;
+  left: 22px;
   opacity: 1;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
@@ -74,8 +74,8 @@ exports[`component: Toggle should initialize value to false 1`] = `
 
 .c0 .c4 {
   position: absolute;
-  top: 0;
-  left: 4px;
+  top: 1px;
+  left: 5px;
   opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
@@ -124,14 +124,14 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 }
 
 .c2 {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: hsl(0,0%,100%);
 }
 
 .c5 {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: hsl(0,0%,100%);
 }
 
@@ -141,8 +141,8 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
   height: 20px;
   border-radius: 10px;
   outline: none;
-  background-color: hsl(200,96%,11%);
-  border: 1px solid hsl(200,96%,11%);
+  background-color: hsl(200,10%,20%);
+  border: 1px solid hsl(200,10%,20%);
   cursor: pointer;
 }
 
@@ -181,8 +181,8 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 
 .c0 .c1 {
   position: absolute;
-  top: 0;
-  left: 20px;
+  top: 1px;
+  left: 22px;
   opacity: 1;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
@@ -190,8 +190,8 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 
 .c0 .c4 {
   position: absolute;
-  top: 0;
-  left: 4px;
+  top: 1px;
+  left: 5px;
   opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
@@ -240,14 +240,14 @@ exports[`component: Toggle should render a toggle 1`] = `
 }
 
 .c2 {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: hsl(0,0%,100%);
 }
 
 .c5 {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   color: hsl(0,0%,100%);
 }
 
@@ -257,8 +257,8 @@ exports[`component: Toggle should render a toggle 1`] = `
   height: 20px;
   border-radius: 10px;
   outline: none;
-  background-color: hsl(200,96%,11%);
-  border: 1px solid hsl(200,96%,11%);
+  background-color: hsl(200,10%,20%);
+  border: 1px solid hsl(200,10%,20%);
   cursor: pointer;
 }
 
@@ -297,8 +297,8 @@ exports[`component: Toggle should render a toggle 1`] = `
 
 .c0 .c1 {
   position: absolute;
-  top: 0;
-  left: 20px;
+  top: 1px;
+  left: 22px;
   opacity: 1;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
@@ -306,8 +306,8 @@ exports[`component: Toggle should render a toggle 1`] = `
 
 .c0 .c4 {
   position: absolute;
-  top: 0;
-  left: 4px;
+  top: 1px;
+  left: 5px;
   opacity: 0;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;


### PR DESCRIPTION
I noticed that the color was off, too, so that's fixed as well. Other than that, I just had to resize the icons and shift them slightly to adhere to the style guide.