### PR TITLE
fix(docs): allow href for markdown rendering

### DIFF
--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -93,15 +93,6 @@ const IconButtonBase = React.forwardRef<HTMLButtonElement, IconButtonProps>((pro
   )
 })
 
-IconButtonBase.defaultProps = {
-  variant: 'standard',
-  iconSize: 'medium',
-  display: 'inline-flex',
-  disabled: false,
-  inverse: false,
-  type: 'button',
-}
-
 export const IconButton = styled(IconButtonBase)<IconButtonProps>`
   display: ${p => p.display || 'inline-flex'};
   align-items: center;
@@ -124,5 +115,14 @@ export const IconButton = styled(IconButtonBase)<IconButtonProps>`
   ${margins}
   ${iconSizes}
 `
+
+IconButton.defaultProps = {
+  variant: 'standard',
+  iconSize: 'medium',
+  display: 'inline-flex',
+  disabled: false,
+  inverse: false,
+  type: 'button',
+}
 
 export default IconButton

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -22,7 +22,6 @@ module.exports = {
       },
     },
     'gatsby-plugin-styled-components',
-    'gatsby-plugin-catch-links',
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/website/package.json
+++ b/website/package.json
@@ -36,7 +36,6 @@
     "fast-glob": "^2.2.6",
     "gatsby": "^2.3.23",
     "gatsby-mdx": "^0.6.2",
-    "gatsby-plugin-catch-links": "^2.0.13",
     "gatsby-plugin-manifest": "^2.0.29",
     "gatsby-plugin-react-helmet": "^3.0.12",
     "gatsby-plugin-sharp": "^2.0.34",

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -141,21 +141,14 @@ const StyledLink = styled(Link)`
 
 const StyledA = StyledLink.withComponent('a')
 
