### PR TITLE
Update cactus-web dependencies

### DIFF
--- a/examples/mock-ebpp/package.json
+++ b/examples/mock-ebpp/package.json
@@ -57,7 +57,7 @@
     "@reach/router": "^1.2.1",
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.5.0",
-    "@repay/cactus-web": "^0.7.4",
+    "@repay/cactus-web": "^0.8.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   }

--- a/examples/standard/package.json
+++ b/examples/standard/package.json
@@ -19,7 +19,7 @@
     "@repay/cactus-i18n": "^0.3.11",
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.5.0",
-    "@repay/cactus-web": "^0.7.4",
+    "@repay/cactus-web": "^0.8.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2"
   },

--- a/examples/theme-components/package.json
+++ b/examples/theme-components/package.json
@@ -25,7 +25,7 @@
     "@reach/router": "^1.2.1",
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.5.0",
-    "@repay/cactus-web": "^0.7.0",
+    "@repay/cactus-web": "^0.8.0",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "styled-components": "^4.1.2"

--- a/website/package.json
+++ b/website/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@repay/cactus-icons": "^0.6.1",
     "@repay/cactus-theme": "^0.5.0",
-    "@repay/cactus-web": "^0.7.0",
+    "@repay/cactus-web": "^0.8.0",
     "normalize.css": "^8.0.1",
     "prismjs": "^1.16.0",
     "react": "^16.10.2",


### PR DESCRIPTION
Same as the last one, but for cactus-web.  Should be easy-peasy, since none of our actual packages depend on cactus-web.  Just docs/examples.