### PR TITLE
feat(cactus-i18n): allow choosing to use isolating char

### DIFF
--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -41,6 +41,12 @@ interface I18nControllerOptions {
 
   /** Flag for displaying error messages. Default is false */
   debugMode?: boolean
+
+  /**
+   * Flag to disable bidi isolating unicode characters.
+   * @default = true
+   */
+  useIsolating?: boolean
 }
 
 const _dictionaries = new WeakMap<BaseI18nController, Dictionary>()
@@ -68,12 +74,15 @@ export default abstract class BaseI18nController {
       throw new Error('The default language provided is not a supported language')
     }
 
+    const useIsolating = options.hasOwnProperty('useIsolating')
+      ? Boolean(options.useIsolating)
+      : true
     this._supportedLangs = options.supportedLangs
     this.defaultLang = options.defaultLang
     this.setLang(options.lang || this.defaultLang)
     const bundles = this._supportedLangs.reduce(
       (memo, lang) => {
-        memo[lang] = new FluentBundle(lang)
+        memo[lang] = new FluentBundle(lang, { useIsolating })
         return memo
       },
       {} as Dictionary

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -157,6 +157,31 @@ key-for-no-people = blah blah blue stew`
       expect(controller.getText({ id: 'key_for_the_people' })).toBe('Nosotros somos personas!')
     })
 
+    test('defaults to use bidi isolating', () => {
+      const global = `for-all-to-see = You can't see why this fails { $foo }`
+      const controller = new I18nController({
+        defaultLang: 'en',
+        supportedLangs: ['en', 'es'],
+        global,
+      })
+      expect(controller.getText({ id: 'for-all-to-see', args: { foo: 'bar' } })).toBe(
+        `You can't see why this fails \u2068bar\u2069`
+      )
+    })
+
+    test('can disabled bidi isolating characters', () => {
+      const global = `for-all-to-see = No hidden characters here { $foo }`
+      const controller = new I18nController({
+        defaultLang: 'en',
+        supportedLangs: ['en', 'es'],
+        global,
+        useIsolating: false,
+      })
+      expect(controller.getText({ id: 'for-all-to-see', args: { foo: 'bar' } })).toBe(
+        'No hidden characters here bar'
+      )
+    })
+
     test('should only attempt to load supported languages', () => {
       const global = `
 key_for_the_people = We are the people!


### PR DESCRIPTION
Will allow disabling the isolating characters `U+2068` and `U+2069` in Windows until it has support.