### PR TITLE
I18n Upgrades

### DIFF
--- a/docs/Internationalization/API Documentation.md
+++ b/docs/Internationalization/API Documentation.md
@@ -96,6 +96,29 @@ return (
 )
 ```
 
+In the browser, it is recommended to use the user provided language by default but also allow the user to change as desired.
+
+```jsx
+// App.js
+import React, { useState } from 'react'
+import I18nProvider from '@repay/cactus-i18n'
+import i18nController from './I18nController'
+
+function App(props) {
+  const [lang, setLang] = useState(navigator.language)
+
+  return (
+    <I18nProvider controller={i18nController} lang={lang}>
+      <select name="lang" onChange={event => setLang(event.currentTarget.value)}>
+        ...
+        <option value="es">Español</option>
+      </select>
+      ...
+    </I18nProvider>
+  )
+}
+```
+
 ## I18nSection
 
 The `<I18nSection />` component was designed to allow the translations to be broken up into separate sections and loaded only when a specific section is needed. A section component alone will not render anything; it must be used with other internationalization components like `I18nText` or `I18nElement` in order to render any actual translations. This component is really there to tell any of its children i18n components where to look for translated text. It can also be used to manually change the rendered language in cases where a user wants to present information to another person.
@@ -152,12 +175,23 @@ const section = () => {
     </I18nSection>
   )
 }
-// Section overridden; translations for "my-section" will be loaded instead
+// Section overridden; translation for "my-section__translation-key" will be rendered instead
+// NOTE: the "my-section" should be loaded separately because the text element will not trigger a load
 const override = () => {
   return (
     <I18nSection name="example">
       ...
       <I18nText get="translation-key" section="my-section" args={{ groupName: "example" }} />
+    </I18nSection>
+  )
+}
+
+// The developer may also write the entire key out while providing the section as "global"
+const alsoOverride = () => {
+  return (
+    <I18nSection name="example">
+      ...
+      <I18nText get="my-section__translation-key" section="global" args={{ groupName: "example" }} />
     </I18nSection>
   )
 }

--- a/docs/Internationalization/Getting Started.md
+++ b/docs/Internationalization/Getting Started.md
@@ -24,7 +24,7 @@ welcome-message = Welcome, { $user }!`
 
 // en/accounts.js
 export default `
-welcome-message = Welcome to the accounts page, { $user }!`
+accounts__welcome-message = Welcome to the accounts page, { $user }!`
 
 // es/global.js
 export default `
@@ -32,11 +32,11 @@ welcome-message = ¡Bienvenido, { $user }!`
 
 // es/accounts.js
 export default `
-welcome-message =
-¡Bienvenido a la página de cuentas, { $user }!`
+accounts__welcome-message =
+  ¡Bienvenido a la página de cuentas, { $user }!`
 ```
 
-Notice that we put translations in two separate folders; one for English and one for Spanish. We also made `global.js` and `accounts.js`. This is because of how the i18n framework utilizes sections for organizations and efficiency. We'll discuss that more later. For now, let's move on to extending the `BaseI18nController` class.
+Notice that we put translations in two separate folders; one for English and one for Spanish. We also made `global.js` and `accounts.js`. This is because of how the i18n framework utilizes sections for organization and efficiency. We'll discuss that more later. For now, let's move on to extending the `BaseI18nController` class.
 
 ## Extending `BaseI18nController`
 
@@ -116,7 +116,7 @@ const mainComponent = () => {
 } // Welcome to the accounts page, CS Human!
 ```
 
