### PR TITLE
Handle No Options in Select

### DIFF
--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -47,17 +47,15 @@ describe('component: Select', () => {
     expect(getByText('Who?')).not.toBeNull()
   })
 
-  test('can receive an empty list of options', async () => {
-    const { getByText, getByRole } = render(
+  test('should set placeholder when options are empty', async () => {
+    const { getByRole } = render(
       <StyleProvider>
         <Select id="empty-options" name="test-empty-options" options={[]} />
       </StyleProvider>
     )
 
-    const trigger = getByText('Select an option')
-    fireEvent.click(trigger)
-    await animationRender()
-    expect(getByRole('listbox').getAttribute('aria-activedescendant')).toBeNull()
+    const trigger = getByRole('button')
+    expect(trigger).toHaveTextContent('Disabled. No options available.')
   })
 
   test('can receive options with number values', async () => {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -255,7 +255,7 @@ const SelectTrigger = styled.button`
     cursor: not-allowed;
 
     ${Placeholder} {
-      display: none;
+      color: ${p => p.theme.colors.mediumGray};
     }
   }
 
@@ -1365,6 +1365,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     } = omitMargins(this.props) as Omit<SelectProps, keyof MarginProps>
     let { isOpen, searchValue, activeDescendant } = this.state
     let options = this.getExtOptions()
+    let noOptsDisable = !comboBox && options.length === 0
 
     return (
       <div className={className}>
@@ -1404,7 +1405,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
                   onClick={this.handleClick}
                   onBlur={this.handleBlur}
                   onFocus={this.handleFocus}
-                  disabled={disabled}
+                  disabled={noOptsDisable ? true : disabled}
                   type="button"
                   aria-haspopup="listbox"
                   aria-expanded={isOpen || undefined}
@@ -1413,7 +1414,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
                   <ValueSwitch
                     extraLabel={extraLabel || '+{} more'}
                     options={options}
-                    placeholder={placeholder}
+                    placeholder={noOptsDisable ? 'Disabled. No options available.' : placeholder}
                     multiple={multiple}
                   />
                   <NavigationChevronDown iconSize="tiny" />

--- a/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`component: Select snapshot 1`] = `
 }
 
 .c1:disabled .c2 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c1::-moz-focus-inner {

--- a/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
+++ b/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`component: SelectField minimal snapshot 1`] = `
 }
 
 .c7:disabled .c8 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c7::-moz-focus-inner {
@@ -206,7 +206,7 @@ exports[`component: SelectField render with complex options 1`] = `
 }
 
 .c7:disabled .c8 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c7::-moz-focus-inner {
@@ -362,7 +362,7 @@ exports[`component: SelectField should render a disabled SelectField 1`] = `
 }
 
 .c7:disabled .c8 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c7::-moz-focus-inner {
@@ -557,7 +557,7 @@ exports[`component: SelectField should render an accessible error message 1`] = 
 }
 
 .c8:disabled .c9 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c8::-moz-focus-inner {
@@ -775,7 +775,7 @@ exports[`component: SelectField should render an accessible success message 1`] 
 }
 
 .c8:disabled .c9 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c8::-moz-focus-inner {
@@ -990,7 +990,7 @@ exports[`component: SelectField should render an accessible warning message 1`] 
 }
 
 .c8:disabled .c9 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c8::-moz-focus-inner {
@@ -1179,7 +1179,7 @@ exports[`component: SelectField supports margin props 1`] = `
 }
 
 .c8:disabled .c9 {
-  display: none;
+  color: hsl(0,0%,70%);
 }
 
 .c8::-moz-focus-inner {


### PR DESCRIPTION
A few weeks ago we talked about disabling the select and providing a descriptive placeholder to explain why it's disabled so I decided to get that knocked out real quick. Pretty simple