### PR TITLE
fix(cactus-web): Prevent file input from growing to 100% of parent width

### DIFF
--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -192,6 +192,7 @@ const FileBox = styled(FileBoxBase)`
 
   span {
     margin-left: 8px;
+    margin-right: 8px;
     ${p => p.theme.textStyles.body};
   }
 
@@ -606,11 +607,11 @@ export const FileInput = styled(FileInputBase)`
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px ${p => (p.theme.disabled ? 'solid' : 'dotted')};
-  border-color: ${p => (p.theme.disabled ? p.theme.colors.lightGray : p.theme.colors.darkContrast)};
+  border-color: ${p => (p.theme.disabled ? p.theme.colors.lightGray : p.theme.colors.darkestContrast)};
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   align-items: center;
 

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -607,7 +607,8 @@ export const FileInput = styled(FileInputBase)`
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px ${p => (p.theme.disabled ? 'solid' : 'dotted')};
-  border-color: ${p => (p.theme.disabled ? p.theme.colors.lightGray : p.theme.colors.darkestContrast)};
+  border-color: ${p =>
+    p.theme.disabled ? p.theme.colors.lightGray : p.theme.colors.darkestContrast};
   min-width: 300px;
   min-height: 100px;
   position: relative;

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -77,14 +77,14 @@ exports[`component: FileInput should render a file input 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -388,6 +388,7 @@ exports[`component: FileInput should render a file with an error 1`] = `
 
 .c2 span {
   margin-left: 8px;
+  margin-right: 8px;
   font-size: 18px;
   line-height: 28px;
 }
@@ -451,14 +452,14 @@ exports[`component: FileInput should render a file with an error 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -770,6 +771,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
 
 .c2 span {
   margin-left: 8px;
+  margin-right: 8px;
   font-size: 18px;
   line-height: 28px;
 }
@@ -833,14 +835,14 @@ exports[`component: FileInput should render a loaded file 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -1030,6 +1032,7 @@ exports[`component: FileInput should render a loading file 1`] = `
 
 .c2 span {
   margin-left: 8px;
+  margin-right: 8px;
   font-size: 18px;
   line-height: 28px;
 }
@@ -1093,14 +1096,14 @@ exports[`component: FileInput should render a loading file 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -46,6 +46,7 @@ export const FileInputField = styled(FileInputFieldBase)`
   position: relative;
 
   ${Label} {
+    display: block;
     position: relative;
     bottom: 4px;
     padding-left: 16px;

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -227,6 +227,7 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 
 .c9 span {
   margin-left: 8px;
+  margin-right: 8px;
   font-size: 18px;
   line-height: 28px;
 }
@@ -290,14 +291,14 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -348,6 +349,7 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 }
 
 .c0 .c3 {
+  display: block;
   position: relative;
   bottom: 4px;
   padding-left: 16px;
@@ -678,6 +680,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
 
 .c9 span {
   margin-left: 8px;
+  margin-right: 8px;
   font-size: 18px;
   line-height: 28px;
 }
@@ -741,14 +744,14 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -799,6 +802,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
 }
 
 .c0 .c3 {
+  display: block;
   position: relative;
   bottom: 4px;
   padding-left: 16px;
@@ -1007,6 +1011,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
 
 .c9 span {
   margin-left: 8px;
+  margin-right: 8px;
   font-size: 18px;
   line-height: 28px;
 }
@@ -1070,14 +1075,14 @@ exports[`component: FileInputField should render a loading file 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -1128,6 +1133,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
 }
 
 .c0 .c3 {
+  display: block;
   position: relative;
   bottom: 4px;
   padding-left: 16px;
@@ -1311,14 +1317,14 @@ exports[`component: FileInputField should render file input field 1`] = `
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
-  border-color: hsl(200,9%,35%);
+  border-color: hsl(200,10%,20%);
   min-width: 300px;
   min-height: 100px;
   position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -1369,6 +1375,7 @@ exports[`component: FileInputField should render file input field 1`] = `
 }
 
 .c0 .c3 {
+  display: block;
   position: relative;
   bottom: 4px;
   padding-left: 16px;


### PR DESCRIPTION
My main goal with this PR was to stop the file input from automatically growing to its parent width, but I also made sure the border was using the right color, since it was one shade too light. I also added some extra spacing between the file name and the close button