-Notice that we used the same `get` value on `I18nText`, but by making the `I18nText` component as a child of `I18nSection`, we told the controller that we should be loading translations for the "accounts" section, instead of global. What if we wanted to load translations for a different language, though? To do so, we'll just need to change the `lang` prop on `I18nProvider`:
+Notice that we used the same `get` value on `I18nText`, but by making the `I18nText` component as a child of `I18nSection`, we told the controller that we should be loading translations for the "accounts" section, instead of global, the library then merges the section name and the get key to find the scopped message under `accounts__welcome-message`. What if we wanted to load translations for a different language, though? To do so, we'll just need to change the `lang` prop on `I18nProvider`:
 
 ```jsx
 // index.js

--- a/examples/mock-ebpp/tests/integration.test.ts
+++ b/examples/mock-ebpp/tests/integration.test.ts
@@ -11,74 +11,180 @@ const { getByLabelText } = queries
 
 describe('Integration Tests', () => {
   let page: puppeteer.Page
-  let mobilePage: puppeteer.Page
   let server: ServerObj
 
   beforeEach(async () => {
     await page.reload({ waitUntil: 'domcontentloaded' })
   })
 
+  beforeAll(async () => {
+    page = await global.__BROWSER__.newPage()
+    server = startStaticServer({
+      directory: path.join(process.cwd(), 'dist'),
+      port: 33567,
+      singlePageApp: true,
+    })
+  })
+
+  afterAll(async () => {
+    await server.close()
+    await page.close()
+  })
+
   describe('UI Config Form', () => {
-    beforeAll(async () => {
-      page = await global.__BROWSER__.newPage()
-      mobilePage = await global.__BROWSER__.newPage()
-      const iPhoneX = devices['iPhone X']
-      mobilePage.emulate(iPhoneX)
-      server = startStaticServer({
-        directory: path.join(process.cwd(), 'dist'),
-        port: 33567,
-        singlePageApp: true,
+    describe('Web Views', () => {
+      beforeAll(async () => {
+        await page.goto('http://localhost:33567/ui-config')
       })
-      await page.goto('http://localhost:33567/ui-config')
-      await mobilePage.goto('http://localhost:33567/ui-config')
-    })
 
-    afterAll(async () => {
-      await server.close()
-    })
+      test('should be titled "UI Config"', async () => {
+        await wait(() => expect(page.title()).resolves.toMatch('UI Config'))
+      })
 
-    test('should be titled "UI Config"', async () => {
-      await wait(() => expect(page.title()).resolves.toMatch('UI Config'))
-    })
+      test('should fill out and submit the entire form', async () => {
+        const doc = await getDocument(page)
+        const actions = new Actions(doc, page)
 
-    test('should fill out and submit the entire form', async () => {
-      const doc = await getDocument(page)
-      const actions = new Actions(doc, page)
+        await actions.fillTextField('Display Name', 'Test Merchant')
+        await actions.fillTextField('Merchant Name', 'tst-mrchnt')
+        await actions.fillTextField('Terms and Conditions', 'You must be this tall to test')
+        await actions.fillTextField('Welcome Content', 'Welcome to the integration test app')
+        await actions.fillTextField('Footer Content', 'Powered by coffee and sheer willpower')
+        await actions.selectDropdownOption('Notification Email', 'dhuber@repay.com')
+        await actions.selectDropdownOption('All Locations', ['Tempe', 'Phoenix'])
+        await actions.searchComboBox('Most Popular Location', 'Tempe')
+        await actions.searchComboBox('Card Brands', ['MasterCard', 'FakeBrand'])
+        await actions.uploadFile('Upload Logo')
+        await actions.clickByText('Blue')
+        await actions.clickByText('Allow Customer Login')
+        await actions.clickByText('Use Cactus Styles')
+        await actions.clickByText('Submit')
 
-      await actions.fillTextField('Display Name', 'Test Merchant')
-      await actions.fillTextField('Merchant Name', 'tst-mrchnt')
-      await actions.fillTextField('Terms and Conditions', 'You must be this tall to test')
-      await actions.fillTextField('Welcome Content', 'Welcome to the integration test app')
-      await actions.fillTextField('Footer Content', 'Powered by coffee and sheer willpower')
-      await actions.selectDropdownOption('Notification Email', 'dhuber@repay.com')
-      await actions.selectDropdownOption('All Locations', ['Tempe', 'Phoenix'])
-      await actions.searchComboBox('Most Popular Location', 'Tempe')
-      await actions.searchComboBox('Card Brands', ['MasterCard', 'FakeBrand'])
-      await actions.uploadFile('Upload Logo')
-      await actions.clickByText('Blue')
-      await actions.clickByText('Allow Customer Login')
-      await actions.clickByText('Use Cactus Styles')
-      await actions.clickByText('Submit')
+        const apiData: UIConfigData = await actions.page.evaluate(() => (window as any).apiData)
+        expect(apiData).toMatchObject({
+          display_name: 'Test Merchant',
+          merchant_name: 'tst-mrchnt',
+          terms_and_conditions: 'You must be this tall to test',
+          welcome_content: 'Welcome to the integration test app',
+          footer_content: 'Powered by coffee and sheer willpower',
+          notification_email: 'dhuber@repay.com',
+          all_locations: ['Tempe', 'Phoenix'],
+          mp_location: 'Tempe',
+          card_brands: ['MasterCard', 'FakeBrand'],
+          allow_customer_login: true,
+          use_cactus_styles: true,
+          select_color: 'blue',
+          file_input: [{ fileName: 'test-logo.jpg', contents: 'data:', status: 'loaded' }],
+        })
+      })
 
-      const apiData: UIConfigData = await actions.page.evaluate(() => (window as any).apiData)
-      expect(apiData).toMatchObject({
-        display_name: 'Test Merchant',
-        merchant_name: 'tst-mrchnt',
-        terms_and_conditions: 'You must be this tall to test',
-        welcome_content: 'Welcome to the integration test app',
-        footer_content: 'Powered by coffee and sheer willpower',
-        notification_email: 'dhuber@repay.com',
-        all_locations: ['Tempe', 'Phoenix'],
-        mp_location: 'Tempe',
-        card_brands: ['MasterCard', 'FakeBrand'],
-        allow_customer_login: true,
-        use_cactus_styles: true,
-        select_color: 'blue',
-        file_input: [{ fileName: 'test-logo.jpg', contents: 'data:', status: 'loaded' }],
+      describe('<DateInputField />', () => {
+        // initial value is 2019-10-16
+
+        test('moves focus to date picker on click', async () => {
+          const doc = await getDocument(page)
+          let activeEl
+          const datePickerTrigger = await getByLabelText(doc, 'Open date picker')
+          await datePickerTrigger.click()
+          await page.keyboard.press('Tab')
+          activeEl = await getActiveElement(page)
+          let monthSelect = (await activeEl.asElement()) || undefined
+          let monthSelectAccess = await page.accessibility.snapshot({ root: monthSelect })
+
+          expect(monthSelectAccess).toEqual({
+            role: 'button',
+            name: 'Click to change month and year',
+            roledescription: 'toggles between calendar and month year selectors',
+            focused: true,
+          })
+        })
+
+        test('locks focus to date picker', async () => {
+          const doc = await getDocument(page)
+          const actions = new Actions(doc, page)
+
+          const datePickerTrigger = await getByLabelText(doc, 'Open date picker')
+          await datePickerTrigger.click()
+          let dateButtonAccess = await actions.getActiveAccessibility()
+          expect(dateButtonAccess).toEqual({
+            role: 'gridcell',
+            name: 'Wednesday, October 16, 2019',
+            focused: true,
+            selected: true,
+          })
+
+          // tab and expect focus to circle back to Month select
+          await page.keyboard.press('Tab')
+          let monthSelectAccess = await actions.getActiveAccessibility()
+          expect(monthSelectAccess).toEqual({
+            role: 'button',
+            name: 'Click to change month and year',
+            roledescription: 'toggles between calendar and month year selectors',
+            focused: true,
+          })
+
+          // tab again should be back at dateButton
+          await page.keyboard.press('Tab')
+          let dateButtonAccess2 = await actions.getActiveAccessibility()
+          expect(dateButtonAccess2).toEqual(dateButtonAccess)
+        })
+
+        test('move and select date with keyboard', async () => {
+          const doc = await getDocument(page)
+          const actions = new Actions(doc, page)
+
+          const datePickerTrigger = await getByLabelText(doc, 'Open date picker')
+          await datePickerTrigger.click()
+          let dateButtonAccess = await actions.getActiveAccessibility()
+          expect(dateButtonAccess).toEqual({
+            role: 'gridcell',
+            name: 'Wednesday, October 16, 2019',
+            focused: true,
+            selected: true,
+          })
+
+          // move right
+          await page.keyboard.press('ArrowRight')
+          dateButtonAccess = await actions.getActiveAccessibility()
+          expect(dateButtonAccess).toEqual({
+            role: 'gridcell',
+            name: 'Thursday, October 17, 2019',
+            focused: true,
+            selected: true,
+          })
+
+          // move up
+          await page.keyboard.press('ArrowUp')
+          dateButtonAccess = await actions.getActiveAccessibility()
+          expect(dateButtonAccess).toEqual({
+            role: 'gridcell',
+            name: 'Thursday, October 10, 2019',
+            focused: true,
+            selected: true,
+          })
+
+          // select currently focused date
+          await page.keyboard.press('Enter')
+          const year = await actions.getInputValueByLabel('year')
+          const month = await actions.getInputValueByLabel('month')
+          const day = await actions.getInputValueByLabel('day of month')
+          expect(year).toEqual('2019')
+          expect(month).toEqual('10')
+          expect(day).toEqual('10')
+        })
       })
     })
-
     describe('Mobile Views', () => {
+      let mobilePage: puppeteer.Page
+      beforeAll(async () => {
+        mobilePage = await global.__BROWSER__.newPage()
+        const iPhoneX = devices['iPhone X']
+        await mobilePage.emulate(iPhoneX)
+        await mobilePage.goto('http://localhost:33567/ui-config')
+      })
+      afterAll(async () => {
+        await mobilePage.close()
+      })
       describe('<SelectField />', () => {
         test('should present the mobile view for multiple=false comboBox=false', async () => {
           const doc = await getDocument(mobilePage)
@@ -105,117 +211,11 @@ describe('Integration Tests', () => {
     })
 
     // TODO: Add tests for field errors, partially filled out forms, etc
-
-    describe('<DateInputField />', () => {
-      // initial value is 2019-10-16
-
-      test('moves focus to date picker on click', async () => {
-        const doc = await getDocument(page)
-        let activeEl
-        const datePickerTrigger = await getByLabelText(doc, 'Open date picker')
-        await datePickerTrigger.click()
-        await page.keyboard.press('Tab')
-        activeEl = await getActiveElement(page)
-        let monthSelect = (await activeEl.asElement()) || undefined
-        let monthSelectAccess = await page.accessibility.snapshot({ root: monthSelect })
-
-        expect(monthSelectAccess).toEqual({
-          role: 'button',
-          name: 'Click to change month and year',
-          roledescription: 'toggles between calendar and month year selectors',
-          focused: true,
-        })
-      })
-
-      test('locks focus to date picker', async () => {
-        const doc = await getDocument(page)
-        const actions = new Actions(doc, page)
-
-        const datePickerTrigger = await getByLabelText(doc, 'Open date picker')
-        await datePickerTrigger.click()
-        let dateButtonAccess = await actions.getActiveAccessibility()
-        expect(dateButtonAccess).toEqual({
-          role: 'gridcell',
-          name: 'Wednesday, October 16, 2019',
-          focused: true,
-          selected: true,
-        })
-
-        // tab and expect focus to circle back to Month select
-        await page.keyboard.press('Tab')
-        let monthSelectAccess = await actions.getActiveAccessibility()
-        expect(monthSelectAccess).toEqual({
-          role: 'button',
-          name: 'Click to change month and year',
-          roledescription: 'toggles between calendar and month year selectors',
-          focused: true,
-        })
-
-        // tab again should be back at dateButton
-        await page.keyboard.press('Tab')
-        let dateButtonAccess2 = await actions.getActiveAccessibility()
-        expect(dateButtonAccess2).toEqual(dateButtonAccess)
-      })
-
-      test('move and select date with keyboard', async () => {
-        const doc = await getDocument(page)
-        const actions = new Actions(doc, page)
-
-        const datePickerTrigger = await getByLabelText(doc, 'Open date picker')
-        await datePickerTrigger.click()
-        let dateButtonAccess = await actions.getActiveAccessibility()
-        expect(dateButtonAccess).toEqual({
-          role: 'gridcell',
-          name: 'Wednesday, October 16, 2019',
-          focused: true,
-          selected: true,
-        })
-
-        // move right
-        await page.keyboard.press('ArrowRight')
-        dateButtonAccess = await actions.getActiveAccessibility()
-        expect(dateButtonAccess).toEqual({
-          role: 'gridcell',
-          name: 'Thursday, October 17, 2019',
-          focused: true,
-          selected: true,
-        })
-
-        // move up
-        await page.keyboard.press('ArrowUp')
-        dateButtonAccess = await actions.getActiveAccessibility()
-        expect(dateButtonAccess).toEqual({
-          role: 'gridcell',
-          name: 'Thursday, October 10, 2019',
-          focused: true,
-          selected: true,
-        })
-
-        // select currently focused date
-        await page.keyboard.press('Enter')
-        const year = await actions.getInputValueByLabel('year')
-        const month = await actions.getInputValueByLabel('month')
-        const day = await actions.getInputValueByLabel('day of month')
-        expect(year).toEqual('2019')
-        expect(month).toEqual('10')
-        expect(day).toEqual('10')
-      })
-    })
   })
 
   describe('FAQ', () => {
     beforeAll(async () => {
-      page = await global.__BROWSER__.newPage()
-      server = startStaticServer({
-        directory: path.join(process.cwd(), 'dist'),
-        port: 33567,
-        singlePageApp: true,
-      })
       await page.goto('http://localhost:33567/faq')
-    })
-
-    afterAll(async () => {
-      await server.close()
     })
 
     test('should be titled "FAQ"', async () => {
@@ -305,17 +305,7 @@ describe('Integration Tests', () => {
 
   describe('Rules', () => {
     beforeAll(async () => {
-      page = await global.__BROWSER__.newPage()
-      server = startStaticServer({
-        directory: path.join(process.cwd(), 'dist'),
-        port: 33567,
-        singlePageApp: true,
-      })
       await page.goto('http://localhost:33567/rules')
-    })
-
-    afterAll(async () => {
-      await server.close()
     })
 
     test('should be titled "Rules"', async () => {

--- a/examples/standard/src/containers/Snacks.tsx
+++ b/examples/standard/src/containers/Snacks.tsx
@@ -20,13 +20,6 @@ const Snacks: React.FC<RouteComponentProps> = () => {
   const [includesCarrots] = useFeatureFlags('include_carrot_snacks')
   const snackKeys = includesCarrots ? snackKeysWithCarrots : snackKeysNoCarrots
 
-  // We always get all translations to ensure hooks order
-  const snackTranslationMap: { [k: string]: string | null } = {
-    cookies: useI18nText('cookies', undefined, 'snacks'),
-    chips: useI18nText('chips', undefined, 'snacks'),
-    fruit: useI18nText('fruit', undefined, 'snacks'),
-    carrots: useI18nText('carrots', undefined, 'snacks'),
-  }
   // memoize expensive calculation
   const snackList = useMemo(() => fillSnackList(snackKeys), [snackKeys])
   return (
@@ -38,7 +31,7 @@ const Snacks: React.FC<RouteComponentProps> = () => {
         {snackKeys.map((k, i) => (
           <li key={`${k}-${i}`}>
             <Link to={k}>
-              <I18nText get="go-to-snack" args={{ snack: snackTranslationMap[k] }} />
+              <I18nText get={`go-to-${k}`} />
             </Link>
           </li>
         ))}
@@ -48,7 +41,11 @@ const Snacks: React.FC<RouteComponentProps> = () => {
       </div>
       <ul>
         {snackList.map((item, ix) => {
-          return <li key={ix}>{snackTranslationMap[item]}</li>
+          return (
+            <li key={ix}>
+              <I18nText get={item} />
+            </li>
+          )
         })}
       </ul>
     </I18nSection>

--- a/examples/standard/src/index.tsx
+++ b/examples/standard/src/index.tsx
@@ -16,7 +16,7 @@ appRoot.className = 'app-root'
 document.body.appendChild(appRoot)
 
 class RootWrapper extends Component<{}, { lang: string; features: FeatureFlagsObject }> {
-  state = { lang: '', features: {} }
+  state = { lang: navigator.language, features: {} }
 
   handleLangChange = (event: ChangeEvent<HTMLSelectElement>) =>
     this.setState({ lang: event.target.value })

--- a/examples/standard/src/locales/en/carrots.js
+++ b/examples/standard/src/locales/en/carrots.js
@@ -1,4 +1,4 @@
 export default `