-const isStorybookUrl = (url: string) => url.includes('/stories/')
-const forceLocationReload = (event: React.SyntheticEvent<HTMLAnchorElement>) => {
-  event.preventDefault()
-  const href = event.currentTarget.getAttribute('href')
-  global.window && href !== null && href !== '' && (global.window.location.href = href)
-}
+const isStorybookUrl = (url: string) => /stories\/[a-zA-Z]/.test(url)
 
 const BaseMenuList: React.FC<{ menu: MenuGroup; className?: string }> = ({ menu, className }) => (
   <ul className={className}>
     {menu.items.map(item => (
       <li key={item.url}>
         {isStorybookUrl(item.url) ? (
-          <StyledA href={item.url} onClick={forceLocationReload}>
-            {item.title}
-          </StyledA>
+          <StyledA href={item.url}>{item.title}</StyledA>
         ) : (
           <StyledLink to={item.url}>{item.title}</StyledLink>
         )}

--- a/website/src/components/Link.tsx
+++ b/website/src/components/Link.tsx
@@ -1,6 +1,18 @@
 import { Link as GatsbyLink } from 'gatsby'
 import { Link as RepayLink } from '@repay/cactus-web'
+import React from 'react'
 
-const Link = RepayLink.withComponent(GatsbyLink)
+const LocalLink = RepayLink.withComponent(GatsbyLink)
+
+const isOutside = (href: string) =>
+  href.startsWith('http') && !(global.window && href.startsWith(window.location.origin))
+
+const Link = ({ href, to, ...rest }: any) => {
+  to = to || href || ''
+  if (isOutside(to)) {
+    return <RepayLink to={to} {...rest} />
+  }
+  return <LocalLink to={to} {...rest} />
+}
 
 export default Link

--- a/website/src/pages/design-system/icons.tsx
+++ b/website/src/pages/design-system/icons.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { categories, iconsCategoryMap } from '../../helpers/iconGroups'
 import { Flex } from '@repay/cactus-web'
+import Link from '../../components/Link'
 import Text from '../../components/Text'
 
 export default () => (
@@ -22,7 +23,7 @@ export default () => (
       outside the named purposed due to utility.
     </Text>
     <Text>
-      To learn how to use the icons see the <a href="/icons/">Icons documentation</a>.
+      To learn how to use the icons see the <Link href="/icons/">Icons documentation</Link>.
     </Text>
     {categories.map(cat => {
       const iconList = iconsCategoryMap[cat]
@@ -45,8 +46,8 @@ export default () => (
       )
     })}
     <Text mt={6} mb={5} fontSize="h3">
-      Lastly, the <a href="/design-system/shared-styles/">shared styles</a> such as shadows and
-      spacing which round out the foundation.
+      Lastly, the <Link href="/design-system/shared-styles/">shared styles</Link> such as shadows
+      and spacing which round out the foundation.
     </Text>
   </>
 )

--- a/website/src/pages/design-system/language.tsx
+++ b/website/src/pages/design-system/language.tsx
@@ -73,7 +73,7 @@ export default () => {
         tables, batch cards, notification messages, etc. Atoms and molecules compose our{' '}
         <Em>organisms</Em>: navigation, sidebars, and carousel payment actions. For more information
         on the Atomic Design methodology, see the{' '}
-        <a href="http://atomicdesign.bradfrost.com/">book by Brad Frost</a> who created it.
+        <Link href="http://atomicdesign.bradfrost.com/">book by Brad Frost</Link> who created it.
       </p>
       <p>
         Next, we'll present and dicuss our <Link to="/design-system/foundation/">foundation</Link>{' '}

--- a/website/src/pages/design-system/typography.tsx
+++ b/website/src/pages/design-system/typography.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 
-import { Box, Flex } from '@repay/cactus-web'
+import { Flex } from '@repay/cactus-web'
 import cactusTheme from '@repay/cactus-theme'
 import Helmet from 'react-helmet'
+import Link from '../../components/Link'
 import styled from 'styled-components'
 import Text, { Span } from '../../components/Text'
 
@@ -263,7 +264,7 @@ export default () => {
         </tbody>
       </table>
       <Text mt={6} mb={5} fontSize="h3">
-        Next, we'll review all the <a href="/design-system/icons/">icons</a>.
+        Next, we'll review all the <Link href="/design-system/icons/">icons</Link>.
       </Text>
     </>
   )

--- a/website/src/pages/stories.tsx
+++ b/website/src/pages/stories.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react'
+import Link from '../components/Link'
 import storybookConfig from '../storybook-config.json'
 
 export default () => (
   <>
     <h1>Storybooks</h1>
     <p>
-      For some libraries, we developed using <a href="https://storybook.js.org">Storybook</a> which
-      is an open source tool to help with the development of UI components. Visit one of the links
-      below to experiment with the libraries and adjust props.
+      For some libraries, we developed using <Link to="https://storybook.js.org">Storybook</Link>{' '}
+      which is an open source tool to help with the development of UI components. Visit one of the
+      links below to experiment with the libraries and adjust props.
     </p>
     <ul>
       {storybookConfig.map(story => (
         <li key={story.name}>
-          {/** needs to be anchor, not Link because the stories are not part of gatsby */}
-          <a href={`/stories/${story.dirname}/`}>{story.name}</a>
+          <Link to={`/stories/${story.dirname}/`}>{story.name}</Link>
         </li>
       ))}
     </ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7403,14 +7403,6 @@ gatsby-mdx@^0.6.2:
     unist-util-remove "^1.0.1"
     unist-util-visit "^1.4.0"
 
-gatsby-plugin-catch-links@^2.0.13:
-  version "2.0.13"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.0.13.tgz#b49bb1e2383881cffca86a428348a7afdb6c3dd4"
-  integrity sha512-3JOwByiAKaiHo9k+QMiqe15H0T7wGh0NyulSFz7am1HC5/XHzcrX2ysW/zo1PV5eZq3P+n+X5V0t28cp+n1FBg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    escape-string-regexp "^1.0.5"
-
 gatsby-plugin-manifest@^2.0.29:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.1.1.tgz#e987d6e655b1dcfba6e10d65ff20722aaeb75391"
@@ -15496,24 +15488,7 @@ style-to-object@^0.2.1:
   dependencies:
     css "2.2.4"
 
-styled-components@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.2.0.tgz#811fbbec4d64c7189f6c7482b9eb6fefa7fefef7"
-  integrity sha512-L/LzkL3ZbBhqIVHdR7DbYujy4tqvTNRfc+4JWDCYyhTatI+8CRRQUmdaR0+ARl03DWsfKLhjewll5uNLrqrl4A==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.7.3"
-    "@emotion/unitless" "^0.7.0"
-    babel-plugin-styled-components ">= 1"
-    css-to-react-native "^2.2.2"
-    memoize-one "^5.0.0"
-    prop-types "^15.5.4"
-    react-is "^16.6.0"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
-    supports-color "^5.5.0"
-
-styled-components@^4.2.0:
+styled-components@^4.1.2, styled-components@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.3.1.tgz#18c3709f4ed9d582cd206b1acd8b758a211dd114"
   integrity sha512-04XKQFFSEx3qTeN5I4kiSeajrwG6juDMw2+vUgvfxeXFegE40TuPKS4fFey8RJP1Ii1AoVQVUOglrdUUey0ZHw==


### PR DESCRIPTION
This finishes up converting the links on the documentation website and fixes markdown rendered links by accepting href as well as to. Also uses normal anchor tags for links outside of the site.