### PR TITLE
fix(cactus-web): Line up text on left side of input correctly

### DIFF
--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -92,7 +92,7 @@ const Input = styled.input<InputProps>`
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px;
+  padding: 7px 28px 7px 16px;
   font-size: 18px;
   width: ${p => p.width || 'auto'};
   background-color: ${p => (p.disabled ? p.theme.colors.lightGray : p.theme.colors.white)};

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -92,7 +92,7 @@ const Input = styled.input<InputProps>`
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px 7px 16px;
+  padding: 7px 28px 7px 15px;
   font-size: 18px;
   width: ${p => p.width || 'auto'};
   background-color: ${p => (p.disabled ? p.theme.colors.lightGray : p.theme.colors.white)};

--- a/modules/cactus-web/src/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/modules/cactus-web/src/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`component: TextInput should render a disabled input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px 7px 16px;
+  padding: 7px 28px 7px 15px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,90%);
@@ -102,7 +102,7 @@ exports[`component: TextInput should render a success input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px 7px 16px;
+  padding: 7px 28px 7px 15px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -178,7 +178,7 @@ exports[`component: TextInput should render a text input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px 7px 16px;
+  padding: 7px 28px 7px 15px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -255,7 +255,7 @@ exports[`component: TextInput should render an error input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px 7px 16px;
+  padding: 7px 28px 7px 15px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -331,7 +331,7 @@ exports[`component: TextInput should render an input with a placeholder 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px 7px 16px;
+  padding: 7px 28px 7px 15px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -409,7 +409,7 @@ exports[`component: TextInput should render an invalid input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px 7px 16px;
+  padding: 7px 28px 7px 15px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);

--- a/modules/cactus-web/src/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/modules/cactus-web/src/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`component: TextInput should render a disabled input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px;
+  padding: 7px 28px 7px 16px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,90%);
@@ -102,7 +102,7 @@ exports[`component: TextInput should render a success input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px;
+  padding: 7px 28px 7px 16px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -178,7 +178,7 @@ exports[`component: TextInput should render a text input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px;
+  padding: 7px 28px 7px 16px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -255,7 +255,7 @@ exports[`component: TextInput should render an error input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px;
+  padding: 7px 28px 7px 16px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -331,7 +331,7 @@ exports[`component: TextInput should render an input with a placeholder 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px;
+  padding: 7px 28px 7px 16px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);
@@ -409,7 +409,7 @@ exports[`component: TextInput should render an invalid input 1`] = `
   height: 32px;
   outline: none;
   box-sizing: border-box;
-  padding: 7px 28px;
+  padding: 7px 28px 7px 16px;
   font-size: 18px;
   width: auto;
   background-color: hsl(0,0%,100%);


### PR DESCRIPTION
Defined padding bottom and left on text input to ensure that the text is lined up correctly with the left side of the input