-header = All about carrots!
-description = We like carrots; especially roasted carrots or carrots with dips!
+carrots__header = All about carrots!
+carrots__description = We like carrots; especially roasted carrots or carrots with dips!
 `

--- a/examples/standard/src/locales/en/chips.js
+++ b/examples/standard/src/locales/en/chips.js
@@ -1,4 +1,4 @@
 export default `
-header = All about chips!
-description = We like lays, doritos, and potato chips.
+chips__header = All about chips!
+chips__description = We like lays, doritos, and potato chips.
 `

--- a/examples/standard/src/locales/en/coffee.js
+++ b/examples/standard/src/locales/en/coffee.js
@@ -1,5 +1,5 @@
 export default `
-link-message = Click here to hear about coffee!
-welcome-message = Let's talk about COFFEE!!
-description = We love coffee. We drink it every day in the office.
+coffee__link-message = Click here to hear about coffee!
+coffee__welcome-message = Let's talk about COFFEE!!
+coffee__description = We love coffee. We drink it every day in the office.
 `

--- a/examples/standard/src/locales/en/cookies.js
+++ b/examples/standard/src/locales/en/cookies.js
@@ -1,4 +1,4 @@
 export default `
-header = All about cookies!
-description = We like chocolate chip cookies, sugar cookies, and oatmeal raisin cookies.
+cookies__header = All about cookies!
+cookies__description = We like chocolate chip cookies, sugar cookies, and oatmeal raisin cookies.
 `

--- a/examples/standard/src/locales/en/fruit.js
+++ b/examples/standard/src/locales/en/fruit.js
@@ -1,4 +1,4 @@
 export default `
