### PR TITLE
fix(cactus-web): Provide more space for elements in accordion header

### DIFF
--- a/examples/mock-ebpp/src/containers/faq.tsx
+++ b/examples/mock-ebpp/src/containers/faq.tsx
@@ -120,7 +120,9 @@ const Faq = (props: FaqProps) => {
             <Accordion.Provider maxOpen={2}>
               {accordions.map((accordion, index) => (
                 <Accordion key={index}>
-                  <Accordion.Header>{accordion.header}</Accordion.Header>
+                  <Accordion.Header>
+                    <Text as="h3">{accordion.header}</Text>
+                  </Accordion.Header>
                   <Accordion.Body>{accordion.body}</Accordion.Body>
                 </Accordion>
               ))}

--- a/examples/mock-ebpp/tests/helpers/actions.ts
+++ b/examples/mock-ebpp/tests/helpers/actions.ts
@@ -99,11 +99,11 @@ class Actions {
   }
 
   focusAccordionHeaderByText = async (headerText: string) => {
-    const accordionSpan = await getByText(this.doc, headerText)
-    const accordionHeader = (await accordionSpan.evaluateHandle(
-      as => as.parentElement
+    const accordionHeader = await getByText(this.doc, headerText)
+    const accordionHeaderButton = (await accordionHeader.evaluateHandle(as =>
+      as.parentElement.querySelector('button')
     )) as ElementHandle<Element>
-    await accordionHeader.focus()
+    await accordionHeaderButton.focus()
   }
 
   pressKey = async (key: string) => {

--- a/modules/cactus-web/src/Accordion/Accordion.mdx
+++ b/modules/cactus-web/src/Accordion/Accordion.mdx
@@ -20,13 +20,13 @@ You can use a single Accordion by itself:
 
 ```jsx
 import React from 'react'
-import { Accordion } from '@repay/cactus-web'
+import { Accordion, Text } from '@repay/cactus-web'
 
 const SingleAccordion = props => {
   return (
     <Accordion>
       <Accordion.Header>
-        My Header
+        <Text as="h3">My Header</Text>
       </Accordion.Header>
       <Accordion.Body>
         Accordion Content Goes Here
@@ -42,14 +42,14 @@ When using `Accordion.Provider`, you can set the maximum number of Accordions th
 
 ```jsx
 import React from 'react'
-import { Accordion } from '@repay/cactus-web'
+import { Accordion, Text } from '@repay/cactus-web'
 
 const MultipleAccordions = props => {
   return (
     <Accordion.Provider maxOpen={2}>
       <Accordion>
         <Accordion.Header>
-          My Header 1
+          <Text as="h3">My Header 1</Text>
         </Accordion.Header>
         <Accordion.Body>
           Accordion Content Goes Here
@@ -57,7 +57,7 @@ const MultipleAccordions = props => {
       </Accordion>
       <Accordion>
         <Accordion.Header>
-          My Header 2
+          <Text as="h3">My Header 2</Text>
         </Accordion.Header>
         <Accordion.Body>
           Accordion Content Goes Here
@@ -65,7 +65,7 @@ const MultipleAccordions = props => {
       </Accordion>
       <Accordion>
         <Accordion.Header>
-          My Header 3
+          <Text as="h3">>My Header 3</Text
         </Accordion.Header>
         <Accordion.Body>
           Accordion Content Goes Here

--- a/modules/cactus-web/src/Accordion/Accordion.story.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.story.tsx
@@ -69,7 +69,9 @@ storiesOf('Accordion', module)
   .add('Basic Usage', () => (
     <Box width="312px">
       <Accordion>
-        <Accordion.Header>{text('header', 'Accordion')}</Accordion.Header>
+        <Accordion.Header>
+          <Text as="h3">{text('header', 'Accordion')}</Text>
+        </Accordion.Header>
         <Accordion.Body>{text('content', 'Some Accordion Content')}</Accordion.Body>
       </Accordion>
     </Box>
@@ -77,7 +79,9 @@ storiesOf('Accordion', module)
   .add('Long', () => (
     <Box width="960px">
       <Accordion>
-        <Accordion.Header>{text('header', 'Accordion')}</Accordion.Header>
+        <Accordion.Header>
+          <Text as="h3">{text('header', 'Accordion')}</Text>
+        </Accordion.Header>
         <Accordion.Body>{text('content', 'Some Accordion Content')}</Accordion.Body>
       </Accordion>
     </Box>
@@ -88,7 +92,9 @@ storiesOf('Accordion', module)
       <Box width="312px">
         <Accordion.Provider maxOpen={number('maxOpen', 1)}>
           <Accordion>
-            <Accordion.Header>{text('header 1', 'Accordion 1')}</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">{text('header 1', 'Accordion 1')}</Text>
+            </Accordion.Header>
             <Accordion.Body>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
               tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
@@ -97,7 +103,9 @@ storiesOf('Accordion', module)
             </Accordion.Body>
           </Accordion>
           <Accordion>
-            <Accordion.Header>{text('header 2', 'Accordion 2')}</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">{text('header 2', 'Accordion 2')}</Text>
+            </Accordion.Header>
             <Accordion.Body>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
               tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
@@ -106,7 +114,9 @@ storiesOf('Accordion', module)
             </Accordion.Body>
           </Accordion>
           <Accordion>
-            <Accordion.Header>{text('header 3', 'Accordion 3')}</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">{text('header 3', 'Accordion 3')}</Text>
+            </Accordion.Header>
             <Accordion.Body>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
               tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
@@ -115,7 +125,9 @@ storiesOf('Accordion', module)
             </Accordion.Body>
           </Accordion>
           <Accordion>
-            <Accordion.Header>{text('header 4', 'Accordion 4')}</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">{text('header 4', 'Accordion 4')}</Text>
+            </Accordion.Header>
             <Accordion.Body>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
               tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
@@ -141,7 +153,9 @@ storiesOf('Accordion', module)
                   let group = index
                   blocks.push(
                     <Accordion key={group}>
-                      <Accordion.Header>{group} Accordion</Accordion.Header>
+                      <Accordion.Header>
+                        <Text as="h3">{group} Accordion</Text>
+                      </Accordion.Header>
                       <Accordion.Body>
                         {(!state[group] || state[group] < 10) && (
                           <Text>
@@ -176,7 +190,9 @@ storiesOf('Accordion', module)
     <Box width="312px">
       <Accordion.Provider maxOpen={number('maxOpen', 2)}>
         <Accordion defaultOpen>
-          <Accordion.Header>{text('header 1', 'Accordion 1')}</Accordion.Header>
+          <Accordion.Header>
+            <Text as="h3">{text('header 1', 'Accordion 1')}</Text>
+          </Accordion.Header>
           <Accordion.Body>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
             tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
@@ -185,7 +201,9 @@ storiesOf('Accordion', module)
           </Accordion.Body>
         </Accordion>
         <Accordion defaultOpen>
-          <Accordion.Header>{text('header 2', 'Accordion 2')}</Accordion.Header>
+          <Accordion.Header>
+            <Text as="h3">{text('header 2', 'Accordion 2')}</Text>
+          </Accordion.Header>
           <Accordion.Body>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
             tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
@@ -194,35 +212,5 @@ storiesOf('Accordion', module)
           </Accordion.Body>
         </Accordion>
       </Accordion.Provider>
-    </Box>
-  ))
-  .add('With Nested Accordions', () => (
-    <Box width="968px">
-      <Accordion>
-        <Accordion.Header>Parent</Accordion.Header>
-        <Accordion.Body mx={4}>
-          <Accordion.Provider maxOpen={2}>
-            <Accordion>
-              <Accordion.Header>Child 1</Accordion.Header>
-              <Accordion.Body>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris
-                eu tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa.
-                Vestibulum lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis
-                gravida ex, nec euismod augue aliquam vel.
-              </Accordion.Body>
-            </Accordion>
-
-            <Accordion>
-              <Accordion.Header>Child 2</Accordion.Header>
-              <Accordion.Body>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris
-                eu tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa.
-                Vestibulum lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis
-                gravida ex, nec euismod augue aliquam vel.
-              </Accordion.Body>
-            </Accordion>
-          </Accordion.Provider>
-        </Accordion.Body>
-      </Accordion>
     </Box>
   ))

--- a/modules/cactus-web/src/Accordion/Accordion.test.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.test.tsx
@@ -5,6 +5,7 @@ import { StyleProvider } from '../StyleProvider/StyleProvider'
 import Accordion from './Accordion'
 import animationRender from '../../tests/helpers/animationRender'
 import KeyCodes from '../helpers/keyCodes'
+import Text from '../Text/Text'
 
 afterEach(() => {
   cleanup()
@@ -16,7 +17,9 @@ describe('component: Accordion', () => {
       const { container } = render(
         <StyleProvider>
           <Accordion id="accordion">
-            <Accordion.Header>Test Header</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">Test Header</Text>
+            </Accordion.Header>
             <Accordion.Body>Test Body</Accordion.Body>
           </Accordion>
         </StyleProvider>
@@ -31,7 +34,9 @@ describe('component: Accordion', () => {
       const { container } = render(
         <StyleProvider>
           <Accordion>
-            <Accordion.Header>Test Header</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">Test Header</Text>
+            </Accordion.Header>
             <Accordion.Body>Test Body</Accordion.Body>
           </Accordion>
         </StyleProvider>
@@ -49,7 +54,9 @@ describe('component: Accordion', () => {
       const { container } = render(
         <StyleProvider>
           <Accordion defaultOpen>
-            <Accordion.Header>Test Header</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">Test Header</Text>
+            </Accordion.Header>
             <Accordion.Body>Test Body</Accordion.Body>
           </Accordion>
         </StyleProvider>
@@ -62,10 +69,14 @@ describe('component: Accordion', () => {
       const { container, getByTestId } = render(
         <StyleProvider>
           <Accordion data-testid="parent">
-            <Accordion.Header>Parent</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">Parent</Text>
+            </Accordion.Header>
             <Accordion.Body>
               <Accordion data-testid="child">
-                <Accordion.Header>Child</Accordion.Header>
+                <Accordion.Header>
+                  <Text as="h4">Child</Text>
+                </Accordion.Header>
                 <Accordion.Body>Child Content</Accordion.Body>
               </Accordion>
             </Accordion.Body>
@@ -97,7 +108,9 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider>
             <Accordion>
-              <Accordion.Header>Test Header</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Test Header</Text>
+              </Accordion.Header>
               <Accordion.Body>Test Body</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -117,11 +130,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider>
             <Accordion data-testid="A1">
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>Should show first and not second</Accordion.Body>
             </Accordion>
             <Accordion data-testid="A2">
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>Should show second and not first</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -154,11 +171,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
             <Accordion data-testid="A1">
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>Should show A1</Accordion.Body>
             </Accordion>
             <Accordion data-testid="A2">
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>Should show A2</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -187,11 +208,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
             <Accordion defaultOpen>
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>Should show A1</Accordion.Body>
             </Accordion>
             <Accordion defaultOpen>
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>Should show A2</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -209,11 +234,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
             <Accordion data-testid="A1">
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>A1 Content</Accordion.Body>
             </Accordion>
             <Accordion data-testid="A2">
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>A2 Content</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -231,11 +260,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
             <Accordion data-testid="A1">
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>A1 Content</Accordion.Body>
             </Accordion>
             <Accordion data-testid="A2">
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>A2 Content</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -253,11 +286,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
             <Accordion data-testid="A1">
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>A1 Content</Accordion.Body>
             </Accordion>
             <Accordion data-testid="A2">
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>A2 Content</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -295,7 +332,9 @@ describe('component: Accordion', () => {
       const { getByTestId } = render(
         <StyleProvider>
           <Accordion data-testid="Accordion">
-            <Accordion.Header>My Accordion</Accordion.Header>
+            <Accordion.Header>
+              <Text as="h3">My Accordion</Text>
+            </Accordion.Header>
             <Accordion.Body>My Accordion Content</Accordion.Body>
           </Accordion>
         </StyleProvider>
@@ -314,11 +353,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
             <Accordion data-testid="A1">
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>A1 Content</Accordion.Body>
             </Accordion>
             <Accordion data-testid="A2">
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>A2 Content</Accordion.Body>
             </Accordion>
           </Accordion.Provider>
@@ -337,11 +380,15 @@ describe('component: Accordion', () => {
         <StyleProvider>
           <Accordion.Provider maxOpen={2}>
             <Accordion data-testid="A1">
-              <Accordion.Header>Accordion 1</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 1</Text>
+              </Accordion.Header>
               <Accordion.Body>A1 Content</Accordion.Body>
             </Accordion>
             <Accordion data-testid="A2">
-              <Accordion.Header>Accordion 2</Accordion.Header>
+              <Accordion.Header>
+                <Text as="h3">Accordion 2</Text>
+              </Accordion.Header>
               <Accordion.Body>A2 Content</Accordion.Body>
             </Accordion>
           </Accordion.Provider>

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -5,6 +5,7 @@ import { CactusTheme } from '@repay/cactus-theme'
 import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 'styled-system'
 import { NavigationChevronDown, NavigationChevronLeft } from '@repay/cactus-icons'
 import { omitMargins } from '../helpers/omit'
+import IconButton from '../IconButton/IconButton'
 import KeyCodes from '../helpers/keyCodes'
 import PropTypes from 'prop-types'
 import Rect from '@reach/rect'
@@ -20,7 +21,7 @@ interface AccordionProps
 }
 
 interface AccordionHeaderProps
-  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {}
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {}
 
 interface AccordionBodyProps
   extends MarginProps,
@@ -117,26 +118,23 @@ const AccordionHeaderBase = (props: AccordionHeaderProps) => {
   }
 
   return (
-    <button
-      {...rest}
-      id={headerId}
-      className={className}
-      data-role="accordion-button"
-      type="button"
-      role="button"
-      onClick={handleToggle}
-      onKeyDown={handleHeaderKeyDown}
-      onKeyUp={handleHeaderKeyUp}
-      aria-expanded={isOpen}
-      aria-controls={bodyId}
-    >
-      <span>{children}</span>
-      {isOpen ? (
-        <NavigationChevronDown iconSize="small" mx="16px" aria-hidden="true" />
-      ) : (
-        <NavigationChevronLeft iconSize="small" mx="16px" aria-hidden="true" />
-      )}
-    </button>
+    <div {...rest} id={headerId} className={className} onClick={handleToggle}>
+      {children}
+      <IconButton
+        iconSize="small"
+        mx="16px"
+        onKeyDown={handleHeaderKeyDown}
+        onKeyUp={handleHeaderKeyUp}
+        data-role="accordion-button"
+        type="button"
+        role="button"
+        aria-expanded={isOpen}
+        aria-controls={bodyId}
+        aria-labelledby={headerId}
+      >
+        {isOpen ? <NavigationChevronDown /> : <NavigationChevronLeft />}
+      </IconButton>
+    </div>
   )
 }
 
@@ -158,12 +156,13 @@ export const AccordionHeader = styled(AccordionHeaderBase)`
     border: 0;
   }
 
-  &:focus {
-    border: 2px solid ${p => p.theme.colors.callToAction};
-    border-radius: 5px;
+  p,
+  h1,
+  h2,
+  h3,
+  h4 {
+    margin: 0;
   }
-
-  ${p => p.theme.textStyles.h3};
 `
 
 const AccordionBodyInner = styled.div`
@@ -467,6 +466,9 @@ const AccordionBase = (props: AccordionProps) => {
 export const Accordion = styled(AccordionBase)`
   width: 100%;
   border-bottom: 2px solid ${p => p.theme.colors.lightContrast};
+  &:first-of-type {
+    border-top: 2px solid ${p => p.theme.colors.lightContrast};
+  }
   ${margin}
   ${width}
   ${maxWidth}

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -132,7 +132,11 @@ const AccordionHeaderBase = (props: AccordionHeaderProps) => {
         aria-controls={bodyId}
         aria-labelledby={headerId}
       >
-        {isOpen ? <NavigationChevronDown /> : <NavigationChevronLeft />}
+        {isOpen ? (
+          <NavigationChevronDown aria-hidden="true" />
+        ) : (
+          <NavigationChevronLeft aria-hidden="true" />
+        )}
       </IconButton>
     </div>
   )

--- a/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -112,6 +112,7 @@ exports[`component: Accordion Component Should render Accordion 1`] = `
         variant="standard"
       >
         <svg
+          aria-hidden="true"
           class="c3"
           fill="currentcolor"
           height="1em"

--- a/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -1,11 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component: Accordion Component Should render Accordion 1`] = `
+.c3 {
+  vertical-align: middle;
+}
+
 .c2 {
-  font-size: 16px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  box-sizing: border-box;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 1px;
+  border: none;
+  background: transparent;
+  outline: none;
+  cursor: pointer;
+  color: hsl(200,96%,11%);
   margin-left: 16px;
   margin-right: 16px;
-  vertical-align: middle;
+  font-size: 16px;
+}
+
+.c2::-moz-focus-inner {
+  border: 0;
+}
+
+.c2:focus {
+  background-color: hsla(200,96%,35%,0.25);
+}
+
+.c2:hover {
+  color: hsl(200,96%,35%);
 }
 
 .c1 {
@@ -30,17 +64,18 @@ exports[`component: Accordion Component Should render Accordion 1`] = `
   background: none;
   border: 2px transparent;
   outline: none;
-  font-size: 25.92px;
-  line-height: 40px;
 }
 
 .c1::-moz-focus-inner {
   border: 0;
 }
 
-.c1:focus {
-  border: 2px solid hsl(200,96%,35%);
-  border-radius: 5px;
+.c1 p,
+.c1 h1,
+.c1 h2,
+.c1 h3,
+.c1 h4 {
+  margin: 0;
 }
 
 .c0 {
@@ -48,37 +83,47 @@ exports[`component: Accordion Component Should render Accordion 1`] = `
   border-bottom: 2px solid hsl(200,29%,90%);
 }
 
+.c0:first-of-type {
+  border-top: 2px solid hsl(200,29%,90%);
+}
+
 <div>
   <div
     class="c0"
     id="accordion"
   >
-    <button
-      aria-controls="accordion-body"
-      aria-expanded="false"
+    <div
       class="c1"
-      data-role="accordion-button"
       id="accordion-header"
-      role="button"
-      type="button"
     >
-      <span>
-        Test Header
-      </span>
-      <svg
-        aria-hidden="true"
-        class="c2"
-        fill="currentcolor"
-        height="1em"
-        mx="16px"
-        viewBox="0 0 24 24"
-        width="1em"
+      <h3
+        class=""
       >
-        <path
-          d="M17.7071068,2.70710678 C18.0976311,2.31658249 18.0976311,1.68341751 17.7071068,1.29289322 C17.3165825,0.902368927 16.6834175,0.902368927 16.2928932,1.29289322 L6.29289322,11.2928932 C5.90236893,11.6834175 5.90236893,12.3165825 6.29289322,12.7071068 L16.2928932,22.7071068 C16.6834175,23.0976311 17.3165825,23.0976311 17.7071068,22.7071068 C18.0976311,22.3165825 18.0976311,21.6834175 17.7071068,21.2928932 L8.41421356,12 L17.7071068,2.70710678 Z"
-        />
-      </svg>
-    </button>
+        Test Header
+      </h3>
+      <button
+        aria-controls="accordion-body"
+        aria-expanded="false"
+        aria-labelledby="accordion-header"
+        class="c2"
+        data-role="accordion-button"
+        role="button"
+        type="button"
+        variant="standard"
+      >
+        <svg
+          class="c3"
+          fill="currentcolor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M17.7071068,2.70710678 C18.0976311,2.31658249 18.0976311,1.68341751 17.7071068,1.29289322 C17.3165825,0.902368927 16.6834175,0.902368927 16.2928932,1.29289322 L6.29289322,11.2928932 C5.90236893,11.6834175 5.90236893,12.3165825 6.29289322,12.7071068 L16.2928932,22.7071068 C16.6834175,23.0976311 17.3165825,23.0976311 17.7071068,22.7071068 C18.0976311,22.3165825 18.0976311,21.6834175 17.7071068,21.2928932 L8.41421356,12 L17.7071068,2.70710678 Z"
+          />
+        </svg>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -132,7 +132,30 @@ IconButton.propTypes = {
   iconSize: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
   variant: PropTypes.oneOf(['standard', 'action', 'danger']),
   disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired,
+  label: (props: IconButtonProps, propName: string, componentName: string) => {
+    if (!props.label && !props['aria-labelledby']) {
+      return new Error(
+        `One of props 'label' or 'aria-labelledby' was not specified in ${componentName}.`
+      )
+    } else if (props.label !== undefined && typeof props.label !== 'string') {
+      return new Error(
+        `Invalid prop 'label' of type '${typeof props.label}' supplied to '${componentName}', expected 'string'.`
+      )
+    }
+  },
+  'aria-labelledby': (props: IconButtonProps, propName: string, componentName: string) => {
+    if (!props['aria-labelledby'] && !props.label) {
+      return new Error(
+        `One of props 'label' or 'aria-labelledby' was not specified in ${componentName}.`
+      )
+    } else if (props['aria-labelledby'] && typeof props['aria-labelledby'] !== 'string') {
+      return new Error(
+        `Invalid prop 'aria-labelledby' of type '${typeof props[
+          'aria-labelledby'
+        ]}' supplied to '${componentName}', expected 'string'.`
+      )
+    }
+  },
   display: PropTypes.oneOf(['flex', 'inline-flex']),
   inverse: PropTypes.bool,
 }


### PR DESCRIPTION
Converted the accordion headers to `div` rather than `button` so we can include whatever kinds of headers we want as children. This is a breaking change because, previously, the accordion headers automatically had h3 styles, whereas now you must explicitly render your accordion header with whatever text styles you want