### PR TITLE
feat(cactus-i18n): restrict logging to debugMode only

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,5 +41,19 @@ jobs:
       - name: Build cactus-web
         run: yarn web build
 
-      - name: Test Packages
-        run: yarn run test:ci
+      - name: Test Modules
+        run: |
+          yarn theme test:ci
+          yarn fwk test:ci
+          yarn i18n test:ci
+          yarn icons test:ci
+          yarn web test:ci
+
+      - name: Integration Tests
+        run: |
+          yarn w standard test:ci
+          yarn w theme-components test:ci
+          yarn w mock-ebpp test:ci
+
+      - name: Test Docs Website
+        run: yarn docs test:ci

--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -111,14 +111,14 @@ export default abstract class BaseI18nController {
       )
     }
     const bundle = this._getDict()[lang]
-    if (!bundle) {
+    if (this._debugMode && !bundle) {
       console.error(
         `Attempting to set dictionary for unsupported language: ${lang} and section: ${section}`
       )
       return
     }
     const errors = bundle.addResource(new FluentResource(ftl))
-    if (Array.isArray(errors) && errors.length) {
+    if (this._debugMode && Array.isArray(errors) && errors.length) {
       console.error(`Errors found in resource for section ${section} ${lang}`)
       console.log(errors)
     }
@@ -232,6 +232,24 @@ export default abstract class BaseI18nController {
           console.error(`FTL Resource ${lang}/${section} failed to load:`, error)
         }
       })
+  }
+
+  hasText({
+    section = 'global',
+    id,
+    lang,
+  }: {
+    section?: string
+    id: string
+    lang?: string
+  }): boolean {
+    const key = section === 'global' ? id : `${section}__${id}`
+    const bundles = this._getDict()
+    let languages = this._languages
+    if (typeof lang === 'string') {
+      languages = this.negotiateLang(lang)
+    }
+    return languages.some(l => bundles[l] && bundles[l].hasMessage(key))
   }
 
   hasLoaded(section: string, lang?: string) {

--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -97,7 +97,10 @@ export default abstract class BaseI18nController {
     }
   }
 
-  abstract load({ lang, section }: { lang: string; section: string }): Promise<ResourceDefinition[]>
+  abstract load(
+    { lang, section }: { lang: string; section: string },
+    extra: { [key: string]: any }
+  ): Promise<ResourceDefinition[]>
 
   _getDict(): Dictionary {
     return _dictionaries.get(this) || {}
@@ -210,7 +213,10 @@ export default abstract class BaseI18nController {
     return message
   }
 
-  _load({ lang: requestedLang, section }: { lang: string; section: string }): void {
+  _load(
+    { lang: requestedLang, section }: { lang: string; section: string },
+    extra: { [key: string]: any } = {}
+  ): void {
     const [lang] = this.negotiateLang(requestedLang)
     const loadingKey = `${section}/${lang}`
     if (this._loadingState[loadingKey] !== undefined) {
@@ -218,7 +224,7 @@ export default abstract class BaseI18nController {
     }
 
     this._loadingState[loadingKey] = 'loading'
-    this.load({ lang, section })
+    this.load({ lang, section }, extra)
       .then(resourceDefs => {
         resourceDefs.forEach(resDef => {
           this.setDict(resDef.lang, section, resDef.ftl)

--- a/modules/cactus-i18n/src/hooks.ts
+++ b/modules/cactus-i18n/src/hooks.ts
@@ -25,18 +25,3 @@ export const useI18nResource = (
   const { controller, section, lang } = context
   return controller.get({ args, section: sectionOverride || section, id, lang })
 }
-
-export const useI18nContext = (section?: string, lang?: string) => {
-  const context = useContext(I18nContext)
-  if (context === null) {
-    return null
-  }
-  const newContext = { ...context }
-  if (section) {
-    newContext.section = section
-  }
-  if (lang) {
-    newContext.lang = lang
-  }
-  return newContext
-}

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -416,6 +416,43 @@ key-for-no-people = blah blah blue stew`
       })
       expect(container).toHaveTextContent('This text should render')
     })
+
+    test('will load extra dependencies with custom props', () => {
+      const controller = new I18nController({
+        defaultLang: 'en',
+        supportedLangs: ['en', 'en-US'],
+        global: `runny-nose = WRONG KEY`,
+      })
+      const kleenexPromise = MockPromise.resolve([
+        {
+          lang: 'en',
+          ftl: `kleenex__runny-nose = { needed__runny-nose }`,
+        },
+      ])
+      const neededPromise = MockPromise.resolve([
+        {
+          lang: 'en',
+          ftl: `needed__runny-nose = This text should render`,
+        },
+      ])
+      //@ts-ignore
+      controller.load = jest.fn(({ section }) =>
+        section === 'needed' ? neededPromise : kleenexPromise
+      )
+
+      const i18nDependencies = [{ section: 'needed', extra: 'data', for: 'load function' }]
+      const { container } = render(
+        <I18nProvider controller={controller}>
+          <I18nSection name="kleenex" dependencies={i18nDependencies}>
+            <I18nText get="runny-nose" />
+          </I18nSection>
+        </I18nProvider>
+      )
+      expect(controller.load).toHaveBeenCalledWith(
+        { section: 'needed', lang: 'en' },
+        { extra: 'data', for: 'load function' }
+      )
+    })
   })
 
   describe('<I18nText />', () => {

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -242,6 +242,19 @@ key-for-no-people = blah blah blue stew`
         )
       })
 
+      test('can check for existing messages', () => {
+        const global = `this_is_the_key = This should render`
+        const i18nController = new I18nController({
+          defaultLang: 'en',
+          supportedLangs: ['en'],
+          global,
+          debugMode: true,
+        })
+        expect(i18nController.hasText({ id: 'this_is_the_key' })).toEqual(true)
+        expect(i18nController.hasText({ section: 'other', id: 'not' })).toEqual(false)
+        expect(console.warn).not.toHaveBeenCalled()
+      })
+
       test('keeps track of failed resources', () => {
         const globalPromise = MockPromise.reject(Error('failed to load requested resource'))
         const mockLoad = jest.fn((...args) => globalPromise)


### PR DESCRIPTION
* removes all logging when not in debug mode
* allows extra properties to be passed via `I18nSection` to the controller.load function
* allows adding dependencies to an `I18nSection`

[CACTUS-232]
[CACTUS-233]

[CACTUS-232]: https://repayonline.atlassian.net/browse/CACTUS-232
[CACTUS-233]: https://repayonline.atlassian.net/browse/CACTUS-233