-header = All about fruit!
-description = Fruit is amazing, especially when it's perfectly ripe.
+fruit__header = All about fruit!
+fruit__description = Fruit is amazing, especially when it's perfectly ripe.
 `

--- a/examples/standard/src/locales/en/snacks.js
+++ b/examples/standard/src/locales/en/snacks.js
@@ -1,13 +1,13 @@
 export default `
-link-message = Click here to see a list of snacks we like!
-snacks-header = We love snacks!
-snacks-desc = Here's a really long list of the snacks we like:
-cookies = cookies
-chips = chips
-fruit = fruit
-carrots = carrots
-go-to-cookies = Go to { cookies } page
-go-to-chips = Go to { chips } page
-go-to-fruit = Go to { fruit } page
-go-to-carrots = Go to { carrots } page
+snacks__link-message = Click here to see a list of snacks we like!
+snacks__snacks-header = We love snacks!
+snacks__snacks-desc = Here's a really long list of the snacks we like:
+snacks__cookies = cookies
+snacks__chips = chips
+snacks__fruit = fruit
+snacks__carrots = carrots
+snacks__go-to-cookies = Go to { snacks__cookies } page
+snacks__go-to-chips = Go to { snacks__chips } page
+snacks__go-to-fruit = Go to { snacks__fruit } page
+snacks__go-to-carrots = Go to { snacks__carrots } page
 `

--- a/examples/standard/src/locales/en/snacks.js
+++ b/examples/standard/src/locales/en/snacks.js
@@ -6,5 +6,8 @@ cookies = cookies
 chips = chips
 fruit = fruit
 carrots = carrots
-go-to-snack = Visit { $snack } page
+go-to-cookies = Go to { cookies } page
+go-to-chips = Go to { chips } page
+go-to-fruit = Go to { fruit } page
+go-to-carrots = Go to { carrots } page
 `

