### PR TITLE
Extend Theme Generator Options

### DIFF
--- a/modules/cactus-theme/src/theme.ts
+++ b/modules/cactus-theme/src/theme.ts
@@ -43,6 +43,12 @@ export type TextStyle = {
   lineHeight: string
 }
 
+type BorderSize = 'thin' | 'thick'
+
+type Shape = 'square' | 'intermediate' | 'round'
+
+type Font = 'Helvetica Neue' | 'Helvetica' | 'Arial'
+
 export interface CactusTheme {
   breakpoints?: Array<String>
   mediaQueries?: {
@@ -105,6 +111,10 @@ export interface CactusTheme {
     warning: ColorStyle
     disable: ColorStyle
   }
+  border: BorderSize
+  shape: Shape
+  font: String
+  boxShadows: Boolean
 }
 
 export type CactusColor = Exclude<keyof CactusTheme['colors'], 'status'>
@@ -117,7 +127,14 @@ let lightGray = `hsl(0, 0%, 90%)`
 let mediumGray = `hsl(0, 0%, 70%)`
 let darkGray = `hsl(0, 0%, 50%)`
 
-type HueGeneratorOptions = {
+type SharedGeneratorOptions = {
+  border?: BorderSize
+  shape?: Shape
+  font?: Font
+  boxShadows?: Boolean
+}
+
+interface HueGeneratorOptions extends SharedGeneratorOptions {
   primaryHue: number
 }
 
@@ -233,7 +250,7 @@ function fromHue({
   ]
 }
 
-type TwoColorGeneratorOptions = {
+interface TwoColorGeneratorOptions extends SharedGeneratorOptions {
   primary: string
   secondary?: string
 }
@@ -547,7 +564,13 @@ function isHue(options: GeneratorOptions): options is HueGeneratorOptions {
   return (options as HueGeneratorOptions).primaryHue != null
 }
 
-const repayOptions: GeneratorOptions = { primaryHue: 200 }
+const repayOptions: GeneratorOptions = {
+  primaryHue: 200,
+  border: 'thick',
+  shape: 'round',
+  font: 'Helvetica',
+  boxShadows: true,
+}
 
 export function generateTheme(options: GeneratorOptions = repayOptions): CactusTheme {
   const [colors, colorStyles] = isHue(options) ? fromHue(options) : fromTwoColor(options)
@@ -566,12 +589,23 @@ export function generateTheme(options: GeneratorOptions = repayOptions): CactusT
   iconSizes.medium = iconSizes[2]
   iconSizes.large = iconSizes[3]
 
+  const { border = 'thick', shape = 'round', font = 'Helvetica', boxShadows = true } = options
+  const fontOptions: Font[] = ['Helvetica', 'Helvetica Neue', 'Arial']
+
+  fontOptions.sort((x: Font, y: Font) => {
+    return x === font ? -1 : y === font ? 1 : 0
+  })
+
   return {
     colors,
     colorStyles,
     space: [0, 2, 4, 8, 16, 24, 32, 40],
     fontSizes,
     iconSizes,
+    border,
+    shape,
+    font: `${fontOptions.join(', ')}, sans-serif`,
+    boxShadows,
     textStyles: {
       tiny: {
         fontSize: '12.5px',

--- a/modules/cactus-theme/tests/theme.test.ts
+++ b/modules/cactus-theme/tests/theme.test.ts
@@ -90,4 +90,36 @@ describe('@repay/cactus-theme', () => {
   )
 
   themeAccessibility('two dark colors', generateTheme({ primary: '#133337', secondary: '#AC101D' }))
+
+  test('can generate a theme with custom borders', () => {
+    const theme = generateTheme({ primaryHue: 200, border: 'thin' })
+    expect(theme).toMatchObject({
+      ...cactusTheme,
+      border: 'thin',
+    })
+  })
+
+  test('can generate a theme with custom shape', () => {
+    const theme = generateTheme({ primaryHue: 200, shape: 'square' })
+    expect(theme).toMatchObject({
+      ...cactusTheme,
+      shape: 'square',
+    })
+  })
+
+  test('can generate a theme with custom font', () => {
+    const theme = generateTheme({ primaryHue: 200, font: 'Arial' })
+    expect(theme).toMatchObject({
+      ...cactusTheme,
+      font: 'Arial, Helvetica, Helvetica Neue, sans-serif',
+    })
+  })
+
+  test('can generate a theme with no box-shadow', () => {
+    const theme = generateTheme({ primaryHue: 200, boxShadows: false })
+    expect(theme).toMatchObject({
+      ...cactusTheme,
+      boxShadows: false,
+    })
+  })
 })

--- a/modules/cactus-web/cactus-addon/register.jsx
+++ b/modules/cactus-web/cactus-addon/register.jsx
@@ -22,6 +22,10 @@ class Panel extends React.Component {
       type: THEME_TYPES.use_hue,
       primary: '#96D35F',
       secondary: '#FFFFFF',
+      border: 'thick',
+      shape: 'round',
+      font: 'Helvetica',
+      boxShadows: true,
     },
     backgroundInverse: false,
   }
@@ -42,12 +46,17 @@ class Panel extends React.Component {
 
   emitThemeChange = () => {
     const { values } = this.state
-    this.props.channel.emit(
-      THEME_CHANGE,
+    const colors =
       values.type === THEME_TYPES.use_hue
         ? { primaryHue: values.primaryHue }
         : { primary: values.primary, secondary: values.secondary }
-    )
+    this.props.channel.emit(THEME_CHANGE, {
+      border: values.border,
+      shape: values.shape,
+      font: values.font,
+      boxShadows: values.boxShadows,
+      ...colors,
+    })
   }
 
   handleDecoratorListening = () => {
@@ -150,6 +159,73 @@ class Panel extends React.Component {
               </Form.Field>
             </React.Fragment>
           )}
+          <Form.Field>
+            <label htmlFor="border" style={{ display: 'block' }}>
+              Border Width
+            </label>
+            <select
+              id="border"
+              name="border"
+              onChange={({ currentTarget }) => {
+                this.handleThemeChange('border', currentTarget.value)
+              }}
+              value={values.border}
+              style={{ marginLeft: '8px' }}
+            >
+              <option value="thin">Thin</option>
+              <option value="thick">Thick</option>
+            </select>
+          </Form.Field>
+          <Form.Field>
+            <label htmlFor="shape" style={{ display: 'block' }}>
+              Component Shape
+            </label>
+            <select
+              id="shape"
+              name="shape"
+              onChange={({ currentTarget }) => {
+                this.handleThemeChange('shape', currentTarget.value)
+              }}
+              value={values.shape}
+              style={{ marginLeft: '8px' }}
+            >
+              <option value="square">Square</option>
+              <option value="intermediate">Intermediate</option>
+              <option value="round">Round</option>
+            </select>
+          </Form.Field>
+          <Form.Field>
+            <label htmlFor="shape" style={{ display: 'block' }}>
+              Font
+            </label>
+            <select
+              id="font"
+              name="font"
+              onChange={({ currentTarget }) => {
+                this.handleThemeChange('font', currentTarget.value)
+              }}
+              value={values.font}
+              style={{ marginLeft: '8px' }}
+            >
+              <option value="Helvetica Neue">Helvetica Neue</option>
+              <option value="Helvetica">Helvetica</option>
+              <option value="Arial">Arial</option>
+            </select>
+          </Form.Field>
+          <Form.Field>
+            <input
+              id="boxShadows"
+              name="boxShadows"
+              type="checkbox"
+              onChange={({ currentTarget }) => {
+                this.handleThemeChange('boxShadows', currentTarget.checked)
+              }}
+              checked={values.boxShadows}
+            />
+            <label htmlFor="shape" style={{ display: 'block' }}>
+              Box Shadows
+            </label>
+          </Form.Field>
 
           <SectionTitle>Background</SectionTitle>
           <Form.Field>

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -96,7 +96,7 @@
     "@reach/utils": "^0.5.0",
     "@reach/visually-hidden": "^0.5.0",
     "@repay/cactus-icons": "^0.6.1",
-    "@repay/cactus-theme": "^0.4.5",
+    "@repay/cactus-theme": "^0.4.6",
     "lodash": "^4.17.15",
     "react-live": "^2.2.2",
     "styled-system": "^5.1.1"


### PR DESCRIPTION
I added the following new options to the theme generator:
- border
- shape
- font
- boxShadows

Each of these are optional, so if you don't pass any values for them, they'll default to the values for the cactus theme. For the fonts, I wanted to make sure we still have fallback fonts available, so I basically just made sure to put whatever font is chosen at the front of the comma-separated list of fonts. That way, the chosen font will be the first font the browser looks for, but if it's not there, we can still fall back to one of the other fonts we have set.

These changes are a little weird to test since these properties aren't actually being used yet, but if you want to do some local testing just for sanity's sake, you can add some console logs in a component's css like so:
```
${p => {
  console.log(p.theme.border)
  console.log(p.theme.shape)
  console.log(p.theme.font)
  console.log(p.theme.boxShadows)
}}
```
Then, you can build the theme with `yarn theme build`. Now, bring the component you modified up in Storybook, open the "Cactus Theme" knob section, and change some of their values. You should see the values you set reflected in the console logs.
