### PR TITLE
fix(cactus-web): Don't pass margin props to inner input element

### DIFF
--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from 'react'
 
 import { FieldOnChangeHandler, Omit } from '../types'
 import { Label, LabelProps } from '../Label/Label'
-import { MarginProps, margins } from '../helpers/margins'
+import { MarginProps, margins, splitProps } from '../helpers/margins'
 import { TextInput, TextInputProps } from '../TextInput/TextInput'
 import PropTypes from 'prop-types'
 import StatusMessage, { Status } from '../StatusMessage/StatusMessage'
@@ -34,7 +34,7 @@ const TextInputFieldBase = (props: TextInputFieldProps) => {
     name,
     id,
     ...inputProps
-  } = props
+  } = splitProps(props)
 
   const ref = useRef<HTMLDivElement | null>(null)
 

--- a/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
+++ b/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
@@ -916,7 +916,6 @@ exports[`component: TextInputField should support margin space props 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin: 8px;
 }
 
 .c5 .c1 {


### PR DESCRIPTION
Quick fix for `TextInputField`