### PR TITLE
feat(cactus-web): Add more mobile optimized select dropdown

### DIFF
--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -833,7 +833,7 @@ describe('component: Select', () => {
       expect(document.activeElement).toBe(getByRole('listbox'))
     })
 
-    test('CLICK w/ metaKey key will toggle option but not close', async () => {
+    test('CLICK will toggle option but not close', async () => {
       const startingValue = ['tucson']
       const onChange = jest.fn()
       const { getByText, getByRole, rerender } = render(
@@ -865,7 +865,7 @@ describe('component: Select', () => {
       )
       await animationRender()
       expect(getActiveValue()).toBe('tucson')
-      fireEvent.click(getByText('phoenix'), { metaKey: true })
+      fireEvent.click(getByText('phoenix'))
       await animationRender()
       expect(onChange).toHaveBeenCalledWith('city', ['tucson', 'phoenix'])
       expect(document.activeElement).toBe(getByRole('listbox'))

--- a/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
+++ b/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import * as styledComponents from 'styled-components'
+import { breakpoints } from '../helpers/constants'
 import { Omit } from '../types'
 import cactusTheme, { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
@@ -25,13 +26,11 @@ const DebugStyle = createGlobalStyle`
   }
 `
 
-const breakpoints = ['768px', '1024px', '1200px', '1440px']
-
 const queries = {
-  small: `@media screen and (min-width: ${breakpoints[0]})`,
-  medium: `@media screen and (min-width: ${breakpoints[1]})`,
-  large: `@media screen and (min-width: ${breakpoints[2]})`,
-  extraLarge: `@media screen and (min-width: ${breakpoints[3]})`,
+  small: `@media screen and (min-width: ${breakpoints.small}px)`,
+  medium: `@media screen and (min-width: ${breakpoints.medium}px)`,
+  large: `@media screen and (min-width: ${breakpoints.large}px)`,
+  extraLarge: `@media screen and (min-width: ${breakpoints.extraLarge}px)`,
 }
 
 const GlobalStyle = createGlobalStyle`
@@ -89,7 +88,7 @@ export const StyleProvider: React.FC<StyleProviderProps> = props => {
   const { global, children, theme: providedTheme, ...themeProviderProps } = props
   shouldCheckTheme && checkThemeProperties(providedTheme || cactusTheme)
   const theme = providedTheme ? providedTheme : cactusTheme
-  theme.breakpoints = breakpoints.slice()
+  theme.breakpoints = Object.values(breakpoints).map(bp => bp.toString())
   theme.mediaQueries = queries
 
   return (

--- a/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
+++ b/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import * as styledComponents from 'styled-components'
-import { breakpoints } from '../helpers/constants'
+import { breakpointOrder, breakpoints } from '../helpers/constants'
 import { Omit } from '../types'
 import cactusTheme, { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
@@ -88,7 +88,7 @@ export const StyleProvider: React.FC<StyleProviderProps> = props => {
   const { global, children, theme: providedTheme, ...themeProviderProps } = props
   shouldCheckTheme && checkThemeProperties(providedTheme || cactusTheme)
   const theme = providedTheme ? providedTheme : cactusTheme
-  theme.breakpoints = Object.values(breakpoints).map(bp => bp.toString())
+  theme.breakpoints = breakpointOrder.map(bp => breakpoints[bp].toString())
   theme.mediaQueries = queries
 
   return (

--- a/modules/cactus-web/src/helpers/constants.ts
+++ b/modules/cactus-web/src/helpers/constants.ts
@@ -4,3 +4,10 @@ export const breakpoints = {
   large: 1200,
   extraLarge: 1440,
 }
+
+export const breakpointOrder: Array<keyof typeof breakpoints> = [
+  'small',
+  'medium',
+  'large',
+  'extraLarge',
+]

--- a/modules/cactus-web/src/helpers/constants.ts
+++ b/modules/cactus-web/src/helpers/constants.ts
@@ -1,0 +1,6 @@
+export const breakpoints = {
+  small: 768,
+  medium: 1024,
+  large: 1200,
+  extraLarge: 1440,
+}


### PR DESCRIPTION
Keeps multiselect open when you click options, adds mobile version of the select's dropdown. Honestly, I'm not very happy with the way I ended up having to do the fade in/out on the dropdown, but I've been trying anything I can think of for days now and there just doesn't seem to be a good way to make the gradients appear only when you have somewhere to scroll, so I had to just add some extra vertical padding. I also don't think we can test this outside integration tests since we don't have a viewport for the unit tests. Anyway, I'm open to any feedback on this so let me know what you think.