### PR TITLE
fix(cactus-web): Allow Select to receive empty options & numbers

### DIFF
--- a/examples/standard/package.json
+++ b/examples/standard/package.json
@@ -18,7 +18,7 @@
     "@repay/cactus-i18n": "^0.2.0",
     "@repay/cactus-icons": "^0.6.0",
     "@repay/cactus-theme": "^0.4.4",
-    "@repay/cactus-web": "^0.4.4",
+    "@repay/cactus-web": "^0.4.13",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },

--- a/examples/standard/src/containers/Home.tsx
+++ b/examples/standard/src/containers/Home.tsx
@@ -40,7 +40,7 @@ const Home: React.FC<RouteComponentProps> = () => {
             label="Language"
             name="termsLang"
             value={termsLang}
-            onChange={(_, value) => setTermsLang(value)}
+            onChange={(_, value: string | number) => setTermsLang(value.toString())}
             options={languageOptions}
           />
         </Box>

--- a/modules/cactus-web/src/Select/Select.story.tsx
+++ b/modules/cactus-web/src/Select/Select.story.tsx
@@ -40,7 +40,7 @@ storiesOf('Select', module)
     { cactus: { overrides: { height: '220vh', width: '220vw' } } }
   )
   .add('Long list of options', () => (
-    <FormHandler defaultValue={arizonaCities[6]} onChange={(name, value) => value}>
+    <FormHandler defaultValue={arizonaCities[6]} onChange={(name, value: string | number) => value}>
       {({ value, onChange }) => (
         <Select
           options={arizonaCities}

--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -46,6 +46,29 @@ describe('component: Select', () => {
     expect(getByText('Who?')).not.toBeNull()
   })
 
+  test('can receive an empty list of options', async () => {
+    const { getByText, getByRole } = render(
+      <StyleProvider>
+        <Select id="empty-options" name="test-empty-options" options={[]} />
+      </StyleProvider>
+    )
+
+    const trigger = getByText('Select an option')
+    fireEvent.click(trigger)
+    await animationRender()
+    expect(getByRole('listbox').getAttribute('aria-activedescendant')).toBeNull()
+  })
+
+  test('can receive options with number values', async () => {
+    const options = [{ label: '1', value: 1 }, { label: 'two', value: 2 }, { label: '3', value: 3 }]
+    const { getByText } = render(
+      <StyleProvider>
+        <Select id="test-numbers" name="test-number-options" options={options} />
+      </StyleProvider>
+    )
+    expect(getByText('two')).not.toBeNull()
+  })
+
   test('sets active descendant to the top option when value does not exist in options', async () => {
     const { getByText, getByRole } = render(
       <StyleProvider>
@@ -478,7 +501,7 @@ describe('component: Select', () => {
   describe('onFocus()', () => {
     test('is called when user focuses on Select', () => {
       const onFocus = jest.fn()
-      const { getByText, getByRole, rerender } = render(
+      const { getByText } = render(
         <StyleProvider>
           <Select
             id="test-id"

--- a/modules/cactus-web/src/SelectField/SelectField.story.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.story.tsx
@@ -34,7 +34,7 @@ storiesOf('SelectField', module)
   .add(
     'Controlled Form',
     () => (
-      <FormHandler onChange={(name: string, value: string) => value}>
+      <FormHandler onChange={(name: string, value: string | number) => value}>
         {({ value, onChange }) => (
           <SelectField
             label={text('label', `What's that in the sky?`)}

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -23,7 +23,7 @@ interface SelectFieldProps extends MarginProps, WidthProps, Omit<SelectProps, 'i
   warning?: string
   error?: string
   tooltip?: string
-  onChange?: FieldOnChangeHandler<string>
+  onChange?: FieldOnChangeHandler<string | number>
 }
 
 const SelectFieldBase: React.FC<SelectFieldProps> = props => {


### PR DESCRIPTION
Two changes happening here:

1. We no longer get console errors when an empty options list is given to the select
2. We are allowing number values to be passed in `options`

Let me know if you have any questions!