### PR TITLE
feat(cactus-web): Add new icon button focus state

### DIFF
--- a/modules/cactus-web/scripts/make-component.js
+++ b/modules/cactus-web/scripts/make-component.js
@@ -106,7 +106,7 @@ import * as React from 'react'
 import { cleanup, render, fireEvent } from 'react-testing-library'
 import ${componentName} from './${componentName}'
 import cactusTheme from '@repay/cactus-theme'
-import { StyleProvider } from '@repay/cactus-web'
+import { StyleProvider } from '../StyleProvider/StyleProvider'
 
 afterEach(cleanup)
 

--- a/modules/cactus-web/src/Grid/Grid.test.tsx
+++ b/modules/cactus-web/src/Grid/Grid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { cleanup, render } from 'react-testing-library'
-import { StyleProvider } from '@repay/cactus-web'
+import { StyleProvider } from '../StyleProvider/StyleProvider'
 import Grid from './Grid'
 
 afterEach(cleanup)
@@ -9,7 +9,7 @@ describe('component: Grid', () => {
   test('should render extraLarge viewport design', () => {
     const { container } = render(
       <StyleProvider>
-        <Grid>
+        <Grid justify="center">
           <Grid.Item tiny={4} extraLarge={2} />
           <Grid.Item tiny={4} extraLarge={2} />
           <Grid.Item tiny={4} extraLarge={2} />
@@ -26,7 +26,7 @@ describe('component: Grid', () => {
   test('should render tiny viewport design', () => {
     const { container } = render(
       <StyleProvider>
-        <Grid>
+        <Grid justify="end">
           <Grid.Item tiny={3} />
           <Grid.Item tiny={3} />
           <Grid.Item tiny={3} />

--- a/modules/cactus-web/src/Grid/Grid.tsx
+++ b/modules/cactus-web/src/Grid/Grid.tsx
@@ -10,7 +10,9 @@ type ColumnNum = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 
 interface GridProps
   extends MarginProps,
-    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {}
+    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  justify?: 'start' | 'center' | 'end'
+}
 
 interface ItemProps
   extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
@@ -69,6 +71,12 @@ export const Item = styled.div<ItemProps>`
   }
 `
 
+const flexJustifyMap = {
+  start: 'flex-start',
+  end: 'flex-end',
+  center: 'center',
+}
+
 interface GridComponent extends StyledComponentBase<'div', CactusTheme, GridProps> {
   Item: React.ComponentType<ItemProps>
 }
@@ -81,15 +89,29 @@ export const Grid = styled.div<GridProps>`
   flex-direction: row;
   flex-wrap: wrap;
 
+  > ${Item} {
+    display: flex;
+    justify-content: ${p => (p.justify ? flexJustifyMap[p.justify] : 'flex-start')};
+  }
+
   @supports (display: grid) {
     display: grid;
     grid-template-columns: repeat(12, 1fr);
     grid-gap: ${GUTTER_WIDTH}px;
+    justify-items: ${p => (p.justify ? p.justify : 'start')};
+
+    > ${Item} {
+      display: block;
+    }
   }
 
   ${margins}
 ` as any
 
 Grid.Item = Item
+
+Grid.defaultProps = {
+  justify: 'start',
+}
 
 export default Grid as GridComponent

--- a/modules/cactus-web/src/Grid/__snapshots__/Grid.test.tsx.snap
+++ b/modules/cactus-web/src/Grid/__snapshots__/Grid.test.tsx.snap
@@ -1,10 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component: Grid breakpoint styles should match larger screen sizes if their breakpoint style is not defined 1`] = `
-.c1 {
+.c2 {
   box-sizing: border-box;
   margin: 8px 8px;
   width: calc(25% - 16px);
+}
+
+.c3 > .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c4 > .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
 }
 
 .c0 {
@@ -22,17 +44,40 @@ exports[`component: Grid breakpoint styles should match larger screen sizes if t
   flex-wrap: wrap;
 }
 
+.c0 > .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
 @media (min-width:769px) {
-  .c1 {
+  .c2 {
     width: calc(50% - 16px);
   }
 }
 
 @supports (display:grid) {
-  .c1 {
+  .c2 {
     grid-column: span 3;
     width: auto;
     margin: 0;
+  }
+}
+
+@supports (display:grid) {
+  .c3 > .c1 {
+    display: block;
+  }
+}
+
+@supports (display:grid) {
+  .c4 > .c1 {
+    display: block;
   }
 }
 
@@ -41,6 +86,11 @@ exports[`component: Grid breakpoint styles should match larger screen sizes if t
     display: grid;
     grid-template-columns: repeat(12,1fr);
     grid-gap: 16px;
+    justify-items: start;
+  }
+
+  .c0 > .c1 {
+    display: block;
   }
 }
 
@@ -49,23 +99,23 @@ exports[`component: Grid breakpoint styles should match larger screen sizes if t
     class="c0"
   >
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
   </div>
 </div>
 `;
 
 exports[`component: Grid should render extraLarge viewport design 1`] = `
-.c1 {
+.c2 {
   box-sizing: border-box;
   margin: 8px 8px;
   width: calc(33.33333333333333% - 16px);
@@ -86,14 +136,25 @@ exports[`component: Grid should render extraLarge viewport design 1`] = `
   flex-wrap: wrap;
 }
 
+.c0 > .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 @media (min-width:1441px) {
-  .c1 {
+  .c2 {
     width: calc(16.666666666666664% - 16px);
   }
 }
 
 @supports (display:grid) {
-  .c1 {
+  .c2 {
     grid-column: span 4;
     width: auto;
     margin: 0;
@@ -105,6 +166,11 @@ exports[`component: Grid should render extraLarge viewport design 1`] = `
     display: grid;
     grid-template-columns: repeat(12,1fr);
     grid-gap: 16px;
+    justify-items: center;
+  }
+
+  .c0 > .c1 {
+    display: block;
   }
 }
 
@@ -113,32 +179,43 @@ exports[`component: Grid should render extraLarge viewport design 1`] = `
     class="c0"
   >
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
   </div>
 </div>
 `;
 
 exports[`component: Grid should render tiny viewport design 1`] = `
-.c1 {
+.c2 {
   box-sizing: border-box;
   margin: 8px 8px;
   width: calc(25% - 16px);
+}
+
+.c3 > .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 .c0 {
@@ -156,11 +233,28 @@ exports[`component: Grid should render tiny viewport design 1`] = `
   flex-wrap: wrap;
 }
 
+.c0 > .c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
 @supports (display:grid) {
-  .c1 {
+  .c2 {
     grid-column: span 3;
     width: auto;
     margin: 0;
+  }
+}
+
+@supports (display:grid) {
+  .c3 > .c1 {
+    display: block;
   }
 }
 
@@ -169,6 +263,11 @@ exports[`component: Grid should render tiny viewport design 1`] = `
     display: grid;
     grid-template-columns: repeat(12,1fr);
     grid-gap: 16px;
+    justify-items: end;
+  }
+
+  .c0 > .c1 {
+    display: block;
   }
 }
 
@@ -177,16 +276,16 @@ exports[`component: Grid should render tiny viewport design 1`] = `
     class="c0"
   >
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
     <div
-      class="c1"
+      class="c1 c2"
     />
   </div>
 </div>

--- a/modules/cactus-web/src/IconButton/IconButton.story.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.story.tsx
@@ -4,6 +4,7 @@ import * as icons from '@repay/cactus-icons/i'
 import { actions } from '@storybook/addon-actions'
 import { boolean, select } from '@storybook/addon-knobs/react'
 import { storiesOf } from '@storybook/react'
+import Grid from '../Grid/Grid'
 import IconButton, { IconButtonSizes, IconButtonVariants } from './IconButton'
 
 const iconButtonVariants: IconButtonVariants[] = ['standard', 'action']
@@ -11,21 +12,35 @@ const iconButtonSizes: IconButtonSizes[] = ['tiny', 'small', 'medium', 'large']
 type IconName = keyof typeof icons
 const iconNames: IconName[] = Object.keys(icons) as IconName[]
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
-const iconButtonStories = storiesOf('IconButton', module)
 
-iconButtonStories.add('Basic Usage', () => {
-  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
-  const Icon = icons[iconName]
-  return (
-    <IconButton
-      variant={select('variant', iconButtonVariants, 'standard')}
-      iconSize={select('size', iconButtonSizes, 'medium')}
-      disabled={boolean('disabled', false)}
-      inverse={boolean('inverse', false)}
-      label="add"
-      {...eventLoggers}
-    >
-      <Icon />
-    </IconButton>
-  )
-})
+storiesOf('IconButton', module)
+  .add('Basic Usage', () => {
+    const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+    const Icon = icons[iconName]
+    return (
+      <IconButton
+        variant={select('variant', iconButtonVariants, 'standard')}
+        iconSize={select('size', iconButtonSizes, 'medium')}
+        disabled={boolean('disabled', false)}
+        inverse={boolean('inverse', false)}
+        label="add"
+        {...eventLoggers}
+      >
+        <Icon />
+      </IconButton>
+    )
+  })
+  .add('All Icons', () => {
+    const variantSelection = select('variant', iconButtonVariants, 'standard')
+    return (
+      <Grid justify="center">
+        {Object.values(icons).map(Icon => (
+          <Grid.Item tiny={3} medium={2} large={1}>
+            <IconButton variant={variantSelection}>
+              <Icon />
+            </IconButton>
+          </Grid.Item>
+        ))}
+      </Grid>
+    )
+  })

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -40,8 +40,7 @@ const variantMap: VariantMap = {
   standard: css`
     color: ${p => p.theme.colors.base};
 
-    &:hover,
-    &:focus {
+    &:hover {
       color: ${p => p.theme.colors.callToAction};
     }
   `,
@@ -107,8 +106,7 @@ export const IconButton = styled(IconButtonBase)<IconButtonProps>`
   display: ${p => p.display || 'inline-flex'};
   align-items: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -116,6 +114,10 @@ export const IconButton = styled(IconButtonBase)<IconButtonProps>`
 
   &::-moz-focus-inner {
     border: 0;
+  }
+
+  &:focus {
+    background-color: ${p => p.theme.colors.transparentCTA};
   }
 
   ${variantOrDisabled}

--- a/modules/cactus-web/src/IconButton/__snapshots__/IconButton.test.tsx.snap
+++ b/modules/cactus-web/src/IconButton/__snapshots__/IconButton.test.tsx.snap
@@ -19,8 +19,7 @@ exports[`component: IconButton should default to standard medium icon button 1`]
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -33,8 +32,11 @@ exports[`component: IconButton should default to standard medium icon button 1`]
   border: 0;
 }
 
-.c0:hover,
 .c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
   color: hsl(200,96%,35%);
 }
 
@@ -77,8 +79,7 @@ exports[`component: IconButton should render call to action icon button 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -89,6 +90,10 @@ exports[`component: IconButton should render call to action icon button 1`] = `
 
 .c0::-moz-focus-inner {
   border: 0;
+}
+
+.c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
 }
 
 .c0:hover,
@@ -135,8 +140,7 @@ exports[`component: IconButton should render disabled variant 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -148,6 +152,10 @@ exports[`component: IconButton should render disabled variant 1`] = `
 
 .c0::-moz-focus-inner {
   border: 0;
+}
+
+.c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
 }
 
 <button
@@ -190,8 +198,7 @@ exports[`component: IconButton should render icon button with aria-label 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -204,8 +211,11 @@ exports[`component: IconButton should render icon button with aria-label 1`] = `
   border: 0;
 }
 
-.c0:hover,
 .c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
   color: hsl(200,96%,35%);
 }
 
@@ -249,8 +259,7 @@ exports[`component: IconButton should render inverse call to action icon button 
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -261,6 +270,10 @@ exports[`component: IconButton should render inverse call to action icon button 
 
 .c0::-moz-focus-inner {
   border: 0;
+}
+
+.c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
 }
 
 .c0:hover,
@@ -307,8 +320,7 @@ exports[`component: IconButton should render inverse disabled variant 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -320,6 +332,10 @@ exports[`component: IconButton should render inverse disabled variant 1`] = `
 
 .c0::-moz-focus-inner {
   border: 0;
+}
+
+.c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
 }
 
 <button
@@ -362,8 +378,7 @@ exports[`component: IconButton should render inverse standard icon button 1`] = 
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -374,6 +389,10 @@ exports[`component: IconButton should render inverse standard icon button 1`] = 
 
 .c0::-moz-focus-inner {
   border: 0;
+}
+
+.c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
 }
 
 .c0:hover,
@@ -421,8 +440,7 @@ exports[`component: IconButton should render large icon button 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -435,8 +453,11 @@ exports[`component: IconButton should render large icon button 1`] = `
   border: 0;
 }
 
-.c0:hover,
 .c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
   color: hsl(200,96%,35%);
 }
 
@@ -479,8 +500,7 @@ exports[`component: IconButton should render small icon button 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -493,8 +513,11 @@ exports[`component: IconButton should render small icon button 1`] = `
   border: 0;
 }
 
-.c0:hover,
 .c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
   color: hsl(200,96%,35%);
 }
 
@@ -537,8 +560,7 @@ exports[`component: IconButton should render standard medium icon button 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -551,8 +573,11 @@ exports[`component: IconButton should render standard medium icon button 1`] = `
   border: 0;
 }
 
-.c0:hover,
 .c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
   color: hsl(200,96%,35%);
 }
 
@@ -595,8 +620,7 @@ exports[`component: IconButton should render tiny icon button 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -609,8 +633,11 @@ exports[`component: IconButton should render tiny icon button 1`] = `
   border: 0;
 }
 
-.c0:hover,
 .c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
   color: hsl(200,96%,35%);
 }
 
@@ -653,8 +680,7 @@ exports[`component: IconButton should support margin space props 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding: 0px;
-  border-radius: 50%;
+  padding: 1px;
   border: none;
   background: transparent;
   outline: none;
@@ -668,8 +694,11 @@ exports[`component: IconButton should support margin space props 1`] = `
   border: 0;
 }
 
-.c0:hover,
 .c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
   color: hsl(200,96%,35%);
 }
 


### PR DESCRIPTION
Alright, so I also added the `justify` prop to `Grid` and that will give the devs some more control over the content inside grids. I noticed that would be a nice feature when I was using the grid to lay out the new story for the icon buttons. Other than that this is the new icon button focus state that we talked about this morning