### PR TITLE
feat(cactus-i18n): i18nContext importable from @repay/cactus-i18n

### DIFF
--- a/modules/cactus-i18n/src/index.ts
+++ b/modules/cactus-i18n/src/index.ts
@@ -6,6 +6,6 @@ export {
   I18nResource,
   I18nText,
 } from './Components'
-export { useI18nText, useI18nResource } from './hooks'
+export { useI18nText, useI18nResource, I18nContext } from './hooks'
 export { default as BaseI18nController } from './BaseI18nController'
 export * from './types'

--- a/modules/cactus-i18n/tests/__snapshots__/exports.test.ts.snap
+++ b/modules/cactus-i18n/tests/__snapshots__/exports.test.ts.snap
@@ -10,6 +10,7 @@ Array [
   "I18nText",
   "useI18nText",
   "useI18nResource",
+  "I18nContext",
   "BaseI18nController",
 ]
 `;


### PR DESCRIPTION
The i18nContext can now be imoorted from @repay/cactus-i18n like import {i18nContext} from
'@repay/cactus-i18n'

[CACTUS-254]

[CACTUS-254]: https://repayonline.atlassian.net/browse/CACTUS-254