### PR TITLE
fix(cactus-web): fix tooltip width drift

### DIFF
--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -530,7 +530,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     clearTimeout(this.scrollClear)
     this.scrollClear = setTimeout(() => {
       this.didScroll = false
-    }, 150) // 120ms worked on Firefox and IE11 so 150 us just extra safe
+    }, 150) // 120ms worked on Firefox and IE11 so 150 is just extra safe
   }
 
   /** END helpers */

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -78,10 +78,15 @@ const cactusPosition: Position = (triggerRect, tooltipRect) => {
   const directionRight = collisions.left && !collisions.right
   const directionUp = collisions.bottom && !collisions.top
 
-  styles = directionRight && !directionUp ? { ...styles, borderTopLeftRadius: '0px' } : styles
-  styles = directionRight && directionUp ? { ...styles, borderBottomLeftRadius: '0px' } : styles
-  styles = !directionRight && !directionUp ? { ...styles, borderTopRightRadius: '0px' } : styles
-  styles = !directionRight && directionUp ? { ...styles, borderBottomRightRadius: '0px' } : styles
+  if (directionRight && !directionUp) {
+    styles.borderTopLeftRadius = '0px'
+  } else if (directionRight && directionUp) {
+    styles.borderBottomLeftRadius = '0px'
+  } else if (!directionRight && !directionUp) {
+    styles.borderTopRightRadius = '0px'
+  } else if (!directionRight && directionUp) {
+    styles.borderBottomRightRadius = '0px'
+  }
 
   return {
     ...styles,
@@ -91,6 +96,8 @@ const cactusPosition: Position = (triggerRect, tooltipRect) => {
     top: directionUp
       ? `${triggerRect.top - tooltipRect.height + scrollY}px`
       : `${triggerRect.top + triggerRect.height + scrollY}px`,
+    // setting width to itself explicitly prevents "drift"
+    width: tooltipRect.width + 'px',
   }
 }
 
@@ -180,23 +187,21 @@ const TooltipContentBase = forwardRef<HTMLDivElement, TooltipContentProps>(funct
   const tooltipRef = useRef<HTMLDivElement | null>(null)
   const tooltipRect = useRect(tooltipRef, isVisible)
   return (
-    <Fragment>
-      <div
-        data-reach-tooltip
-        role={useAriaLabel ? undefined : 'tooltip'}
-        id={useAriaLabel ? undefined : id}
-        children={label}
-        style={{
-          ...style,
-          ...getStyles(position, triggerRect, tooltipRect),
-        }}
-        ref={node => {
-          tooltipRef.current = node
-          if (typeof forwardRef === 'function') forwardRef(node)
-        }}
-        {...rest}
-      />
-    </Fragment>
+    <div
+      data-reach-tooltip
+      role={useAriaLabel ? undefined : 'tooltip'}
+      id={useAriaLabel ? undefined : id}
+      children={label}
+      style={{
+        ...style,
+        ...getStyles(position, triggerRect, tooltipRect),
+      }}
+      ref={node => {
+        tooltipRef.current = node
+        if (typeof forwardRef === 'function') forwardRef(node)
+      }}
+      {...rest}
+    />
   )
 })
 
@@ -229,6 +234,10 @@ Tooltip.propTypes = {
   ariaLabel: PropTypes.string,
   position: PropTypes.func,
   maxWidth: PropTypes.string,
+}
+
+Tooltip.defaultProps = {
+  maxWidth: Math.min(typeof window !== 'undefined' ? window.innerWidth : 500, 500) + 'px',
 }
 
 export default Tooltip

--- a/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`component: Tooltip should render tooltip on hover 1`] = `
   border: 2px solid hsl(200,96%,35%);
   box-sizing: border-box;
   overflow-wrap: break-word;
+  max-width: 500px;
 }
 
 <div
@@ -54,7 +55,7 @@ exports[`component: Tooltip should render tooltip on hover 1`] = `
   data-reach-tooltip="true"
   id="tooltip:3"
   role="tooltip"
-  style="left: -8px; top: 0px; border-top-right-radius: 0px;"
+  style="left: -8px; top: 0px; border-top-right-radius: 0px; width: 0px;"
 >
   This should be displayed
 </div>


### PR DESCRIPTION
When width was left to be auto-generated it was drifting from the initial value causing it to shrink like observed for whatever reason. By setting it explicitly to itself prevents this. 

Also set the default maxWidth to the minimum of `window.innerWidth` and `500` because no one needs a tooltip that's 1024 pixels wide.