### PR TITLE
fix(cactus-web): Fix buttons in header toggling accordion

### DIFF
--- a/modules/cactus-web/src/Accordion/Accordion.test.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.test.tsx
@@ -490,5 +490,41 @@ describe('component: Accordion', () => {
 
       expect(accordion.querySelector('button[aria-label=Delete]')).toBeInTheDocument()
     })
+
+    test('clicking icon buttons inside header should not trigger opening/closing', async () => {
+      const noop = jest.fn()
+      const { getByTestId, container } = render(
+        <StyleProvider>
+          <Accordion>
+            <Accordion.Header
+              render={() => (
+                <Flex alignItems="center" width="100%">
+                  <Text as="h3">Test Header</Text>
+                  <IconButton
+                    iconSize="medium"
+                    variant="danger"
+                    ml="auto"
+                    label="Delete"
+                    onClick={noop}
+                    data-testid="delete"
+                  >
+                    <ActionsDelete aria-hidden="true" />
+                  </IconButton>
+                </Flex>
+              )}
+            />
+            <Accordion.Body>test</Accordion.Body>
+          </Accordion>
+        </StyleProvider>
+      )
+
+      const deleteButton = getByTestId('delete')
+      await act(async () => {
+        fireEvent.click(deleteButton)
+        await animationRender()
+      })
+      expect(noop).toHaveBeenCalled()
+      expect(container).not.toHaveTextContent('Should not show')
+    })
   })
 })

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -84,15 +84,12 @@ const AccordionHeaderBase = (props: AccordionHeaderProps) => {
   } = useContext(AccordionContext)
 
   const handleHeaderClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    const target = event.target as HTMLElement
-    if (
-      handleToggle &&
-      typeof handleToggle === 'function' &&
-      target.tagName !== 'svg' &&
-      target.tagName !== 'path' &&
-      target.tagName !== 'BUTTON' &&
-      target.getAttribute('data-role') !== 'accordion-button'
-    ) {
+    let element: HTMLElement | null = event.target as HTMLElement
+    do {
+      if (element.tagName === 'BUTTON') return
+      element = element.parentElement
+    } while (element !== null && element !== event.currentTarget)
+    if (handleToggle && typeof handleToggle === 'function') {
       handleToggle()
     }
   }

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -83,6 +83,20 @@ const AccordionHeaderBase = (props: AccordionHeaderProps) => {
     focusLast,
   } = useContext(AccordionContext)
 
+  const handleHeaderClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLElement
+    if (
+      handleToggle &&
+      typeof handleToggle === 'function' &&
+      target.tagName !== 'svg' &&
+      target.tagName !== 'path' &&
+      target.tagName !== 'BUTTON' &&
+      target.getAttribute('data-role') !== 'accordion-button'
+    ) {
+      handleToggle()
+    }
+  }
+
   // Used to prevent default behavior/propagation
   const handleHeaderKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     const key = event.which || event.keyCode
@@ -140,13 +154,14 @@ const AccordionHeaderBase = (props: AccordionHeaderProps) => {
       className={`${className} ${variant === 'outline' ? 'outline-variant' : ''} ${
         isOpen ? 'is-open' : ''
       }`}
-      onClick={handleToggle}
+      onClick={handleHeaderClick}
     >
       <IconButton
         iconSize="small"
         mr={4}
         onKeyDown={handleHeaderKeyDown}
         onKeyUp={handleHeaderKeyUp}
+        onClick={handleToggle}
         data-role="accordion-button"
         type="button"
         role="button"


### PR DESCRIPTION
Quick bug fix to restrict the accordion from toggling its open/closed state based on what target was clicked. 