### PR TITLE
Danger Buttons

### DIFF
--- a/modules/cactus-theme/index.ts
+++ b/modules/cactus-theme/index.ts
@@ -76,6 +76,7 @@ export interface CactusTheme {
     transparentSuccess: string
     transparentWarning: string
     transparentError: string
+    errorDark: string
 
     status: StatusColors
   }
@@ -141,6 +142,7 @@ export function generateTheme({ primaryHue }: GeneratorOptions = repayOptions): 
   let transparentSuccess = `hsla(145, 89%, 28%, 0.2)`
   let transparentError = `hsla(353, 84%, 44%, 0.2)`
   let transparentWarning = `hsla(47, 82%, 47%, 0.2)`
+  let errorDark = `hsl(353, 96%, 11%)`
 
   const status: StatusColors = {
     background: {
@@ -197,6 +199,7 @@ export function generateTheme({ primaryHue }: GeneratorOptions = repayOptions): 
       transparentSuccess,
       transparentError,
       transparentWarning,
+      errorDark,
 
       /** Status Colors */
       status,

--- a/modules/cactus-web/src/Button/Button.story.tsx
+++ b/modules/cactus-web/src/Button/Button.story.tsx
@@ -8,7 +8,7 @@ import Button, { ButtonVariants } from './Button'
 
 type IconName = keyof typeof icons
 const iconNames: IconName[] = Object.keys(icons) as IconName[]
-const buttonVariants: ButtonVariants[] = ['standard', 'action']
+const buttonVariants: ButtonVariants[] = ['standard', 'action', 'danger']
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
 const buttonStories = storiesOf('Button', module)
 

--- a/modules/cactus-web/src/Button/Button.test.tsx
+++ b/modules/cactus-web/src/Button/Button.test.tsx
@@ -38,6 +38,16 @@ describe('component: Button', () => {
     expect(button.asFragment()).toMatchSnapshot()
   })
 
+  test('should render danger variant', () => {
+    const { asFragment } = render(
+      <StyleProvider>
+        <Button variant="danger">I am dangerous</Button>
+      </StyleProvider>
+    )
+
+    expect(asFragment()).toMatchSnapshot()
+  })
+
   test('should render disabled variant', () => {
     const button = render(
       <StyleProvider>
@@ -70,6 +80,18 @@ describe('component: Button', () => {
     )
 
     expect(button.asFragment()).toMatchSnapshot()
+  })
+
+  test('should render inverse danger variant', () => {
+    const { asFragment } = render(
+      <StyleProvider>
+        <Button variant="danger" inverse>
+          I am also dangerous
+        </Button>
+      </StyleProvider>
+    )
+
+    expect(asFragment()).toMatchSnapshot()
   })
 
   test('should render inverse disabled variant', () => {

--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types'
 import Spinner from '../Spinner/Spinner'
 import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 
-export type ButtonVariants = 'standard' | 'action'
+export type ButtonVariants = 'standard' | 'action' | 'danger'
 
 interface ButtonProps
   extends Omit<
@@ -49,6 +49,17 @@ const variantMap: VariantMap = {
       border-color: ${p => p.theme.colors.base};
     }
   `,
+  danger: css`
+    color: ${p => p.theme.colors.white};
+    background-color: ${p => p.theme.colors.error};
+    border-color: ${p => p.theme.colors.error};
+
+    &:hover {
+      color: ${p => p.theme.colors.white};
+      background-color: ${p => p.theme.colors.errorDark};
+      border-color: ${p => p.theme.colors.errorDark};
+    }
+  `,
 }
 
 const inverseVariantMap: VariantMap = {
@@ -72,6 +83,16 @@ const inverseVariantMap: VariantMap = {
       color: ${p => p.theme.colors.base};
       background-color: ${p => p.theme.colors.white};
       border-color: ${p => p.theme.colors.white};
+    }
+  `,
+  danger: css`
+    color: ${p => p.theme.colors.error};
+    background-color: ${p => p.theme.colors.white};
+    border-color: ${p => p.theme.colors.error};
+
+    &:hover {
+      color: ${p => p.theme.colors.white};
+      background-color: ${p => p.theme.colors.error};
     }
   `,
 }
@@ -164,7 +185,7 @@ export const Button = styled(ButtonBase)`
 
 // @ts-ignore
 Button.propTypes = {
-  variant: PropTypes.oneOf(['standard', 'action']),
+  variant: PropTypes.oneOf(['standard', 'action', 'danger']),
   disabled: PropTypes.bool,
   inverse: PropTypes.bool,
   loading: PropTypes.bool,

--- a/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
@@ -165,6 +165,22 @@ exports[`component: Button should render Spinner when loading is true 1`] = `
   margin-top: -8px;
 }
 
+.c8 .c1 {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-left: -8px;
+  margin-top: -8px;
+}
+
+.c9 .c1 {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-left: -8px;
+  margin-top: -8px;
+}
+
 <button
     aria-live="assertive"
     class="c0"
@@ -254,6 +270,71 @@ exports[`component: Button should render call to action variant 1`] = `
   >
     <span>
       Click me!
+    </span>
+  </button>
+</DocumentFragment>
+`;
+
+exports[`component: Button should render danger variant 1`] = `
+<DocumentFragment>
+  .c0 {
+  position: relative;
+  border-radius: 20px;
+  padding: 2px 30px;
+  border: 2px solid;
+  outline: none;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: 18px;
+  line-height: 28px;
+  color: hsl(0,0%,100%);
+  background-color: hsl(353,84%,44%);
+  border-color: hsl(353,84%,44%);
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
+.c0:focus::after {
+  content: '';
+  display: block;
+  position: absolute;
+  height: calc(100% + 10px);
+  width: calc(100% + 10px);
+  top: -5px;
+  left: -5px;
+  border: 2px solid hsl(200,96%,35%);
+  border-radius: 20px;
+  box-sizing: border-box;
+}
+
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
+}
+
+.c0 .c1 {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-left: -8px;
+  margin-top: -8px;
+}
+
+.c0:hover {
+  color: hsl(0,0%,100%);
+  background-color: hsl(353,96%,11%);
+  border-color: hsl(353,96%,11%);
+}
+
+<button
+    aria-live="assertive"
+    class="c0"
+    type="button"
+  >
+    <span>
+      I am dangerous
     </span>
   </button>
 </DocumentFragment>
@@ -380,6 +461,70 @@ exports[`component: Button should render inverse call to action variant 1`] = `
   >
     <span>
       Click me!
+    </span>
+  </button>
+</DocumentFragment>
+`;
+
+exports[`component: Button should render inverse danger variant 1`] = `
+<DocumentFragment>
+  .c0 {
+  position: relative;
+  border-radius: 20px;
+  padding: 2px 30px;
+  border: 2px solid;
+  outline: none;
+  cursor: pointer;
+  box-sizing: border-box;
+  font-size: 18px;
+  line-height: 28px;
+  color: hsl(353,84%,44%);
+  background-color: hsl(0,0%,100%);
+  border-color: hsl(353,84%,44%);
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
+.c0:focus::after {
+  content: '';
+  display: block;
+  position: absolute;
+  height: calc(100% + 10px);
+  width: calc(100% + 10px);
+  top: -5px;
+  left: -5px;
+  border: 2px solid hsl(200,96%,35%);
+  border-radius: 20px;
+  box-sizing: border-box;
+}
+
+.c0 svg {
+  display: inline-block;
+  margin-top: -4px;
+}
+
+.c0 .c1 {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  margin-left: -8px;
+  margin-top: -8px;
+}
+
+.c0:hover {
+  color: hsl(0,0%,100%);
+  background-color: hsl(353,84%,44%);
+}
+
+<button
+    aria-live="assertive"
+    class="c0"
+    type="button"
+  >
+    <span>
+      I am also dangerous
     </span>
   </button>
 </DocumentFragment>

--- a/modules/cactus-web/src/IconButton/IconButton.story.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.story.tsx
@@ -34,13 +34,15 @@ storiesOf('IconButton', module)
     const variantSelection = select('variant', iconButtonVariants, 'standard')
     return (
       <Grid justify="center">
-        {Object.values(icons).map(Icon => (
-          <Grid.Item tiny={3} medium={2} large={1}>
-            <IconButton variant={variantSelection}>
-              <Icon />
-            </IconButton>
-          </Grid.Item>
-        ))}
+        {Object.values(icons)
+          .slice(0, Object.keys(icons).length - 2)
+          .map((Icon, ix) => (
+            <Grid.Item tiny={3} medium={2} large={1} key={ix}>
+              <IconButton label={`icb-${ix}`} variant={variantSelection}>
+                <Icon />
+              </IconButton>
+            </Grid.Item>
+          ))}
       </Grid>
     )
   })

--- a/modules/cactus-web/src/IconButton/IconButton.story.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.story.tsx
@@ -7,7 +7,7 @@ import { storiesOf } from '@storybook/react'
 import Grid from '../Grid/Grid'
 import IconButton, { IconButtonSizes, IconButtonVariants } from './IconButton'
 
-const iconButtonVariants: IconButtonVariants[] = ['standard', 'action']
+const iconButtonVariants: IconButtonVariants[] = ['standard', 'action', 'danger']
 const iconButtonSizes: IconButtonSizes[] = ['tiny', 'small', 'medium', 'large']
 type IconName = keyof typeof icons
 const iconNames: IconName[] = Object.keys(icons) as IconName[]

--- a/modules/cactus-web/src/IconButton/IconButton.test.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.test.tsx
@@ -81,6 +81,18 @@ describe('component: IconButton', () => {
     expect(iconButton.asFragment()).toMatchSnapshot()
   })
 
+  test('should render danger icon button', () => {
+    const iconButton = render(
+      <StyleProvider>
+        <IconButton label="boolest" variant="danger">
+          <StatusCheck />
+        </IconButton>
+      </StyleProvider>
+    )
+
+    expect(iconButton.asFragment()).toMatchSnapshot()
+  })
+
   test('should render inverse standard icon button', () => {
     const iconButton = render(
       <StyleProvider>
@@ -97,6 +109,18 @@ describe('component: IconButton', () => {
     const iconButton = render(
       <StyleProvider>
         <IconButton label="boolest" variant="action" inverse>
+          <StatusCheck />
+        </IconButton>
+      </StyleProvider>
+    )
+
+    expect(iconButton.asFragment()).toMatchSnapshot()
+  })
+
+  test('should render inverse danger icon button', () => {
+    const iconButton = render(
+      <StyleProvider>
+        <IconButton label="boolest" variant="danger" inverse>
           <StatusCheck />
         </IconButton>
       </StyleProvider>

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -7,7 +7,7 @@ import { omitMargins } from '../helpers/omit'
 import PropTypes from 'prop-types'
 import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 
-export type IconButtonVariants = 'standard' | 'action'
+export type IconButtonVariants = 'standard' | 'action' | 'danger'
 export type IconButtonSizes = 'tiny' | 'small' | 'medium' | 'large'
 
 interface IconButtonProps
@@ -39,6 +39,13 @@ const variantMap: VariantMap = {
       color: ${p => p.theme.colors.callToAction};
     }
   `,
+  danger: css`
+    color: ${p => p.theme.colors.error};
+
+    &:hover {
+      color: ${p => p.theme.colors.errorDark};
+    }
+  `,
 }
 
 const inverseVariantMap: VariantMap = {
@@ -57,6 +64,14 @@ const inverseVariantMap: VariantMap = {
     &:focus {
       color: ${p => p.theme.colors.base};
       background: ${p => p.theme.colors.white};
+    }
+  `,
+  danger: css`
+    color: ${p => p.theme.colors.error};
+
+    &:hover,
+    &:focus {
+      color: ${p => p.theme.colors.white};
     }
   `,
 }
@@ -114,7 +129,7 @@ export const IconButton = styled(IconButtonBase)<IconButtonProps>`
 // @ts-ignore
 IconButton.propTypes = {
   iconSize: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
-  variant: PropTypes.oneOf(['standard', 'action']),
+  variant: PropTypes.oneOf(['standard', 'action', 'danger']),
   disabled: PropTypes.bool,
   label: PropTypes.string.isRequired,
   display: PropTypes.oneOf(['flex', 'inline-flex']),

--- a/modules/cactus-web/src/IconButton/__snapshots__/IconButton.test.tsx.snap
+++ b/modules/cactus-web/src/IconButton/__snapshots__/IconButton.test.tsx.snap
@@ -123,6 +123,67 @@ exports[`component: IconButton should render call to action icon button 1`] = `
 </DocumentFragment>
 `;
 
+exports[`component: IconButton should render danger icon button 1`] = `
+<DocumentFragment>
+  .c1 {
+  vertical-align: middle;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 1px;
+  border: none;
+  background: transparent;
+  outline: none;
+  cursor: pointer;
+  color: hsl(353,84%,44%);
+  font-size: 24px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
+.c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover {
+  color: hsl(353,96%,11%);
+}
+
+<button
+    aria-label="boolest"
+    class="c0"
+    type="button"
+    variant="danger"
+  >
+    <svg
+      class="c1"
+      fill="currentcolor"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <path
+        d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
+      />
+    </svg>
+  </button>
+</DocumentFragment>
+`;
+
 exports[`component: IconButton should render disabled variant 1`] = `
 <DocumentFragment>
   .c1 {
@@ -289,6 +350,68 @@ exports[`component: IconButton should render inverse call to action icon button 
     class="c0"
     type="button"
     variant="action"
+  >
+    <svg
+      class="c1"
+      fill="currentcolor"
+      height="1em"
+      viewBox="0 0 24 24"
+      width="1em"
+    >
+      <path
+        d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
+      />
+    </svg>
+  </button>
+</DocumentFragment>
+`;
+
+exports[`component: IconButton should render inverse danger icon button 1`] = `
+<DocumentFragment>
+  .c1 {
+  vertical-align: middle;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 1px;
+  border: none;
+  background: transparent;
+  outline: none;
+  cursor: pointer;
+  color: hsl(353,84%,44%);
+  font-size: 24px;
+}
+
+.c0::-moz-focus-inner {
+  border: 0;
+}
+
+.c0:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c0:hover,
+.c0:focus {
+  color: hsl(0,0%,100%);
+}
+
+<button
+    aria-label="boolest"
+    class="c0"
+    type="button"
+    variant="danger"
   >
     <svg
       class="c1"


### PR DESCRIPTION
This adds the styles for the danger variants for `Button` and `IconButton`. We already have a danger variant for `TextButton` implemented.

I didn't get any designs for the inverse versions of these variants,  but I just tried to follow the same patterns we've done for the other ones. If we end up using them later on down the line, I'm sure Mariana will stub out some designs for them.

I also fixed a bug in the `IconButton` story that was caused by trying to render all values inside `icons`. Apparently, the last value is a parse function and not an icon, so I sliced it out before rendering.