### PR TITLE
feat(cactus-web): Allow user to initially render accordions open

### DIFF
--- a/examples/mock-ebpp/package.json
+++ b/examples/mock-ebpp/package.json
@@ -58,7 +58,7 @@
     "@reach/router": "^1.2.1",
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.4.5",
-    "@repay/cactus-web": "^0.5.2",
+    "@repay/cactus-web": "^0.6.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   }

--- a/examples/standard/package.json
+++ b/examples/standard/package.json
@@ -18,7 +18,7 @@
     "@repay/cactus-i18n": "^0.2.0",
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.4.5",
-    "@repay/cactus-web": "^0.5.2",
+    "@repay/cactus-web": "^0.6.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   },

--- a/examples/theme-components/package.json
+++ b/examples/theme-components/package.json
@@ -25,7 +25,7 @@
     "@reach/router": "^1.2.1",
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.4.5",
-    "@repay/cactus-web": "^0.5.2",
+    "@repay/cactus-web": "^0.6.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "styled-components": "^4.1.2"

--- a/modules/cactus-web/src/Accordion/Accordion.story.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.story.tsx
@@ -175,7 +175,7 @@ storiesOf('Accordion', module)
   .add('With Open Initialization', () => (
     <div style={{ width: '312px' }}>
       <Accordion.Provider maxOpen={number('maxOpen', 2)}>
-        <Accordion open>
+        <Accordion defaultOpen>
           <Accordion.Header>{text('header 1', 'Accordion 1')}</Accordion.Header>
           <Accordion.Body>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
@@ -184,7 +184,7 @@ storiesOf('Accordion', module)
             euismod augue aliquam vel.
           </Accordion.Body>
         </Accordion>
-        <Accordion open>
+        <Accordion defaultOpen>
           <Accordion.Header>{text('header 2', 'Accordion 2')}</Accordion.Header>
           <Accordion.Body>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu

--- a/modules/cactus-web/src/Accordion/Accordion.story.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.story.tsx
@@ -172,3 +172,27 @@ storiesOf('Accordion', module)
       }}
     </ContentManager>
   ))
+  .add('With Open Initialization', () => (
+    <div style={{ width: '312px' }}>
+      <Accordion.Provider maxOpen={number('maxOpen', 2)}>
+        <Accordion open>
+          <Accordion.Header>{text('header 1', 'Accordion 1')}</Accordion.Header>
+          <Accordion.Body>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+            tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+            lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+            euismod augue aliquam vel.
+          </Accordion.Body>
+        </Accordion>
+        <Accordion open>
+          <Accordion.Header>{text('header 2', 'Accordion 2')}</Accordion.Header>
+          <Accordion.Body>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+            tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+            lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+            euismod augue aliquam vel.
+          </Accordion.Body>
+        </Accordion>
+      </Accordion.Provider>
+    </div>
+  ))

