### PR TITLE
fix(cactus-web): Fix how we decide to make an option the create option

### DIFF
--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -763,6 +763,7 @@ class List extends React.Component<ListProps, ListState> {
                     let isSelected = opt.isSelected
                     let ariaSelected: boolean | 'true' | 'false' | undefined =
                       isSelected || undefined
+                    let isCreateNewOption = comboBox && optId === `create-${this.state.searchValue}`
                     // multiselectable should have aria-select©ed on all options
                     if (multiple) {
                       ariaSelected = isSelected ? 'true' : 'false'
@@ -774,13 +775,13 @@ class List extends React.Component<ListProps, ListState> {
                         className={activeDescendant === optId ? 'highlighted-option' : undefined}
                         data-value={opt.value}
                         role="option"
-                        data-role={optId.includes('create') ? 'create' : 'option'}
+                        data-role={isCreateNewOption ? 'create' : 'option'}
                         aria-selected={ariaSelected}
                         onMouseEnter={this.handleOptionMouseEnter}
                       >
-                        {optId.includes('create') ? (
+                        {isCreateNewOption ? (
                           <ActionsAdd mr={2} mb={2} />
-                        ) : multiple && !optId.includes('create') ? (
+                        ) : multiple ? (
                           <CheckBox
                             id={`multiselect-option-check-${optId}`}
                             aria-hidden="true"


### PR DESCRIPTION
When I built the combobox, I looked at the ids on the options to determine if the id contained "create", in which case I gave it the "create" `data-role`. However, option ids are generated in part using the option's label, so this breaks if the option contains the string "create".  /facepalm

This fixes that issue, though, and I already tested it locally on channels