--- a/examples/standard/src/locales/en/terms.js
+++ b/examples/standard/src/locales/en/terms.js
@@ -1,5 +1,5 @@
 export default `
-terms-and-conditions =
+terms__terms-and-conditions =
   By navigating to this application you are agreeing to 
   absolutely nothing. There are no assumptions being made
   on your behalf without your consent. We just ask you

--- a/examples/standard/src/locales/es/carrots.js
+++ b/examples/standard/src/locales/es/carrots.js
@@ -1,5 +1,5 @@
 export default `
-header = ¡Todo sobre las zanahorias!
-description = 
+carrots__header = ¡Todo sobre las zanahorias!
+carrots__description = 
   Nos gustan las zanahorias; Especialmente zanahorias asadas o zanahorias con salsas!
 `

--- a/examples/standard/src/locales/es/chips.js
+++ b/examples/standard/src/locales/es/chips.js
@@ -1,4 +1,4 @@
 export default `
-header = ¡Todo sobre chips!
-description = Nos gustan los lays, los doritos y las papas fritas.
+chips__header = ¡Todo sobre chips!
+chips__description = Nos gustan los lays, los doritos y las papas fritas.
 `

--- a/examples/standard/src/locales/es/coffee.js
+++ b/examples/standard/src/locales/es/coffee.js
@@ -1,5 +1,5 @@
 export default `