--- a/modules/cactus-web/src/Accordion/Accordion.test.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.test.tsx
@@ -54,7 +54,7 @@ describe('component: Accordion', () => {
     test('should allow the user to initialize accordions as open', () => {
       const { container } = render(
         <StyleProvider>
-          <Accordion open>
+          <Accordion defaultOpen>
             <Accordion.Header>Test Header</Accordion.Header>
             <Accordion.Body>Test Body</Accordion.Body>
           </Accordion>
@@ -156,11 +156,11 @@ describe('component: Accordion', () => {
       const { container } = render(
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
-            <Accordion open>
+            <Accordion defaultOpen>
               <Accordion.Header>Accordion 1</Accordion.Header>
               <Accordion.Body>Should show A1</Accordion.Body>
             </Accordion>
-            <Accordion open>
+            <Accordion defaultOpen>
               <Accordion.Header>Accordion 2</Accordion.Header>
               <Accordion.Body>Should show A2</Accordion.Body>
             </Accordion>

--- a/modules/cactus-web/src/Accordion/Accordion.test.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.test.tsx
@@ -50,6 +50,19 @@ describe('component: Accordion', () => {
       })
       expect(container).toHaveTextContent('Test Body')
     })
+
+    test('should allow the user to initialize accordions as open', () => {
+      const { container } = render(
+        <StyleProvider>
+          <Accordion open>
+            <Accordion.Header>Test Header</Accordion.Header>
+            <Accordion.Body>Test Body</Accordion.Body>
+          </Accordion>
+        </StyleProvider>
+      )
+
+      expect(container).toHaveTextContent('Test Body')
+    })
   })
 
   describe('Provider', () => {
@@ -135,6 +148,26 @@ describe('component: Accordion', () => {
       act(() => {
         fireEvent.click(a2Button)
       })
+      expect(container).toHaveTextContent('Should show A1')
+      expect(container).toHaveTextContent('Should show A2')
+    })
+
+    test('should allow the user to initialize accordions as open', () => {
+      const { container } = render(
+        <StyleProvider>
+          <Accordion.Provider maxOpen={2}>
+            <Accordion open>
+              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Body>Should show A1</Accordion.Body>
+            </Accordion>
+            <Accordion open>
+              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Body>Should show A2</Accordion.Body>
+            </Accordion>
+          </Accordion.Provider>
+        </StyleProvider>
+      )
+
       expect(container).toHaveTextContent('Should show A1')
       expect(container).toHaveTextContent('Should show A2')
     })

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -385,15 +385,12 @@ const AccordionBase = (props: AccordionProps) => {
     if (managedAccordions) {
       managedAccordions[id] = { open: isOpen, order: order++ }
     }
-  }, [id, managedAccordions]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
     return () => {
       if (managedAccordions) {
         delete managedAccordions[id]
       }
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [id, managedAccordions]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleOpen = () => {
     if (isManaged) {

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -14,7 +14,7 @@ interface AccordionProps
     MaxWidthProps,
     WidthProps,
     React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
-  open?: boolean
+  defaultOpen?: boolean
 }
 
 interface AccordionHeaderProps
@@ -369,10 +369,11 @@ const AccordionBase = (props: AccordionProps) => {
     isManaged,
     managedAccordions,
   } = useContext(ProviderContext)
+  const { defaultOpen, ...restProps } = props
   const id = useId(props.id)
   const headerId = `${id}-header`
   const bodyId = `${id}-body`
-  let isOpen = props.open || false
+  let isOpen = defaultOpen || false
 
   if (isManaged && managedAccordions !== undefined && managedAccordions[id] !== undefined) {
     isOpen = managedAccordions[id].open
@@ -421,7 +422,7 @@ const AccordionBase = (props: AccordionProps) => {
     }
   }
 
-  const rest = omitMargins(props, 'width', 'maxWidth')
+  const rest = omitMargins(restProps, 'width', 'maxWidth')
 
   return (
     <div id={id} {...rest}>
@@ -451,11 +452,11 @@ export const Accordion = styled(AccordionBase)`
 ` as any
 
 Accordion.defaultProps = {
-  open: false,
+  defaultOpen: false,
 }
 
 Accordion.propTypes = {
-  open: PropTypes.bool,
+  defaultOpen: PropTypes.bool,
 }
 
 Accordion.Header = AccordionHeader

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -13,7 +13,9 @@ interface AccordionProps
   extends MarginProps,
     MaxWidthProps,
     WidthProps,
-    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {}
+    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  open?: boolean
+}
 
 interface AccordionHeaderProps
   extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {}
@@ -37,15 +39,12 @@ interface AccordionProviderProps {
 }
 
 interface AccordionProviderContext {
-  accordions: {
-    [key: string]: { open: boolean }
-  }
   manageOpen: ((name: string, open: boolean) => void) | undefined
   manageFocus: ((id: string, offset: number) => void) | undefined
   focusFirst: (() => void) | undefined
   focusLast: (() => void) | undefined
   isManaged: boolean
-  managedAccordions: Array<string> | undefined
+  managedAccordions: { [key: string]: { open: boolean; order: number } } | undefined
 }
 
 const AccordionContext = createContext<AccordionContext>({
@@ -246,7 +245,6 @@ export const AccordionBody = styled(AccordionBodyBase)`
 `
 
 const ProviderContext = createContext<AccordionProviderContext>({
-  accordions: {},
   manageOpen: undefined,
   manageFocus: undefined,
   focusFirst: undefined,
@@ -255,42 +253,38 @@ const ProviderContext = createContext<AccordionProviderContext>({
   managedAccordions: undefined,
 })
 
-interface AccordionProviderState {
-  [key: string]: { open: boolean; order: number }
-}
-
 let order = 0
 
 export const AccordionProvider = (props: AccordionProviderProps) => {
   const { maxOpen = 1 } = props
-  const [state, setState] = useState<AccordionProviderState>({})
+  const [update, makeUpdate] = useState<boolean>(false)
 
-  const managedAccordions = useRef<Array<string>>([])
+  const managedAccordions = useRef<{ [key: string]: { open: boolean; order: number } }>({})
 
   const manageOpen = (id: string, open: boolean) => {
-    const newState = { ...state }
-    newState[id] = { open: open, order: order++ }
+    managedAccordions.current[id] = { open: open, order: order++ }
+    const accordions = managedAccordions.current
     if (open) {
-      const allOpen = Object.keys(newState).filter(
-        accordionId => newState[accordionId].open === true
+      const allOpen = Object.keys(accordions).filter(
+        accordionId => accordions[accordionId].open === true
       )
       if (allOpen.length > maxOpen) {
         allOpen.sort((a, b) => {
-          if (newState[a].order < newState[b].order) {
+          if (accordions[a].order < accordions[b].order) {
             return -1
-          } else if (newState[a].order > newState[b].order) {
+          } else if (accordions[a].order > accordions[b].order) {
             return 1
           }
           return 0
         })
-        newState[allOpen[0]].open = false
+        managedAccordions.current[allOpen[0]].open = false
       }
     }
-    setState(newState)
+    makeUpdate(!update)
   }
 
   const manageFocus = (id: string, offset: number) => {
-    if (managedAccordions.current.length > 1) {
+    if (Object.keys(managedAccordions.current).length > 1) {
       const orderedIds = getOrderedIds()
       const currentIndex = orderedIds.indexOf(id)
       let nextIndex = currentIndex + offset
@@ -304,14 +298,14 @@ export const AccordionProvider = (props: AccordionProviderProps) => {
   }
 
   const focusFirst = () => {
-    if (managedAccordions.current.length > 1) {
+    if (Object.keys(managedAccordions.current).length > 1) {
       const orderedIds = getOrderedIds()
       focusById(orderedIds[0])
     }
   }
 
   const focusLast = () => {
-    if (managedAccordions.current.length > 1) {
+    if (Object.keys(managedAccordions.current).length > 1) {
       const orderedIds = getOrderedIds()
       focusById(orderedIds[orderedIds.length - 1])
     }
@@ -328,21 +322,13 @@ export const AccordionProvider = (props: AccordionProviderProps) => {
   }
 
   const getOrderedIds = () =>
-    Array.from(document.querySelectorAll(`#${managedAccordions.current.join(',#')}`)).map(
-      el => el.id
-    )
-
-  const value: { [key: string]: { open: boolean } } = {}
-  Object.keys(state).forEach(accordionId => {
-    value[accordionId] = {
-      open: state[accordionId].open,
-    }
-  })
+    Array.from(
+      document.querySelectorAll(`#${Object.keys(managedAccordions.current).join(',#')}`)
+    ).map(el => el.id)
 
   return (
     <ProviderContext.Provider
       value={{
-        accordions: value,
         manageOpen,
         manageFocus,
         focusFirst,
@@ -376,7 +362,6 @@ interface AccordionState {
 
 const AccordionBase = (props: AccordionProps) => {
   const {
-    accordions,
     manageOpen,
     manageFocus,
     focusFirst,
@@ -387,24 +372,23 @@ const AccordionBase = (props: AccordionProps) => {
   const id = useId(props.id)
   const headerId = `${id}-header`
   const bodyId = `${id}-body`
-  let isOpen = false
+  let isOpen = props.open || false
 
-  if (isManaged) {
-    isOpen = accordions[id] === undefined ? false : accordions[id].open
+  if (isManaged && managedAccordions !== undefined && managedAccordions[id] !== undefined) {
+    isOpen = managedAccordions[id].open
   }
   const [state, setState] = useState<AccordionState>({ isOpen: isOpen })
 
   useEffect(() => {
     if (managedAccordions) {
-      managedAccordions.push(id)
+      managedAccordions[id] = { open: isOpen, order: order++ }
     }
-  }, [id, managedAccordions])
+  }, [id, managedAccordions]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     return () => {
       if (managedAccordions) {
-        const accordionIndex = managedAccordions.indexOf(id)
-        managedAccordions.splice(accordionIndex, 1)
+        delete managedAccordions[id]
       }
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
@@ -465,6 +449,14 @@ export const Accordion = styled(AccordionBase)`
   ${width}
   ${maxWidth}
 ` as any
+
+Accordion.defaultProps = {
+  open: false,
+}
+
+Accordion.propTypes = {
+  open: PropTypes.bool,
+}
 
 Accordion.Header = AccordionHeader
 Accordion.Body = AccordionBody

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -119,6 +119,7 @@ const AccordionHeaderBase = (props: AccordionHeaderProps) => {
       id={headerId}
       className={className}
       data-role="accordion-button"
+      type="button"
       role="button"
       onClick={handleToggle}
       onKeyDown={handleHeaderKeyDown}

--- a/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -60,6 +60,7 @@ exports[`component: Accordion Component Should render Accordion 1`] = `
       data-role="accordion-button"
       id="accordion-header"
       role="button"
+      type="button"
     >
       <span>
         Test Header

--- a/website/package.json
+++ b/website/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.4.5",
-    "@repay/cactus-web": "^0.5.2",
+    "@repay/cactus-web": "^0.6.0",
     "normalize.css": "^8.0.1",
     "prismjs": "^1.16.0",
     "react": "^16.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,6 +1767,22 @@
     "@babel/preset-typescript" "^7.3.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
+"@repay/cactus-web@^0.5.2":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@repay/cactus-web/-/cactus-web-0.5.8.tgz#7ef32461b0987d8efe2384dfdbc8288dc2895340"
+  integrity sha512-TXLaORfW6wlwU3FAcM1OFrjy6fC+mIHyRO1TlTg8H+JuKmdY02lde/6Xm29NPv9G7/QCxpuwDYe/dabH12uUjg==
+  dependencies:
+    "@reach/menu-button" "^0.5.0"
+    "@reach/portal" "^0.5.0"
+    "@reach/rect" "^0.5.0"
+    "@reach/tooltip" "^0.5.0"
+    "@reach/utils" "^0.5.0"
+    "@reach/visually-hidden" "^0.5.0"
+    "@repay/cactus-icons" "^0.6.1"
+    "@repay/cactus-theme" "^0.4.5"
+    lodash "^4.17.15"
+    styled-system "^5.1.1"
+
 "@repay/eslint-config@^1.1.1":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@repay/eslint-config/-/eslint-config-1.3.0.tgz#00bd69feda08b56c6d19218d9991189c08f43025"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,22 +1767,6 @@
     "@babel/preset-typescript" "^7.3.3"
     babel-plugin-dynamic-import-node "^2.3.0"
 
-"@repay/cactus-web@^0.5.2":
-  version "0.5.8"
-  resolved "https://registry.yarnpkg.com/@repay/cactus-web/-/cactus-web-0.5.8.tgz#7ef32461b0987d8efe2384dfdbc8288dc2895340"
-  integrity sha512-TXLaORfW6wlwU3FAcM1OFrjy6fC+mIHyRO1TlTg8H+JuKmdY02lde/6Xm29NPv9G7/QCxpuwDYe/dabH12uUjg==
-  dependencies:
-    "@reach/menu-button" "^0.5.0"
-    "@reach/portal" "^0.5.0"
-    "@reach/rect" "^0.5.0"
-    "@reach/tooltip" "^0.5.0"
-    "@reach/utils" "^0.5.0"
-    "@reach/visually-hidden" "^0.5.0"
-    "@repay/cactus-icons" "^0.6.1"
-    "@repay/cactus-theme" "^0.4.5"
-    lodash "^4.17.15"
-    styled-system "^5.1.1"
-
 "@repay/eslint-config@^1.1.1":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@repay/eslint-config/-/eslint-config-1.3.0.tgz#00bd69feda08b56c6d19218d9991189c08f43025"


### PR DESCRIPTION
Allows devs to initially render an open accordion using the `open` prop.

To do this, I had to refactor the structure of the `managedAccordions` ref that I added in my last PR, and use that for both focus management (same as before) and for managing whether or not accordions are open (new behavior). Previously, I was using the `useState` hook in the provider to manage whether or not the accordions were open, but now I need that information to be available from the first render. 

Let me know if you have any questions/comments!