### PR TITLE
chore(): deprecate v1 and revert to v0 publishes

### DIFF
--- a/modules/cactus-fwk/package.json
+++ b/modules/cactus-fwk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repay/cactus-fwk",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "Cactus Framework for React",
   "main": "dist/cactus-fwk.cjs.js",
   "module": "dist/cactus-fwk.js",

--- a/modules/cactus-icons/package.json
+++ b/modules/cactus-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repay/cactus-icons",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Cactus design-system icons as React elements",
   "module": "i/index.js",
   "main": "i/index.cjs.js",

--- a/modules/cactus-theme/package.json
+++ b/modules/cactus-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repay/cactus-theme",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "The theme for the Cactus design-system at REPAY",
   "repository": "https://github.com/repaygithub/cactus/tree/master/modules/cactus-theme",
   "license": "MIT",

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repay/cactus-web",
-  "version": "1.1.1",
+  "version": "0.2.0",
   "description": "A UI component library for web built in React by REPAY",
   "main": "dist/cactus-web.js",
   "module": "dist/cactus-web.cjs.js",


### PR DESCRIPTION
I've already deprecated the v1 packages on npm, these are the new versions that I will publish for these libraries except for cactus-fwk which has no changes since v0.2.0