-link-message = Haga clic aquí para escuchar sobre el café!
-welcome-message = ¡Hablemos de CAFÉ!
-description = Nos encanta el cafe Lo tomamos todos los días en la oficina.
+coffee__link-message = Haga clic aquí para escuchar sobre el café!
+coffee__welcome-message = ¡Hablemos de CAFÉ!
+coffee__description = Nos encanta el cafe Lo tomamos todos los días en la oficina.
 `

--- a/examples/standard/src/locales/es/cookies.js
+++ b/examples/standard/src/locales/es/cookies.js
@@ -1,5 +1,5 @@
 export default `
-header = ¡Todo sobre las galletas!
-description = Nos gustan las galletas con chispas de chocolate, las galletas de azúcar y
+cookies__header = ¡Todo sobre las galletas!
+cookies__description = Nos gustan las galletas con chispas de chocolate, las galletas de azúcar y
   las galletas de avena con pasas.
 `

--- a/examples/standard/src/locales/es/fruit.js
+++ b/examples/standard/src/locales/es/fruit.js
@@ -1,5 +1,5 @@
 export default `
-header = ¡Todo sobre la fruta!
-description = La fruta es increíble, especialmente cuando
+fruit__header = ¡Todo sobre la fruta!
+fruit__description = La fruta es increíble, especialmente cuando
   está perfectamente madura.
 `

--- a/examples/standard/src/locales/es/snacks.js
+++ b/examples/standard/src/locales/es/snacks.js
@@ -1,13 +1,13 @@
 export default `
-link-message = Haga clic aquí para ver una lista de los bocadillos que nos gustan!
-snacks-header = ¡Nos encantan los bocadillos!
-snacks-desc = Aquí hay una lista muy larga de los bocadillos que nos gustan:
-cookies = galletas
-chips = patatas fritas
-fruit = fruta
-carrots = zanahorias
-go-to-cookies = Ir a la página de galletas
-go-to-chips = Ir a la página de patatas fritas
-go-to-fruit = Ir a la página de frutas
-go-to-carrots = Ir a la página de zanahorias
+snacks__link-message = Haga clic aquí para ver una lista de los bocadillos que nos gustan!
+snacks__snacks-header = ¡Nos encantan los bocadillos!
+snacks__snacks-desc = Aquí hay una lista muy larga de los bocadillos que nos gustan:
+snacks__cookies = galletas
+snacks__chips = patatas fritas
+snacks__fruit = fruta
+snacks__carrots = zanahorias
+snacks__go-to-cookies = Ir a la página de galletas
+snacks__go-to-chips = Ir a la página de patatas fritas
+snacks__go-to-fruit = Ir a la página de frutas
+snacks__go-to-carrots = Ir a la página de zanahorias
 `

--- a/examples/standard/src/locales/es/snacks.js
+++ b/examples/standard/src/locales/es/snacks.js
@@ -3,8 +3,11 @@ link-message = Haga clic aquí para ver una lista de los bocadillos que nos gust
 snacks-header = ¡Nos encantan los bocadillos!
 snacks-desc = Aquí hay una lista muy larga de los bocadillos que nos gustan:
 cookies = galletas
-chips = papas fritas
+chips = patatas fritas
 fruit = fruta
 carrots = zanahorias
-go-to-snack = Visita la pagina de { $snack }
+go-to-cookies = Ir a la página de galletas
+go-to-chips = Ir a la página de patatas fritas
+go-to-fruit = Ir a la página de frutas
+go-to-carrots = Ir a la página de zanahorias
 `

