### PR TITLE
fix(cactus-web): Add button type to toggle

### DIFF
--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -135,7 +135,7 @@ const ToggleButton = styled.button<ToggleButtonProps>`
 const Toggle = (props: ToggleProps) => {
   const { value, ...toggleProps } = props
   return (
-    <ToggleButton aria-checked={value} {...toggleProps}>
+    <ToggleButton type="button" aria-checked={value} {...toggleProps}>
       <StyledX />
       <StyledCheck />
     </ToggleButton>

--- a/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -89,6 +89,7 @@ exports[`component: Toggle should initialize value to false 1`] = `
 <button
     aria-checked="true"
     class="c0"
+    type="button"
   >
     <svg
       class="c1 c2 c3"
@@ -205,6 +206,7 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 <button
     aria-checked="false"
     class="c0"
+    type="button"
   >
     <svg
       class="c1 c2 c3"
@@ -321,6 +323,7 @@ exports[`component: Toggle should render a toggle 1`] = `
 <button
     aria-checked="false"
     class="c0"
+    type="button"
   >
     <svg
       class="c1 c2 c3"


### PR DESCRIPTION
While working on the case study for shadows, I noticed that, if a toggle is placed inside a `<form>` tag, it will try to submit the form when clicked. 🤯
By adding `type="button"` to the toggle, that issue is prevented.