### PR TITLE
fix(cactus-web): Remove special characters in select ids

### DIFF
--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -163,7 +163,7 @@ function asOption(opt: string | OptionType): OptionType {
 }
 
 function getOptionId(option: OptionType) {
-  return `${option.label}-${option.value}`.replace(/\s/g, '-').replace(/:|\.|\//g, '')
+  return `${option.label}-${option.value}`.replace(/[\s:.\/]/g, '')
 }
 
 function getOptionsMap(options: OptionType[]) {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -163,7 +163,7 @@ function asOption(opt: string | OptionType): OptionType {
 }
 
 function getOptionId(option: OptionType) {
-  return `${option.label}-${option.value}`.replace(/\s/g, '-')
+  return `${option.label}-${option.value}`.replace(/\s/g, '-').replace(/:|\.|\//g, '')
 }
 
 function getOptionsMap(options: OptionType[]) {


### PR DESCRIPTION
When I was adding the select fields in channels, I noticed that we were getting some console errors when the query selector to find select options contained a url in its value. Turns out it was because of some special characters in the url (colon, slash, period). This PR just removes them, but if you want to replace them with something other than empty string I'm all for it.