--- a/examples/standard/src/locales/es/terms.js
+++ b/examples/standard/src/locales/es/terms.js
@@ -1,5 +1,5 @@
 export default `
-terms-and-conditions =
+terms__terms-and-conditions =
   Al navegar a esta aplicación, usted acepta
   absolutamente nada. No se hacen suposiciones
   en su nombre sin su consentimiento. Solo te preguntamos

--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -4,9 +4,9 @@ import { ResourceDefinition } from './types'
 
 interface Dictionary {
   /**
-   * Dictionary containing fluent bundles for each section
+   * Dictionary containing fluent bundles for each language with currently loaded sections
    */
-  [section: string]: { [lang: string]: FluentBundle }
+  [lang: string]: FluentBundle
 }
 
 export interface LoadingState {
@@ -71,7 +71,14 @@ export default abstract class BaseI18nController {
     this._supportedLangs = options.supportedLangs
     this.defaultLang = options.defaultLang
     this.setLang(options.lang || this.defaultLang)
-    _dictionaries.set(this, { global: {} })
+    const bundles = this._supportedLangs.reduce(
+      (memo, lang) => {
+        memo[lang] = new FluentBundle(lang)
+        return memo
+      },
+      {} as Dictionary
+    )
+    _dictionaries.set(this, bundles)
     this._debugMode = Boolean(options.debugMode)
 
     if (options.global === undefined) {
@@ -94,18 +101,18 @@ export default abstract class BaseI18nController {
           `Ignore this message if you have just updated the requested language.`
       )
     }
-    const bundle = new FluentBundle(lang)
+    const bundle = this._getDict()[lang]
+    if (!bundle) {
+      console.error(
+        `Attempting to set dictionary for unsupported language: ${lang} and section: ${section}`
+      )
+      return
+    }
     const errors = bundle.addResource(new FluentResource(ftl))
     if (Array.isArray(errors) && errors.length) {
       console.error(`Errors found in resource for section ${section} ${lang}`)
       console.log(errors)
     }
-    const _dict = this._getDict()
-    if (!_dict[section]) {
-      _dict[section] = {}
-    }
-    _dict[section][lang] = bundle
-
     this._loadingState[`${section}/${lang}`] = 'loaded'
   }
 
@@ -132,14 +139,14 @@ export default abstract class BaseI18nController {
     id: string
     lang?: string
   }): [(string | null), object] {
-    const _dict = this._getDict()
-    const bundles = _dict[section]
+    const bundles = this._getDict()
+    const key = section === 'global' ? id : `${section}__${id}`
     if (bundles !== undefined) {
       let languages = this._languages
       if (typeof overrideLang === 'string') {
         languages = this.negotiateLang(overrideLang)
       }
-      const lang = languages.find(l => bundles[l] && bundles[l].hasMessage(id))
+      const lang = languages.find(l => bundles[l] && bundles[l].hasMessage(key))
       const bundle = lang && bundles[lang]
       if (!bundle) {
         if (
@@ -147,13 +154,13 @@ export default abstract class BaseI18nController {
           (section !== 'global' || this._loadingState[`global/${this.defaultLang}`] === 'loaded')
         ) {
           console.warn(
-            `The requested id ${id} for section ${section} does not exist` +
+            `The requested message ${key} does not exist` +
               ` in these translations: ${this._languages.join(', ')}`
           )
         }
         return [null, {}]
       }
-      const message = bundle.getMessage(id)
+      const message = bundle.getMessage(key)
       let text: string | null = null
       let attrs: { [key: string]: string } = {}
       let errors: any[] = []

--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -201,15 +201,15 @@ export default abstract class BaseI18nController {
     return message
   }
 
-  _load(args: { lang: string; section: string }): void {
-    const { lang, section } = args
+  _load({ lang: requestedLang, section }: { lang: string; section: string }): void {
+    const [lang] = this.negotiateLang(requestedLang)
     const loadingKey = `${section}/${lang}`
     if (this._loadingState[loadingKey] !== undefined) {
       return
     }
 
     this._loadingState[loadingKey] = 'loading'
-    this.load(args)
+    this.load({ lang, section })
       .then(resourceDefs => {
         resourceDefs.forEach(resDef => {
           this.setDict(resDef.lang, section, resDef.ftl)

--- a/modules/cactus-i18n/src/Components.tsx
+++ b/modules/cactus-i18n/src/Components.tsx
@@ -15,10 +15,17 @@ const I18nProvider: React.FC<I18nProviderProps> = props => {
   if (!(controller instanceof BaseI18nController)) {
     throw Error('I18nProvider must be given a controller which extends BaseI18nController')
   }
-  // TODO remove reference to navigator.language to make platform agnostic
-  const lang = props.lang || navigator.language
-  let i18nContext: I18nContextType | null = null
+  if (typeof props.lang === 'string') {
+    controller.setLang(props.lang)
+  }
+  const lang = controller.lang
   let [loadingState, setLoading] = useState({})
+  let i18nContext: I18nContextType | null = {
+    controller: controller,
+    lang,
+    section: 'global',
+    loadingState,
+  }
   useEffect(() => {
     if (controller instanceof BaseI18nController) {
       controller.addListener(setLoading)
@@ -30,15 +37,6 @@ const I18nProvider: React.FC<I18nProviderProps> = props => {
       controller._load({ lang, section: 'global' })
     }
   }, [controller, lang])
-  if (controller instanceof BaseI18nController) {
-    controller.setLang(lang)
-    i18nContext = {
-      controller: controller,
-      lang,
-      section: 'global',
-      loadingState,
-    }
-  }
   return (
     <I18nContext.Provider value={i18nContext}>
       <React.Fragment>{props.children}</React.Fragment>

--- a/modules/cactus-i18n/src/Components.tsx
+++ b/modules/cactus-i18n/src/Components.tsx
@@ -15,6 +15,7 @@ const I18nProvider: React.FC<I18nProviderProps> = props => {
   if (!(controller instanceof BaseI18nController)) {
     throw Error('I18nProvider must be given a controller which extends BaseI18nController')
   }
+  // TODO remove reference to navigator.language to make platform agnostic
   const lang = props.lang || navigator.language
   let i18nContext: I18nContextType | null = null
   let [loadingState, setLoading] = useState({})

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -157,6 +157,23 @@ key-for-no-people = blah blah blue stew`
       expect(controller.getText({ id: 'key_for_the_people' })).toBe('Nosotros somos personas!')
     })
 
