### PR TITLE
fix(cactus-web): Make select option ids unique enough to use getElementById

### DIFF
--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -162,17 +162,17 @@ function asOption(opt: string | OptionType): OptionType {
   return opt
 }
 
-function getOptionId(option: OptionType) {
-  return `${option.label}-${option.value}`.replace(/[\s:.\/]/g, '')
+function getOptionId(selectId: string, option: OptionType) {
+  return `${selectId}-${option.label}-${option.value}`.replace(/\s/g, '-')
 }
 
-function getOptionsMap(options: OptionType[]) {
+function getOptionsMap(selectId: string, options: OptionType[]) {
   let optionsMap: { [k: string]: OptionType & { id: string } } = {}
   for (let i = 0; i < options.length; ++i) {
     const opt = asOption(options[i])
     optionsMap[opt.value] = {
       ...opt,
-      id: getOptionId(opt),
+      id: getOptionId(selectId, opt),
     }
   }
   return optionsMap
@@ -291,7 +291,9 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
         let selectedOption: OptionType = asOption(
           this.props.options[getSelectedIndex(this.props.options, selected)]
         )
-        let optionEl: HTMLLIElement | null = listEl.querySelector(`#${getOptionId(selectedOption)}`)
+        let optionEl: HTMLElement | null = document.getElementById(
+          `#${getOptionId(this.props.id, selectedOption)}`
+        )
         if (optionEl === null) {
           return
         }
@@ -553,7 +555,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     let { isOpen, value, selectedValue } = this.state
     // @ts-ignore
     let options: OptionType[] = mixOptions.map(asOption)
-    let optionsMap = getOptionsMap(options)
+    let optionsMap = getOptionsMap(id, options)
 
     return (
       <div className={className}>


### PR DESCRIPTION
By prefixing the option ids with the id of the select itself, it makes them unique enough to use `document.getElementById()` instead of `querySelector`. That way, we don't have to worry about special characters in the label or value. I tested this with all of the options I've found in channels that cause these console errors and this fix seemed to take care of the problem.