### PR TITLE
Use default date formats

### DIFF
--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -5,6 +5,7 @@ import {
   DateType,
   formatDate,
   FormatTokenType,
+  getDefaultFormat,
   getLastDayOfMonth,
   isToken,
   parseDate,
@@ -67,15 +68,6 @@ const NUMBER_INPUT_TYPE = !IS_FIREFOX ? 'number' : 'tel'
 const portalStyleOptions = { offset: 8 }
 const noop = function() {}
 const ALLOW_DEFAULT = ['Tab', 'Home', 'PageUp', 'PageDown', 'ArrowLeft', 'ArrowRight']
-
-function getDefaultFormat(type: DateType) {
-  if (type === 'datetime') {
-    return 'YYYY-MM-dd HH:mm'
-  } else if (type === 'time') {
-    return 'HH:mm'
-  }
-  return 'YYYY-MM-dd'
-}
 
 function isOwnInput(target: any, container: Element): target is HTMLInputElement {
   return (
@@ -730,7 +722,7 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
       if (props.value instanceof Date) {
         value = PartialDate.from(props.value, { type: value.getType() })
       } else {
-        value.parse(props.value, props.format as string)
+        value.parse(props.value, props.format)
       }
       // only update local value if provided value is a valid date
       if (value.isValid() && !value.equals(state.value)) {

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -170,7 +170,7 @@ export function getLocaleFormat(locale?: string, options: GetLocaleformatOpt = {
 
 export function getDefaultFormat(type: DateType) {
   if (type === 'datetime') {
-    return 'YYYY-MM-dd HH:mm'
+    return 'YYYY-MM-ddTHH:mm'
   } else if (type === 'time') {
     return 'HH:mm'
   }

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -168,6 +168,15 @@ export function getLocaleFormat(locale?: string, options: GetLocaleformatOpt = {
   return formatArray.join('')
 }
 
+export function getDefaultFormat(type: DateType) {
+  if (type === 'datetime') {
+    return 'YYYY-MM-dd HH:mm'
+  } else if (type === 'time') {
+    return 'HH:mm'
+  }
+  return 'YYYY-MM-dd'
+}
+
 export function formatDate(date: Date, format: string) {
   let breakup = parseFormat(format)
   return breakup
@@ -246,7 +255,7 @@ function asOptions(formatOrOpts?: string | Partial<PartialDateOpts>): PartialDat
       let format = result.format
       if (format.includes('YYYY') || format.includes('dd')) {
         result.type = 'date'
-        if (format.includes('h')) {
+        if (format.includes('h') || format.includes('H')) {
           result.type += 'time'
         }
       } else {
@@ -257,7 +266,7 @@ function asOptions(formatOrOpts?: string | Partial<PartialDateOpts>): PartialDat
     }
   }
   if (!result.format) {
-    result.format = getLocaleFormat(result.locale, { type: result.type as DateType })
+    result.format = getDefaultFormat(result.type as DateType)
   }
   return result as PartialDateOpts
 }
@@ -502,7 +511,7 @@ export class PartialDate implements FormatTokenMap {
     return val === undefined ? '' : ('0' + val).slice(-2)
   }
 
-  parse(dateStr: string, format: string) {
+  parse(dateStr: string, format: string = this._format) {
     let parsedFormat = parseFormat(format)
     let cursor = 0
     for (const token of parsedFormat) {

--- a/modules/cactus-web/tests/dates.test.ts
+++ b/modules/cactus-web/tests/dates.test.ts
@@ -34,7 +34,7 @@ describe('date helpers', () => {
   describe('getDefaultFormat()', () => {
     test('default formats changes are a breaking change', () => {
       expect(getDefaultFormat('date')).toBe('YYYY-MM-dd')
-      expect(getDefaultFormat('datetime')).toBe('YYYY-MM-dd HH:mm')
+      expect(getDefaultFormat('datetime')).toBe('YYYY-MM-ddTHH:mm')
       expect(getDefaultFormat('time')).toBe('HH:mm')
     })
   })
@@ -49,7 +49,7 @@ describe('date helpers', () => {
     })
 
     test('YYYY-MM-dd H:mm', () => {
-      expect(formatDate(new Date(2018, 7, 12, 5, 23), 'YYYY-MM-dd H:mm')).toEqual('2018-08-12 5:23')
+      expect(formatDate(new Date(2018, 7, 12, 5, 23), 'YYYY-MM-ddTH:mm')).toEqual('2018-08-12T5:23')
     })
 
     test('YYYY-MM-dd h:mm aa', () => {
@@ -160,8 +160,8 @@ describe('date helpers', () => {
         })
 
         test('leaves time stable during large year changes', () => {
-          const pd = new PartialDate('01/02/2020 11:53', {
-            format: 'MM/dd/YYYY HH:mm',
+          const pd = new PartialDate('01/02/2020T11:53', {
+            format: 'MM/dd/YYYYTHH:mm',
             type: 'datetime',
           })
           pd.setYear(2)

--- a/modules/cactus-web/tests/dates.test.ts
+++ b/modules/cactus-web/tests/dates.test.ts
@@ -1,4 +1,10 @@
-import { formatDate, getLocaleFormat, parseDate, PartialDate } from '../src/helpers/dates'
+import {
+  formatDate,
+  getDefaultFormat,
+  getLocaleFormat,
+  parseDate,
+  PartialDate,
+} from '../src/helpers/dates'
 
 describe('date helpers', () => {
   describe('getLocalFormat()', () => {
@@ -22,6 +28,14 @@ describe('date helpers', () => {
     test.skip('can parse es locale', () => {
       const format = getLocaleFormat('es')
       expect(format).toEqual('dd/MM/YYYY, H:mm')
+    })
+  })
+
+  describe('getDefaultFormat()', () => {
+    test('default formats changes are a breaking change', () => {
+      expect(getDefaultFormat('date')).toBe('YYYY-MM-dd')
+      expect(getDefaultFormat('datetime')).toBe('YYYY-MM-dd HH:mm')
+      expect(getDefaultFormat('time')).toBe('HH:mm')
     })
   })
 
@@ -69,7 +83,7 @@ describe('date helpers', () => {
     describe('constructor()', () => {
       test('constructor can receive blank string and will return all placeholders', () => {
         const pd = new PartialDate('')
-        expect(pd.format()).toEqual('##/##/####')
+        expect(pd.format()).toEqual('####-##-##')
       })
 
       test('constructor can receive a partial date string and will return a partial date', () => {
@@ -79,7 +93,7 @@ describe('date helpers', () => {
 
       test('can be given a DateType', () => {
         const pd = new PartialDate('', { type: 'time' })
-        expect(pd.format()).toEqual('#:## ##')
+        expect(pd.format()).toEqual('##:##')
       })
 
       test('constructed with 24 hour time will set period', () => {
@@ -170,6 +184,12 @@ describe('date helpers', () => {
         const pd = new PartialDate('01/14/2018, 1:24 AM', 'MM/dd/YYYY, h:mm aa')
         pd.parse('2019-02-14', 'YYYY-MM-dd')
         expect(pd.format()).toEqual('02/14/2019, 1:24 AM')
+      })
+
+      test('uses internal format when not provided', () => {
+        const pd = new PartialDate('2019-12-01 12:00', { type: 'datetime' })
+        pd.parse('2019-12-17 12:00')
+        expect(pd.toLocaleFormat()).toEqual('12/17/2019, 12:00 PM')
       })
     })
 


### PR DESCRIPTION
This fixes the the issue where DateInput would incorrectly parse provided date strings when no format was provided as a prop. This also updates the default datetime format to conform more strictly to the ISO8601 format with a `T` between the date and time sections. I.e. `YYYY-MM-ddTHH:mm`

BREAKING: the default datetime format for the DateInput and DateInputField
now includes a T separator. No change is necessary if already using an ISO8601
date parser.