### PR TITLE
test(): Jack up jest timeout for integration tests

### DIFF
--- a/examples/mock-ebpp/tests/integration.test.ts
+++ b/examples/mock-ebpp/tests/integration.test.ts
@@ -42,6 +42,7 @@ describe('Integration Tests', () => {
       })
 
       test('should fill out and submit the entire form', async () => {
+        jest.setTimeout(25000)
         const doc = await getDocument(page)
         const actions = new Actions(doc, page)
 


### PR DESCRIPTION
I'm not 100% sure that this will fix the problem, but I did manage to get the integration tests to pass four times in a row with this timeout. We'll have to see how things go with this over the next couple of weeks or so.