### PR TITLE
fix(cactus-web): Date objects to have correct year when less than 100

### DIFF
--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -587,13 +587,15 @@ export class PartialDate implements FormatTokenMap {
   }
 
   toDate(): Date {
-    return new Date(
+    let date = new Date(
       this.getYear(),
       this.getMonth(),
       this.getDate(),
       this.getHours(),
       this.getMinutes()
     )
+    date.setUTCFullYear(this.getYear())
+    return date
   }
 
   isValid(): boolean {

--- a/modules/cactus-web/tests/dates.test.ts
+++ b/modules/cactus-web/tests/dates.test.ts
@@ -106,6 +106,21 @@ describe('date helpers', () => {
         const pd = new PartialDate('02/29/2020', 'MM/dd/YYYY')
         expect(pd.toDate()).toEqual(new Date(2020, 1, 29))
       })
+
+      test('correctly sets the year when year is less than 100', () => {
+        const pd = new PartialDate('01/02/0004', 'MM/dd/YYYY')
+        let expected = new Date('0004-01-02')
+        expected.setUTCMinutes(new Date().getTimezoneOffset())
+        expect(pd.toDate()).toEqual(expected)
+      })
+
+      test('correctly updates the year when year becomes less than 100', () => {
+        const pd = new PartialDate('01/02/2020', 'MM/dd/YYYY')
+        pd.setYear(38)
+        let expected = new Date('0038-01-02')
+        expected.setUTCMinutes(new Date().getTimezoneOffset())
+        expect(pd.toDate()).toEqual(expected)
+      })
     })
 
     describe('#parse()', () => {


### PR DESCRIPTION
JS Date objects assume the year is 1900s if provided value is less than 100,
therefore we need to use setFullUTCYear to not only set the full year but
also prevent the date object from changing through timezones.