### PR TITLE
File input improvements

### DIFF
--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -405,7 +405,6 @@ const FileInputBase = (props: FileInputProps) => {
                   errorMsg: errorMsg,
                 })
               }
-              dataURL = dataURL.replace(/data:.+\/.+\;base64,/g, '')
               resolve({ fileName: file.name, contents: dataURL, status: 'loaded' })
             }
 

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -54,7 +54,7 @@ export interface FileInputProps
       'onChange' | 'onError' | 'onFocus' | 'onBlur' | 'ref'
     > {
   name: string
-  accept: string[]
+  accept?: string[]
   labels?: { delete?: string; retry?: string; loading?: string; loaded?: string }
   buttonText?: string
   prompt?: string
@@ -372,7 +372,7 @@ const FileInputBase = (props: FileInputProps) => {
       }
 
       const promises = Array.from(files).map(file => {
-        if (!accepts(file, accept)) {
+        if (accept && !accepts(file, accept)) {
           return new Promise<FileObject>(resolve => {
             const errorMsg = onError(FILE_TYPE_ERR, accept)
             resolve({
@@ -552,7 +552,7 @@ const FileInputBase = (props: FileInputProps) => {
         type="file"
         ref={fileSelector}
         key={state.inputKey}
-        accept={accept.join()}
+        accept={accept && accept.join()}
         multiple={multiple}
         onChange={handleFileSelect}
       />
@@ -657,7 +657,7 @@ interface FileInputComponent
 // @ts-ignore
 FileInput.propTypes = {
   name: PropTypes.string.isRequired,
-  accept: PropTypes.arrayOf(PropTypes.string).isRequired,
+  accept: PropTypes.arrayOf(PropTypes.string),
   labels: PropTypes.shape({
     delete: PropTypes.string,
     retry: PropTypes.string,

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -470,6 +470,9 @@ const FileInputBase = (props: FileInputProps) => {
     event.stopPropagation()
 
     saveFiles(event.dataTransfer.files)
+    if (fileSelector.current) {
+      fileSelector.current.files = event.dataTransfer.files
+    }
   }
 
   const handleOpenFileSelect = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -553,6 +556,7 @@ const FileInputBase = (props: FileInputProps) => {
         ref={fileSelector}
         key={state.inputKey}
         accept={accept && accept.join()}
+        name={name}
         multiple={multiple}
         onChange={handleFileSelect}
       />

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -124,6 +124,7 @@ exports[`component: FileInput should render a file input 1`] = `
   >
     <input
       accept=".tsx"
+      name="throatpunch"
       type="file"
     />
     <div
@@ -499,6 +500,7 @@ exports[`component: FileInput should render a file with an error 1`] = `
   >
     <input
       accept=".md"
+      name="throatpunch"
       type="file"
     />
     <div
@@ -882,6 +884,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   >
     <input
       accept=".md"
+      name="throatpunch"
       type="file"
     />
     <div
@@ -1143,6 +1146,7 @@ exports[`component: FileInput should render a loading file 1`] = `
   >
     <input
       accept=".md"
+      name="throatpunch"
       type="file"
     />
     <div

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -68,7 +68,7 @@ FileInputField.propTypes = {
   labelProps: PropTypes.object,
   tooltip: PropTypes.string,
   name: PropTypes.string.isRequired,
-  accept: PropTypes.arrayOf(PropTypes.string).isRequired,
+  accept: PropTypes.arrayOf(PropTypes.string),
   labels: PropTypes.shape({
     delete: PropTypes.string,
     retry: PropTypes.string,

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -401,6 +401,7 @@ exports[`component: FileInputField should render a file with an error 1`] = `
     >
       <input
         accept=".txt"
+        name="bears"
         type="file"
       />
       <div
@@ -854,6 +855,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
     >
       <input
         accept=".txt"
+        name="bears"
         type="file"
       />
       <div
@@ -1185,6 +1187,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
     >
       <input
         accept=".txt"
+        name="bears"
         type="file"
       />
       <div
@@ -1427,6 +1430,7 @@ exports[`component: FileInputField should render file input field 1`] = `
     >
       <input
         accept=".txt"
+        name="bears"
         type="file"
       />
       <div


### PR DESCRIPTION
There were 3 things that could be improved that I came across as I was adding the file input to channels:

1. Stop removing `data:` and `base64,` from the dataURL. We need to keep that to display images on the page sometimes. Best to leave any modification of that string up to the developer.
2. Make `accept` optional. This prop isn't required on a basic file input, so I don't want to make it required on this. Additionally, there are places in channels where we might shoot ourselves in the foot by restricting file types.
3. Pass the `name` prop to the hidden input and set the value of that input when files are dropped. This will ensure the values are set in the cases when we send the raw form data to the backend.