### PR TITLE
fix(cactus-web): date input changes time with large year changes

### DIFF
--- a/modules/cactus-web/src/DateInput/DateInput.story.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.story.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
 import { actions } from '@storybook/addon-actions'
+import { select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
-import { text } from '@storybook/addon-knobs'
 import DateInput from './DateInput'
 import FormHandler from '../storySupport/FormHandler'
 
@@ -24,6 +24,7 @@ storiesOf('DateInput', module)
           <DateInput
             id="date-input-1"
             name={text('name', 'date-input')}
+            type={select('type', ['date', 'datetime', 'time'], 'date')}
             value={value}
             onChange={onChange}
           />

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -587,14 +587,10 @@ export class PartialDate implements FormatTokenMap {
   }
 
   toDate(): Date {
-    let date = new Date(
-      this.getYear(),
-      this.getMonth(),
-      this.getDate(),
-      this.getHours(),
-      this.getMinutes()
-    )
-    date.setUTCFullYear(this.getYear())
+    let date = new Date()
+    date.setFullYear(this.getYear(), this.getMonth(), this.getDate())
+    date.setHours(this.getHours())
+    date.setUTCMinutes(this.getMinutes(), 0, 0)
     return date
   }
 


### PR DESCRIPTION
This appears to be caused by the minor time adjustments which happen over large amounts of time so when changing the years it will adjust the time by some minutes. To account for this, I generate the date and then set all of the values directly.