### PR TITLE
fix(cactus-i18n): Add plural rules polyfill to support IE11

### DIFF
--- a/modules/cactus-i18n/package.json
+++ b/modules/cactus-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repay/cactus-i18n",
-  "version": "0.3.6",
+  "version": "0.3.8",
   "description": "I18n library for React using Fluent",
   "main": "dist/cactus-i18n.cjs.js",
   "module": "dist/cactus-i18n.js",
@@ -55,7 +55,8 @@
   },
   "dependencies": {
     "@fluent/bundle": "^0.14.0",
-    "@fluent/langneg": "^0.3.0"
+    "@fluent/langneg": "^0.3.0",
+    "intl-pluralrules": "^1.1.2"
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",

--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -1,6 +1,7 @@
 import { FluentBundle, FluentResource } from '@fluent/bundle'
 import { negotiateLanguages } from '@fluent/langneg'
 import { ResourceDefinition } from './types'
+import 'intl-pluralrules'
 
 interface Dictionary {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -9996,6 +9996,13 @@ interpret@^1.0.0, interpret@^1.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
+intl-pluralrules@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/intl-pluralrules/-/intl-pluralrules-1.1.2.tgz#0b5cd83001792b5088140f8bb5505c9f2d580277"
+  integrity sha512-awT+Y/f7ftsg8IUfxRotCYFnDdmpFJQqud1jkOw8RAOUjslbhSC+xJoG4pqj/X8casKgAlQttnsbQP3R0BICyQ==
+  dependencies:
+    make-plural "^6.1.0"
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -11791,6 +11798,11 @@ make-dir@^3.0.0:
   integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
   dependencies:
     semver "^6.0.0"
+
+make-plural@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-6.1.0.tgz#490b381874b7c454bace11b23b899809b95b9e8b"
+  integrity sha512-0ekbPHqxcdRcmjZ43TkRuejK5rXgMF1OjG4FVnVHgCvOcjrexaSX7a0dfAvqhOm1qWPgjYnXtmz3cHpHW5ZewA==
 
 makeerror@1.0.x:
   version "1.0.11"


### PR DESCRIPTION
This fixes a bug in IE11 where pluralized translations aren't working. Need to get this merged ASAP