### PR TITLE
feat(cactus-web): Add box shadow on focus for checkbox

### DIFF
--- a/modules/cactus-web/src/CheckBox/CheckBox.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.tsx
@@ -46,14 +46,20 @@ const CheckBoxContainer = styled.label<CheckBoxContainerProps>`
   display: block;
   vertical-align: middle;
   position: relative;
+
   input:checked ~ div {
     border-color: ${p => !p.disabled && p.theme.colors.callToAction};
     background-color: ${p => !p.disabled && p.theme.colors.callToAction};
   }
+
   input:checked ~ div {
     svg {
-      ${p => !p.disabled && 'visibility: visible'};
+      visibility: visible;
     }
+  }
+
+  input:focus ~ div {
+    box-shadow: 0 0 8px ${p => p.theme.colors.callToAction};
   }
 `
 

--- a/modules/cactus-web/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/modules/cactus-web/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -50,6 +50,10 @@ exports[`component: CheckBox should render a checkbox 1`] = `
   visibility: visible;
 }
 
+.c0 input:focus ~ div {
+  box-shadow: 0 0 8px hsl(200,96%,35%);
+}
+
 <label
     class="c0"
     for="check"
@@ -118,6 +122,14 @@ exports[`component: CheckBox should render a disabled checkbox 1`] = `
   display: block;
   vertical-align: middle;
   position: relative;
+}
+
+.c0 input:checked ~ div svg {
+  visibility: visible;
+}
+
+.c0 input:focus ~ div {
+  box-shadow: 0 0 8px hsl(200,96%,35%);
 }
 
 <label


### PR DESCRIPTION
I also realized that the checkmark SVG should still show even if the checkbox is disabled, so I fixed that.