### PR TITLE
CACTUS-259 Fix Modal Render Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/node_modules
 *.log
+*.swp
 **/dist
 **/coverage
 .cache

--- a/modules/cactus-web/src/Modal/Modal.mdx
+++ b/modules/cactus-web/src/Modal/Modal.mdx
@@ -16,7 +16,7 @@ import { livePreviewStyle } from '../helpers/constants'
 
 # Modal
 
-The `Modal` component is usefull when an action from the user is required, and no other interaction
+The `Modal` component is useful when an action from the user is required, and no other interaction
 on the web page is permited until the modal is closed.
 
 ### Try it out
@@ -61,6 +61,8 @@ These actions are one two: Cancel what is requested to do or confirm it. After a
 those actions is performed, the modal closes. You can also render children inside the modal, for example a `TextInput`, to capture users data.
 Also, the modal has two variants, danger and action. Danger is useful when the user should confirm something that cannot be undone, and thus a double confirmation is requested.
 Action is useful when the user is requested to confirm an action that is not harmful, or when additional data is needed.
+
+Using the `height` prop is not recommended, especially as a percentage, since it can look strange on small screens. The `width` prop is a little more forgiving, but you should still take care to ensure your content can look good on your users' devices.
 
 ## Basic usage
 

--- a/modules/cactus-web/src/Modal/Modal.story.tsx
+++ b/modules/cactus-web/src/Modal/Modal.story.tsx
@@ -30,7 +30,7 @@ const ModalWithState = () => {
   const variant = select('variant', statusOptions, statusOptions.action)
   const buttonText = text('Button Text', 'Confirm')
   const width = text('Width', '30%')
-  const height = text('Height', '55%')
+  const height = text('Height', '')
   const modalLabel = text('Modal Label', 'Modal Label')
   const closeLabel = text('Close icon label', 'Close Label')
 
@@ -63,7 +63,7 @@ const ModalWithTextInput = () => {
   const variant = select('variant', statusOptions, statusOptions.action)
   const buttonText = text('Button Text', 'Confirm')
   const width = text('Width', '30%')
-  const height = text('Height', '55%')
+  const height = text('Height', '')
   const modalLabel = text('Modal Label', 'Modal Label')
   const closeLabel = text('Close icon label', 'Close Label')
 

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -67,6 +67,7 @@ const Modalbase: FunctionComponent<ModalProps & IconComponentProps> = props => {
     icon,
     ...rest
   } = props
+  const hasChildren = variant === 'action' && !!React.Children.count(children)
 
   return (
     <ModalPopUp
@@ -80,7 +81,7 @@ const Modalbase: FunctionComponent<ModalProps & IconComponentProps> = props => {
         <IconButton iconSize="small" onClick={closeModal} label={closeLabel}>
           <NavigationClose />
         </IconButton>
-        <Flex flexDirection="column" alignItems="center" height="100%">
+        <Flex flexDirection="column" flexWrap="nowrap" alignItems="center" height="100%">
           <Icon variant={variant} icon={icon} />
           <Text as="h1" marginBottom="0">
             {modalTitle}
@@ -88,8 +89,8 @@ const Modalbase: FunctionComponent<ModalProps & IconComponentProps> = props => {
           <Text as="h3" fontWeight="normal" margin="0">
             {description}
           </Text>
-          <div className="children">{variant === 'action' && children}</div>
-          <Flex justifyContent="center" width="90%" marginTop="auto">
+          {hasChildren && <div className="children">{children}</div>}
+          <Flex justifyContent="center" width="90%" marginTop="16px">
             <Button variant={variant} onClick={onClick} marginRight="16px">
               {buttonText}
             </Button>
@@ -133,9 +134,10 @@ export const ModalPopUp = styled(DialogOverlay)<ModalProps>`
     border: 1px solid ${baseColor};
     display: block;
     min-width: 30%;
-    min-height: 40%;
+    min-height: 20%;
     width: ${p => p.width};
     height: ${p => p.height};
+    overflow: auto;
   }
   ${IconButton} {
     position: absolute;
@@ -151,6 +153,7 @@ const Icon = styled(IconBase)`
   box-sizing: border-box;
   width: 60px;
   height: 60px;
+  min-height: 60px;
   border-radius: 50%;
   display: flex;
   justify-content: center;
@@ -184,7 +187,6 @@ Modal.defaultProps = {
   modalLabel: 'Modal Label',
   closeLabel: 'Close Label',
   width: '30%',
-  height: '30%',
   isOpen: false,
 }
 export default Modal

--- a/modules/cactus-web/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/modules/cactus-web/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -79,19 +79,19 @@ exports[`Modal is open when isOpen=true snapshot 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
 }
 
 .c9 {
   box-sizing: border-box;
   width: 90%;
-  margin-top: auto;
+  margin-top: 16px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -236,9 +236,9 @@ exports[`Modal is open when isOpen=true snapshot 1`] = `
   border: 1px solid hsl(200,96%,35%);
   display: block;
   min-width: 30%;
-  min-height: 40%;
+  min-height: 20%;
   width: 30%;
-  height: 30%;
+  overflow: auto;
 }
 
 .c0 .c1 {
@@ -255,6 +255,7 @@ exports[`Modal is open when isOpen=true snapshot 1`] = `
   box-sizing: border-box;
   width: 60px;
   height: 60px;
+  min-height: 60px;
   border-radius: 50%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -295,7 +296,6 @@ exports[`Modal is open when isOpen=true snapshot 1`] = `
           aria-label="Modal Label"
           class="c0"
           data-reach-dialog-overlay=""
-          height="30%"
           variant="action"
           width="30%"
         >
@@ -355,9 +355,6 @@ exports[`Modal is open when isOpen=true snapshot 1`] = `
               >
                 Modal Description
               </h3>
-              <div
-                class="children"
-              />
               <div
                 class="c9"
                 display="flex"


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-259

The main issue, it turns out, was simply that it's a bad idea to specify the height of the modal. It works much better if the modal auto-sizes, and then the user can scroll the entire page if it's too tall: most of the changes were to make the modal look better when there's no height specified. Still, I didn't want to remove the option entirely, so I also added overflow scrollbars. That's really not recommended, though, since the scrollbars turn the nice rounded corners into right angles, and I don't know of any way to prevent that.

There are a quite a few changes here:
* Updated Storybook so there is no default height.
* Added `nowrap` to the primary modal content, so it will always be rendered in a single column.
* Hide the `children` div if there are no children.
* Added a specific margin on the row of buttons.
* Changed the `min-height` to 20% to reduce chance of excess whitespace when there's no title/description.
* Added `overflow: auto` so that if all the other changes fail, the contents will still render inside the modal.
* Added a `min-height` on the icon so it won't get squished.

### Testing
Go to the storybook for `Modal` and play around with it. Try different screen sizes, and resizing the browser window. Try adding an explicit height (as a percentage), and try it all again. You may get an ugly scrollbar, but you should never see the the content outside the modal.