+    test('should only attempt to load supported languages', () => {
+      const global = `
+key_for_the_people = We are the people!
+  .aria-label=anything { $value }
+  .name=test
+key-for-no-people = blah blah blue stew`
+      const controller = new I18nController({
+        defaultLang: 'en',
+        supportedLangs: ['en', 'es'],
+        global,
+      })
+      // @ts-ignore
+      controller.load = jest.fn(args => MockPromise.resolve([{ lang: 'en', ftl: global }]))
+      controller._load({ lang: 'de-DE', section: 'global' })
+      expect(controller.load).not.toBeCalled()
+    })
+
     describe('with mocked console.error and console.warn', () => {
       let _error: any
       let _warn: any

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -182,7 +182,7 @@ key-for-no-people = blah blah blue stew`
         })
         expect(i18nController.get({ id: 'bogogo' })).toEqual([null, {}])
         expect(console.warn).toHaveBeenCalledWith(
-          `The requested id bogogo for section global does not exist in these translations: es, en`
+          `The requested message bogogo does not exist in these translations: es, en`
         )
       })
 
@@ -196,7 +196,7 @@ key-for-no-people = blah blah blue stew`
         })
         expect(i18nController.get({ section: 'foobar', id: 'bogogo' })).toEqual([null, {}])
         expect(console.warn).toHaveBeenCalledWith(
-          `The requested section foobar does not exist when requesting id bogogo`
+          `The requested message foobar__bogogo does not exist in these translations: en`
         )
       })
 
@@ -239,7 +239,7 @@ key-for-no-people = blah blah blue stew`
         const sectionPromise = MockPromise.resolve([
           {
             lang: 'en-US',
-            ftl: `runny-nose = This text should render`,
+            ftl: `kleenex__runny-nose = This text should render`,
           },
         ])
         //@ts-ignore
@@ -267,7 +267,7 @@ key-for-no-people = blah blah blue stew`
           global: `runny-nose = WRONG KEY`,
         })
         const globalPromise = MockPromise.resolve([{ lang: 'en', ftl: `runny-nose = WRONG KEY` }])
-        const sectionPromise = MockPromise.resolve([
+        const esGlobalPromise = MockPromise.resolve([
           {
             lang: 'es',
             ftl: `runny-nose = This text should render`,
@@ -275,7 +275,7 @@ key-for-no-people = blah blah blue stew`
         ])
         //@ts-ignore
         controller.load = jest.fn(({ section, lang }) =>
-          lang === 'en' ? globalPromise : sectionPromise
+          lang === 'en' ? globalPromise : esGlobalPromise
         )
         const { container } = render(
           <I18nProvider controller={controller}>
@@ -286,7 +286,7 @@ key-for-no-people = blah blah blue stew`
         )
         act(() => {
           globalPromise._call()
-          sectionPromise._call()
+          esGlobalPromise._call()
         })
         expect(container).toHaveTextContent('This text should render')
       })
@@ -328,7 +328,7 @@ key-for-no-people = blah blah blue stew`
         supportedLangs: ['en-US'],
         global,
       })
-      controller.setDict('en-US', 'kleenex', `key_for_the_people = We are NOT the people!`)
+      controller.setDict('en-US', 'kleenex', `kleenex__key_for_the_people = We are NOT the people!`)
       let container
       act(() => {
         let tester = render(
@@ -516,7 +516,7 @@ key-for-the-group = We are the { $groupName }!
 
     test('allows overriding section for text', () => {
       const global = `key-for-the-group= We are the { $groupName }!`
-      const simple = `key-for-the-group = We are the simple people!`
+      const simple = `simple__key-for-the-group = We are the simple people!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
@@ -589,7 +589,7 @@ key-for-the-group= We are the { $groupName }!
         supportedLangs: ['en-US'],
         global,
       })
-      controller.setDict('en-US', 'other', 'key-for-the-group = We are the OTHER people!')
+      controller.setDict('en-US', 'other', 'other__key-for-the-group = We are the OTHER people!')
       const TestI18nResource = () => {
         const [text, attrs] = useI18nResource('key-for-the-group', undefined, 'other')
         return (

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -250,12 +250,10 @@ key-for-no-people = blah blah blue stew`
           supportedLangs: ['en', 'en-US'],
           global: `runny-nose = WRONG KEY`,
         })
-        const globalPromise = MockPromise.resolve([
-          { lang: 'en-US', ftl: `runny-nose = WRONG KEY` },
-        ])
+        const globalPromise = MockPromise.resolve([{ lang: 'en', ftl: `runny-nose = WRONG KEY` }])
         const sectionPromise = MockPromise.resolve([
           {
-            lang: 'en-US',
+            lang: 'en',
             ftl: `kleenex__runny-nose = This text should render`,
           },
         ])


### PR DESCRIPTION
* docs(examples): use more idiomatic fluent translations
* feat(cactus-i18n): merge sections into a single bundle per language
* feat(cactus-i18n): only load supported languages
* feat(cactus-i18n): make i18n library platform agnostic

BREAKING: 
* all keys in a given section must be prefixed with the pattern:
`<section>__<id>` so that there are no conflicts when merging the resources into
the single bundle.
* The I18nProvider will no longer use navigator.language internally to
ensure cross platform usage. Therefore, any DOM usage should provide the
navigator.language as the initial value for I18nProvider lang prop.
