### PR TITLE
refactor(cactus-web): New toggle styles

### DIFF
--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -32,8 +32,8 @@ const StyledX = styled(NavigationClose)`
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: ${p => p.theme.colors.white};
 `
 
@@ -41,19 +41,19 @@ const StyledCheck = styled(StatusCheck)`
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: ${p => p.theme.colors.white};
 `
 
 export const Toggle = styled(ToggleBase)`
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: ${p => p.theme.colors.darkestContrast};
-  border: 1px solid ${p => p.theme.colors.darkestContrast};
+  background-color: ${p => p.theme.colors.error};
+  border: 1px solid ${p => p.theme.colors.error};
   cursor: ${p => (p.disabled ? 'cursor' : 'pointer')};
 
   &:focus {
@@ -61,23 +61,24 @@ export const Toggle = styled(ToggleBase)`
   }
 
   ::after {
-    width: 18px;
-    height: 18px;
+    width: 26px;
+    height: 26px;
     border-radius: 50%;
     content: '';
-    top: 0;
-    left: 0;
+    top: -1px;
+    left: -1px;
     position: absolute;
     transition: transform 0.3s;
     background-color: ${p => p.theme.colors.white};
+    box-shadow: 0 0 3px ${p => p.theme.colors.darkestContrast};
   }
 
   &[aria-checked='true'] {
-    background-color: ${p => p.theme.colors.callToAction};
-    border-color: ${p => p.theme.colors.callToAction};
+    background-color: ${p => p.theme.colors.success};
+    border-color: ${p => p.theme.colors.success};
 
     ::after {
-      transform: translateX(25px);
+      transform: translateX(26px);
     }
 
     ${StyledX} {
@@ -100,8 +101,7 @@ export const Toggle = styled(ToggleBase)`
   }
 
   &[disabled] {
-    background-color: ${p => p.theme.colors.lightGray};
-    border-color: ${p => p.theme.colors.lightGray};
+    opacity: 0.5;
   }
 
   ${margin}

--- a/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -7,8 +7,8 @@ exports[`component: Toggle should initialize value to true 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: hsl(0,0%,100%);
 }
 
@@ -17,19 +17,19 @@ exports[`component: Toggle should initialize value to true 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
 }
 
 .c0 {
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: hsl(200,10%,20%);
-  border: 1px solid hsl(200,10%,20%);
+  background-color: hsl(353,84%,44%);
+  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
@@ -38,28 +38,29 @@ exports[`component: Toggle should initialize value to true 1`] = `
 }
 
 .c0::after {
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   content: '';
-  top: 0;
-  left: 0;
+  top: -1px;
+  left: -1px;
   position: absolute;
   -webkit-transition: -webkit-transform 0.3s;
   -webkit-transition: transform 0.3s;
   transition: transform 0.3s;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
 .c0[aria-checked='true'] {
-  background-color: hsl(200,96%,35%);
-  border-color: hsl(200,96%,35%);
+  background-color: hsl(145,89%,28%);
+  border-color: hsl(145,89%,28%);
 }
 
 .c0[aria-checked='true']::after {
-  -webkit-transform: translateX(25px);
-  -ms-transform: translateX(25px);
-  transform: translateX(25px);
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
 }
 
 .c0[aria-checked='true'] .c1 {
@@ -83,8 +84,7 @@ exports[`component: Toggle should initialize value to true 1`] = `
 }
 
 .c0[disabled] {
-  background-color: hsl(0,0%,90%);
-  border-color: hsl(0,0%,90%);
+  opacity: 0.5;
 }
 
 .c5[aria-checked='true'] .c1 {
@@ -148,8 +148,8 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: hsl(0,0%,100%);
 }
 
@@ -158,7 +158,7 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
 }
@@ -185,12 +185,12 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 
 .c0 {
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: hsl(200,10%,20%);
-  border: 1px solid hsl(200,10%,20%);
+  background-color: hsl(353,84%,44%);
+  border: 1px solid hsl(353,84%,44%);
   cursor: cursor;
 }
 
@@ -199,28 +199,29 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 }
 
 .c0::after {
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   content: '';
-  top: 0;
-  left: 0;
+  top: -1px;
+  left: -1px;
   position: absolute;
   -webkit-transition: -webkit-transform 0.3s;
   -webkit-transition: transform 0.3s;
   transition: transform 0.3s;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
 .c0[aria-checked='true'] {
-  background-color: hsl(200,96%,35%);
-  border-color: hsl(200,96%,35%);
+  background-color: hsl(145,89%,28%);
+  border-color: hsl(145,89%,28%);
 }
 
 .c0[aria-checked='true']::after {
-  -webkit-transform: translateX(25px);
-  -ms-transform: translateX(25px);
-  transform: translateX(25px);
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
 }
 
 .c0[aria-checked='true'] .c1 {
@@ -244,8 +245,7 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 }
 
 .c0[disabled] {
-  background-color: hsl(0,0%,90%);
-  border-color: hsl(0,0%,90%);
+  opacity: 0.5;
 }
 
 <button
@@ -290,8 +290,8 @@ exports[`component: Toggle should render a toggle 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: hsl(0,0%,100%);
 }
 
@@ -300,19 +300,19 @@ exports[`component: Toggle should render a toggle 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
 }
 
 .c0 {
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: hsl(200,10%,20%);
-  border: 1px solid hsl(200,10%,20%);
+  background-color: hsl(353,84%,44%);
+  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
@@ -321,28 +321,29 @@ exports[`component: Toggle should render a toggle 1`] = `
 }
 
 .c0::after {
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   content: '';
-  top: 0;
-  left: 0;
+  top: -1px;
+  left: -1px;
   position: absolute;
   -webkit-transition: -webkit-transform 0.3s;
   -webkit-transition: transform 0.3s;
   transition: transform 0.3s;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
 .c0[aria-checked='true'] {
-  background-color: hsl(200,96%,35%);
-  border-color: hsl(200,96%,35%);
+  background-color: hsl(145,89%,28%);
+  border-color: hsl(145,89%,28%);
 }
 
 .c0[aria-checked='true']::after {
-  -webkit-transform: translateX(25px);
-  -ms-transform: translateX(25px);
-  transform: translateX(25px);
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
 }
 
 .c0[aria-checked='true'] .c1 {
@@ -366,8 +367,7 @@ exports[`component: Toggle should render a toggle 1`] = `
 }
 
 .c0[disabled] {
-  background-color: hsl(0,0%,90%);
-  border-color: hsl(0,0%,90%);
+  opacity: 0.5;
 }
 
 <button
@@ -411,8 +411,8 @@ exports[`component: Toggle should support margin space props 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: hsl(0,0%,100%);
 }
 
@@ -421,7 +421,7 @@ exports[`component: Toggle should support margin space props 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
 }
@@ -468,12 +468,12 @@ exports[`component: Toggle should support margin space props 1`] = `
 
 .c0 {
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: hsl(200,10%,20%);
-  border: 1px solid hsl(200,10%,20%);
+  background-color: hsl(353,84%,44%);
+  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
   margin-bottom: 16px;
 }
@@ -483,28 +483,29 @@ exports[`component: Toggle should support margin space props 1`] = `
 }
 
 .c0::after {
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   content: '';
-  top: 0;
-  left: 0;
+  top: -1px;
+  left: -1px;
   position: absolute;
   -webkit-transition: -webkit-transform 0.3s;
   -webkit-transition: transform 0.3s;
   transition: transform 0.3s;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
 .c0[aria-checked='true'] {
-  background-color: hsl(200,96%,35%);
-  border-color: hsl(200,96%,35%);
+  background-color: hsl(145,89%,28%);
+  border-color: hsl(145,89%,28%);
 }
 
 .c0[aria-checked='true']::after {
-  -webkit-transform: translateX(25px);
-  -ms-transform: translateX(25px);
-  transform: translateX(25px);
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
 }
 
 .c0[aria-checked='true'] .c1 {
@@ -528,8 +529,7 @@ exports[`component: Toggle should support margin space props 1`] = `
 }
 
 .c0[disabled] {
-  background-color: hsl(0,0%,90%);
-  border-color: hsl(0,0%,90%);
+  opacity: 0.5;
 }
 
 <button

--- a/modules/cactus-web/src/ToggleField/ToggleField.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.tsx
@@ -86,12 +86,14 @@ export const ToggleField = styled(ToggleFieldBase)`
   ${margin}
 
   ${Label} {
-    cursor: pointer;
+    cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
     margin-left: 8px;
+    line-height: 26px;
+    vertical-align: -2px;
   }
 
   ${Toggle} {
-    vertical-align: text-bottom;
+    vertical-align: middle;
   }
 `
 

--- a/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
+++ b/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
@@ -17,8 +17,8 @@ exports[`component: ToggleField snapshot 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: hsl(0,0%,100%);
 }
 
@@ -27,19 +27,19 @@ exports[`component: ToggleField snapshot 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
 }
 
 .c4 {
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: hsl(200,10%,20%);
-  border: 1px solid hsl(200,10%,20%);
+  background-color: hsl(353,84%,44%);
+  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
@@ -48,28 +48,29 @@ exports[`component: ToggleField snapshot 1`] = `
 }
 
 .c4::after {
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   content: '';
-  top: 0;
-  left: 0;
+  top: -1px;
+  left: -1px;
   position: absolute;
   -webkit-transition: -webkit-transform 0.3s;
   -webkit-transition: transform 0.3s;
   transition: transform 0.3s;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
 .c4[aria-checked='true'] {
-  background-color: hsl(200,96%,35%);
-  border-color: hsl(200,96%,35%);
+  background-color: hsl(145,89%,28%);
+  border-color: hsl(145,89%,28%);
 }
 
 .c4[aria-checked='true']::after {
-  -webkit-transform: translateX(25px);
-  -ms-transform: translateX(25px);
-  transform: translateX(25px);
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
 }
 
 .c4[aria-checked='true'] .c5 {
@@ -93,17 +94,18 @@ exports[`component: ToggleField snapshot 1`] = `
 }
 
 .c4[disabled] {
-  background-color: hsl(0,0%,90%);
-  border-color: hsl(0,0%,90%);
+  opacity: 0.5;
 }
 
 .c0 .c9 {
   cursor: pointer;
   margin-left: 8px;
+  line-height: 26px;
+  vertical-align: -2px;
 }
 
 .c0 .c3 {
-  vertical-align: text-bottom;
+  vertical-align: middle;
 }
 
 <div>
@@ -170,8 +172,8 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: hsl(0,0%,100%);
 }
 
@@ -180,7 +182,7 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
 }
@@ -207,12 +209,12 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
 
 .c4 {
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: hsl(200,10%,20%);
-  border: 1px solid hsl(200,10%,20%);
+  background-color: hsl(353,84%,44%);
+  border: 1px solid hsl(353,84%,44%);
   cursor: cursor;
 }
 
@@ -221,28 +223,29 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
 }
 
 .c4::after {
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   content: '';
-  top: 0;
-  left: 0;
+  top: -1px;
+  left: -1px;
   position: absolute;
   -webkit-transition: -webkit-transform 0.3s;
   -webkit-transition: transform 0.3s;
   transition: transform 0.3s;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
 .c4[aria-checked='true'] {
-  background-color: hsl(200,96%,35%);
-  border-color: hsl(200,96%,35%);
+  background-color: hsl(145,89%,28%);
+  border-color: hsl(145,89%,28%);
 }
 
 .c4[aria-checked='true']::after {
-  -webkit-transform: translateX(25px);
-  -ms-transform: translateX(25px);
-  transform: translateX(25px);
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
 }
 
 .c4[aria-checked='true'] .c5 {
@@ -266,17 +269,29 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
 }
 
 .c4[disabled] {
-  background-color: hsl(0,0%,90%);
-  border-color: hsl(0,0%,90%);
+  opacity: 0.5;
+}
+
+.c12 .c9 {
+  cursor: pointer;
+  margin-left: 8px;
+  line-height: 26px;
+  vertical-align: -2px;
+}
+
+.c12 .c3 {
+  vertical-align: middle;
 }
 
 .c0 .c9 {
-  cursor: pointer;
+  cursor: not-allowed;
   margin-left: 8px;
+  line-height: 26px;
+  vertical-align: -2px;
 }
 
 .c0 .c3 {
-  vertical-align: text-bottom;
+  vertical-align: middle;
 }
 
 <div>
@@ -344,8 +359,8 @@ exports[`component: ToggleField snapshot when value=true 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 3px;
-  left: 25px;
+  top: 6px;
+  right: 8px;
   color: hsl(0,0%,100%);
 }
 
@@ -354,19 +369,19 @@ exports[`component: ToggleField snapshot when value=true 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 1px;
+  top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
 }
 
 .c4 {
   position: relative;
-  width: 45px;
-  height: 20px;
-  border-radius: 10px;
+  width: 51px;
+  height: 26px;
+  border-radius: 13px;
   outline: none;
-  background-color: hsl(200,10%,20%);
-  border: 1px solid hsl(200,10%,20%);
+  background-color: hsl(353,84%,44%);
+  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
@@ -375,28 +390,29 @@ exports[`component: ToggleField snapshot when value=true 1`] = `
 }
 
 .c4::after {
-  width: 18px;
-  height: 18px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   content: '';
-  top: 0;
-  left: 0;
+  top: -1px;
+  left: -1px;
   position: absolute;
   -webkit-transition: -webkit-transform 0.3s;
   -webkit-transition: transform 0.3s;
   transition: transform 0.3s;
   background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
 .c4[aria-checked='true'] {
-  background-color: hsl(200,96%,35%);
-  border-color: hsl(200,96%,35%);
+  background-color: hsl(145,89%,28%);
+  border-color: hsl(145,89%,28%);
 }
 
 .c4[aria-checked='true']::after {
-  -webkit-transform: translateX(25px);
-  -ms-transform: translateX(25px);
-  transform: translateX(25px);
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
 }
 
 .c4[aria-checked='true'] .c5 {
@@ -420,17 +436,18 @@ exports[`component: ToggleField snapshot when value=true 1`] = `
 }
 
 .c4[disabled] {
-  background-color: hsl(0,0%,90%);
-  border-color: hsl(0,0%,90%);
+  opacity: 0.5;
 }
 
 .c0 .c9 {
   cursor: pointer;
   margin-left: 8px;
+  line-height: 26px;
+  vertical-align: -2px;
 }
 
 .c0 .c3 {
-  vertical-align: text-bottom;
+  vertical-align: middle;
 }
 
 <div>


### PR DESCRIPTION
Adjusts toggle to fit Mariana's new designs. The only difference is that, after reviewing her designs, Aaron and Allen decided that they liked the idea of using red as the "off" color. I cleared that idea with Mariana, who actually seemed to like it quite a bit, and implemented that here. 

I also fixed a bug/oversight with the `ToggleField` where the cursor on the label wasn't being changed when the toggle is disabled.

Some bonus awesome-ness: After fiddling around with the alignment on the `ToggleField`, I managed to get the label and toggle to align how I want them to across Chrome, Firefox, Safari, AND IE. Phew!