### PR TITLE
fix(cactus-web): firefox dotted line on focus

### DIFF
--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -100,6 +100,10 @@ export const Button = styled.button<ButtonProps>`
   font-size: 18px;
   line-height: 1.5em;
 
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
   svg {
     display: inline-block;
     margin-top: -4px;

--- a/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
@@ -15,6 +15,10 @@ exports[`component: Button should default to standard variant 1`] = `
   border-color: hsl(200,96%,11%);
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -49,6 +53,10 @@ exports[`component: Button should render call to action variant 1`] = `
   color: hsl(0,0%,100%);
   background-color: hsl(200,96%,35%);
   border-color: hsl(200,96%,35%);
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {
@@ -88,6 +96,10 @@ exports[`component: Button should render disabled variant 1`] = `
   cursor: not-allowed;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -116,6 +128,10 @@ exports[`component: Button should render inverse call to action variant 1`] = `
   color: hsl(0,0%,100%);
   background-color: hsl(200,96%,35%);
   border-color: hsl(200,96%,35%);
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {
@@ -155,6 +171,10 @@ exports[`component: Button should render inverse disabled variant 1`] = `
   cursor: not-allowed;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -183,6 +203,10 @@ exports[`component: Button should render inverse standard variant 1`] = `
   color: hsl(0,0%,100%);
   background-color: hsl(200,96%,11%);
   border-color: hsl(0,0%,100%);
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {
@@ -221,6 +245,10 @@ exports[`component: Button should render standard variant 1`] = `
   border-color: hsl(200,96%,11%);
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -256,6 +284,10 @@ exports[`component: Button should support margin space props 1`] = `
   color: hsl(200,96%,11%);
   background-color: hsl(0,0%,100%);
   border-color: hsl(200,96%,11%);
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -113,6 +113,11 @@ export const IconButton = styled(IconButtonBase)<IconButtonProps>`
   background: transparent;
   outline: none;
   cursor: pointer;
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
   ${variantOrDisabled}
   ${margins}
   ${iconSizes}

--- a/modules/cactus-web/src/IconButton/__snapshots__/IconButton.test.tsx.snap
+++ b/modules/cactus-web/src/IconButton/__snapshots__/IconButton.test.tsx.snap
@@ -29,6 +29,10 @@ exports[`component: IconButton should default to standard medium icon button 1`]
   font-size: 24px;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0:hover,
 .c0:focus {
   color: hsl(200,96%,35%);
@@ -81,6 +85,10 @@ exports[`component: IconButton should render call to action icon button 1`] = `
   cursor: pointer;
   color: hsl(200,96%,35%);
   font-size: 24px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0:hover,
@@ -138,6 +146,10 @@ exports[`component: IconButton should render disabled variant 1`] = `
   font-size: 24px;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 <button
     class="c0"
     disabled=""
@@ -186,6 +198,10 @@ exports[`component: IconButton should render icon button with aria-label 1`] = `
   cursor: pointer;
   color: hsl(200,96%,11%);
   font-size: 24px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0:hover,
@@ -243,6 +259,10 @@ exports[`component: IconButton should render inverse call to action icon button 
   font-size: 24px;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0:hover,
 .c0:focus {
   color: hsl(0,0%,100%);
@@ -298,6 +318,10 @@ exports[`component: IconButton should render inverse disabled variant 1`] = `
   font-size: 24px;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 <button
     class="c0"
     disabled=""
@@ -346,6 +370,10 @@ exports[`component: IconButton should render inverse standard icon button 1`] = 
   cursor: pointer;
   color: hsl(0,0%,100%);
   font-size: 24px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0:hover,
@@ -403,6 +431,10 @@ exports[`component: IconButton should render large icon button 1`] = `
   font-size: 40px;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0:hover,
 .c0:focus {
   color: hsl(200,96%,35%);
@@ -455,6 +487,10 @@ exports[`component: IconButton should render small icon button 1`] = `
   cursor: pointer;
   color: hsl(200,96%,11%);
   font-size: 16px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0:hover,
@@ -511,6 +547,10 @@ exports[`component: IconButton should render standard medium icon button 1`] = `
   font-size: 24px;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0:hover,
 .c0:focus {
   color: hsl(200,96%,35%);
@@ -563,6 +603,10 @@ exports[`component: IconButton should render tiny icon button 1`] = `
   cursor: pointer;
   color: hsl(200,96%,11%);
   font-size: 8px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0:hover,
@@ -618,6 +662,10 @@ exports[`component: IconButton should support margin space props 1`] = `
   color: hsl(200,96%,11%);
   margin-bottom: 16px;
   font-size: 24px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0:hover,

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -81,6 +81,10 @@ export const TextButton = styled.button<TextButtonProps>`
     text-decoration: ${p => !p.disabled && 'underline'};
   }
 
+  &::-moz-focus-inner {
+    border: 0;
+  }
+
   svg {
     display: inline-block;
     margin-top: -4px;

--- a/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -25,6 +25,10 @@ exports[`component: TextButton should default to standard variant 1`] = `
   text-decoration: underline;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -66,6 +70,10 @@ exports[`component: TextButton should render a disabled text+icon button 1`] = `
 .c0:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {
@@ -122,6 +130,10 @@ exports[`component: TextButton should render a text+icon button 1`] = `
   text-decoration: underline;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -172,6 +184,10 @@ exports[`component: TextButton should render call to action variant 1`] = `
   text-decoration: underline;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -211,6 +227,10 @@ exports[`component: TextButton should render danger variant 1`] = `
   text-decoration: underline;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -239,6 +259,10 @@ exports[`component: TextButton should render disabled variant 1`] = `
   cursor: pointer;
   color: hsl(0,0%,70%);
   cursor: not-allowed;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {
@@ -282,6 +306,10 @@ exports[`component: TextButton should render inverse call to action variant 1`] 
   text-decoration: underline;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -310,6 +338,10 @@ exports[`component: TextButton should render inverse disabled variant 1`] = `
   cursor: pointer;
   color: hsl(0,0%,70%);
   cursor: not-allowed;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {
@@ -352,6 +384,10 @@ exports[`component: TextButton should render inverse standard variant 1`] = `
   text-decoration: underline;
 }
 
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
 .c0 svg {
   display: inline-block;
   margin-top: -4px;
@@ -389,6 +425,10 @@ exports[`component: TextButton should render standard variant 1`] = `
 .c0:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {
@@ -429,6 +469,10 @@ exports[`component: TextButton should support space props 1`] = `
 .c0:focus {
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
 }
 
 .c0 svg {


### PR DESCRIPTION
Fixes the dotted line that shows up in Firefox only. We could, but shouldn't add this globally because it will force us to realize our own focus states where we remove these.

https://css-tricks.com/removing-the-dotted-outline/#article-header-id-3