### PR TITLE
CACTUS-255 :: StatusMessage Style Update

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -112,9 +112,11 @@ function AccessibleFieldBase(props: AccessibleFieldProps) {
           status,
         })}
       {status !== undefined && (
-        <StatusMessage status={status} id={statusId}>
-          {statusMessage}
-        </StatusMessage>
+        <div>
+          <StatusMessage status={status} id={statusId}>
+            {statusMessage}
+          </StatusMessage>
+        </div>
       )}
     </FieldWrapper>
   )

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -34,7 +34,7 @@ interface AccessibleFieldProps extends MarginProps, WidthProps {
   children: JSX.Element | RenderFunc
 }
 
-export interface ExtAccessibleFieldProps extends Omit<AccessibleFieldProps, 'children'> {}
+export interface ExtAccessibleFieldProps extends Omit<AccessibleFieldProps, 'children'> { }
 
 export function useAccessibleField({
   id,
@@ -106,11 +106,11 @@ function AccessibleFieldBase(props: AccessibleFieldProps) {
       {typeof props.children === 'function'
         ? props.children(accessibility)
         : React.cloneElement(React.Children.only(props.children), {
-            id: fieldId,
-            name,
-            'aria-describedby': ariaDescribedBy,
-            status,
-          })}
+          id: fieldId,
+          name,
+          'aria-describedby': ariaDescribedBy,
+          status,
+        })}
       {status !== undefined && (
         <StatusMessage status={status} id={statusId}>
           {statusMessage}

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -140,8 +140,6 @@ export const AccessibleField = styled(AccessibleFieldBase)`
   }
 
   ${StatusMessage} {
-    display: block;
-    margin-left: 16px;
     margin-top: 4px;
   }
 `

--- a/modules/cactus-web/src/DateInputField/__snapshots__/DateInputField.test.tsx.snap
+++ b/modules/cactus-web/src/DateInputField/__snapshots__/DateInputField.test.tsx.snap
@@ -43,8 +43,6 @@ exports[`component: DateInputField snapshot 1`] = `
 }
 
 .c1 .c18 {
-  display: block;
-  margin-left: 16px;
   margin-top: 4px;
 }
 

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -42,12 +42,12 @@ type FileStatus = 'loading' | 'loaded' | 'error'
 
 export interface FileInputProps
   extends MarginProps,
-    MaxWidthProps,
-    WidthProps,
-    Omit<
-      React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
-      'onChange' | 'onError' | 'onFocus' | 'onBlur' | 'ref'
-    > {
+  MaxWidthProps,
+  WidthProps,
+  Omit<
+  React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
+  'onChange' | 'onError' | 'onFocus' | 'onBlur' | 'ref'
+  > {
   name: string
   accept?: string[]
   labels?: { delete?: string; retry?: string; loading?: string; loaded?: string }
@@ -159,16 +159,16 @@ const FileBoxBase = React.forwardRef<HTMLDivElement, FileBoxProps>((props, ref) 
       {status === 'error' ? (
         <Avatar type="alert" status="error" />
       ) : (
-        status === 'loaded' && <Avatar type="alert" status="success" />
-      )}
+          status === 'loaded' && <Avatar type="alert" status="success" />
+        )}
       <span>{fileName}</span>
       {status === 'loading' ? (
         <Spinner />
       ) : (
-        <IconButton onClick={onClick} label={labels.delete}>
-          <NavigationClose />
-        </IconButton>
-      )}
+          <IconButton onClick={onClick} label={labels.delete}>
+            <NavigationClose />
+          </IconButton>
+        )}
     </div>
   )
 })
@@ -571,32 +571,32 @@ const FileInputBase = (props: FileInputProps) => {
           </TextButton>
         </React.Fragment>
       ) : (
-        <React.Fragment>
-          {state.files.map((file, index) => (
-            <FileInfo
-              key={file.fileName}
-              fileName={file.fileName}
-              onDelete={handleDelete}
-              onRetry={handleRetry}
-              status={file.status}
-              errorMsg={file.errorMsg}
-              labels={labels}
-              boxRef={index === 0 ? topFileBox : undefined}
-            />
-          ))}
-          <TextButton
-            variant="action"
-            id={id}
-            aria-describedby={describedBy}
-            onClick={handleOpenFileSelect}
-            onFocus={handleInputFocus}
-            onBlur={handleInputBlur}
-          >
-            <BatchstatusOpen iconSize="small" />
-            {buttonText}
-          </TextButton>
-        </React.Fragment>
-      )}
+          <React.Fragment>
+            {state.files.map((file, index) => (
+              <FileInfo
+                key={file.fileName}
+                fileName={file.fileName}
+                onDelete={handleDelete}
+                onRetry={handleRetry}
+                status={file.status}
+                errorMsg={file.errorMsg}
+                labels={labels}
+                boxRef={index === 0 ? topFileBox : undefined}
+              />
+            ))}
+            <TextButton
+              variant="action"
+              id={id}
+              aria-describedby={describedBy}
+              onClick={handleOpenFileSelect}
+              onFocus={handleInputFocus}
+              onBlur={handleInputBlur}
+            >
+              <BatchstatusOpen iconSize="small" />
+              {buttonText}
+            </TextButton>
+          </React.Fragment>
+        )}
     </div>
   )
 }
@@ -646,9 +646,9 @@ FileInput.defaultErrorHandler = defaultErrorHandler
 
 interface FileInputComponent
   extends StyledComponentBase<
-    React.FunctionComponent<FileInputProps>,
-    CactusTheme,
-    FileInputProps
+  React.FunctionComponent<FileInputProps>,
+  CactusTheme,
+  FileInputProps
   > {
   defaultErrorHandler: (type: ErrorType, accept?: string[]) => string
 }

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -252,16 +252,9 @@ const FileInfo = styled(FileInfoBase)`
   ${StatusMessage} {
     position: relative;
     margin-top: 4px;
-    width: 100%;
-
-    span {
-      padding-right: 15px;
-    }
 
     ${IconButton} {
-      position: absolute;
-      right: 11px;
-      top: 14px;
+      margin-left: 10px;
       color: ${p => p.theme.colors.white};
     }
 

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -299,16 +299,14 @@ exports[`component: FileInput should render a file with an error 1`] = `
 }
 
 .c12 {
-  border-radius: 0 8px 8px 8px;
-  padding: 8px 16px 8px 16px;
+  padding: 2px 4px;
   position: relative;
   box-sizing: border-box;
   overflow-wrap: break-word;
   display: inline-block;
-  border: 2px solid;
   font-size: 15px;
   line-height: 23px;
-  border-color: hsl(353,84%,44%);
+  background-color: hsla(353,84%,44%,0.3);
 }
 
 .c12 .c5,
@@ -433,17 +431,10 @@ exports[`component: FileInput should render a file with an error 1`] = `
 .c1 .c11 {
   position: relative;
   margin-top: 4px;
-  width: 100%;
-}
-
-.c1 .c11 span {
-  padding-right: 15px;
 }
 
 .c1 .c11 .c7 {
-  position: absolute;
-  right: 11px;
-  top: 14px;
+  margin-left: 10px;
   color: hsl(0,0%,100%);
 }
 
@@ -821,17 +812,10 @@ exports[`component: FileInput should render a loaded file 1`] = `
 .c1 .c18 {
   position: relative;
   margin-top: 4px;
-  width: 100%;
-}
-
-.c1 .c18 span {
-  padding-right: 15px;
 }
 
 .c1 .c18 .c7 {
-  position: absolute;
-  right: 11px;
-  top: 14px;
+  margin-left: 10px;
   color: hsl(0,0%,100%);
 }
 
@@ -1084,17 +1068,10 @@ exports[`component: FileInput should render a loading file 1`] = `
 .c1 .c14 {
   position: relative;
   margin-top: 4px;
-  width: 100%;
-}
-
-.c1 .c14 span {
-  padding-right: 15px;
 }
 
 .c1 .c14 .c12 {
-  position: absolute;
-  right: 11px;
-  top: 14px;
+  margin-left: 10px;
   color: hsl(0,0%,100%);
 }
 

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -136,16 +136,14 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 }
 
 .c19 {
-  border-radius: 0 8px 8px 8px;
-  padding: 8px 16px 8px 16px;
+  padding: 2px 4px;
   position: relative;
   box-sizing: border-box;
   overflow-wrap: break-word;
   display: inline-block;
-  border: 2px solid;
   font-size: 15px;
   line-height: 23px;
-  border-color: hsl(353,84%,44%);
+  background-color: hsla(353,84%,44%,0.3);
 }
 
 .c19 .c12,
@@ -270,17 +268,10 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 .c8 .c18 {
   position: relative;
   margin-top: 4px;
-  width: 100%;
-}
-
-.c8 .c18 span {
-  padding-right: 15px;
 }
 
 .c8 .c18 .c14 {
-  position: absolute;
-  right: 11px;
-  top: 14px;
+  margin-left: 10px;
   color: hsl(0,0%,100%);
 }
 
@@ -727,17 +718,10 @@ exports[`component: FileInputField should render a loaded file 1`] = `
 .c8 .c25 {
   position: relative;
   margin-top: 4px;
-  width: 100%;
-}
-
-.c8 .c25 span {
-  padding-right: 15px;
 }
 
 .c8 .c25 .c14 {
-  position: absolute;
-  right: 11px;
-  top: 14px;
+  margin-left: 10px;
   color: hsl(0,0%,100%);
 }
 
@@ -1059,17 +1043,10 @@ exports[`component: FileInputField should render a loading file 1`] = `
 .c8 .c21 {
   position: relative;
   margin-top: 4px;
-  width: 100%;
-}
-
-.c8 .c21 span {
-  padding-right: 15px;
 }
 
 .c8 .c21 .c19 {
-  position: absolute;
-  right: 11px;
-  top: 14px;
+  margin-left: 10px;
   color: hsl(0,0%,100%);
 }
 

--- a/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
+++ b/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
@@ -36,8 +36,6 @@ exports[`component: SelectField minimal snapshot 1`] = `
 }
 
 .c1 .c14 {
-  display: block;
-  margin-left: 16px;
   margin-top: 4px;
 }
 

--- a/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
+++ b/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
@@ -1,4 +1,3 @@
-import { CactusTheme } from '@repay/cactus-theme'
 import { NotificationAlert, NotificationError, StatusCheck } from '@repay/cactus-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -9,25 +8,24 @@ export type Status = 'success' | 'warning' | 'error'
 export const StatusPropType = PropTypes.oneOf(['success', 'warning', 'error'])
 
 interface StatusMessageProps {
-  status: Status
+  status: string
 }
 
 type StatusMap = { [K in Status]: ReturnType<typeof css> }
 
 const statusMap: StatusMap = {
   success: css`
-    border-color: ${p => p.theme.colors.success};
+    background-color: ${p => p.theme.colors.status.avatar.success};
   `,
   warning: css`
-    border-color: ${p => p.theme.colors.warning};
+    background-color: ${p => p.theme.colors.status.avatar.warning};
   `,
   error: css`
-    border-color: ${p => p.theme.colors.error};
+    background-color: ${p => p.theme.colors.status.avatar.error};
   `,
 }
 
-// @ts-ignore
-const statusColors: any = props => {
+const statusColors: any = (props: StatusMessageProps) => {
   const { status } = props
   return statusMap[status as Status]
 }
@@ -61,13 +59,11 @@ const StatusMessageBase: React.FC<
 }
 
 const StatusMessage = styled(StatusMessageBase)`
-  border-radius: 0 8px 8px 8px;
-  padding: 8px 16px 8px 16px;
+  padding: 2px 4px;
   position: relative;
   box-sizing: border-box;
   overflow-wrap: break-word;
   display: inline-block;
-  border: 2px solid;
   ${p => p.theme.textStyles.small};
   ${statusColors}
 
@@ -77,7 +73,6 @@ const StatusMessage = styled(StatusMessageBase)`
   }
 `
 
-// @ts-ignore
 StatusMessage.propTypes = {
   status: StatusPropType.isRequired,
 }

--- a/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
+++ b/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
@@ -5,10 +5,10 @@ import styled, { css } from 'styled-components'
 
 export type Status = 'success' | 'warning' | 'error'
 
-export const StatusPropType = PropTypes.oneOf(['success', 'warning', 'error'])
+export const StatusPropType = PropTypes.oneOf<Status>(['success', 'warning', 'error'])
 
 interface StatusMessageProps {
-  status: string
+  status: Status
 }
 
 type StatusMap = { [K in Status]: ReturnType<typeof css> }

--- a/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
+++ b/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
@@ -36,8 +36,6 @@ exports[`component: TextAreaField should render a TextAreaField 1`] = `
 }
 
 .c1 .c10 {
-  display: block;
-  margin-left: 16px;
   margin-top: 4px;
 }
 

--- a/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
+++ b/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
@@ -84,8 +84,6 @@ exports[`component: TextInputField should render a TextInputField 1`] = `
 }
 
 .c1 .c10 {
-  display: block;
-  margin-left: 16px;
   margin-top: 4px;
 }
 


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-255

I'm sure I missed something, but hopefully I got everything in there.  When testing, I'd be sure to go into all of the `BlahBlahField` components (i.e. TextInputField, SelectField, ...) with the exception of `CheckboxField` and `RadioButtonField`.

Also, I ended up making some changes to the `FileInput` component, as the style guide did not have the `StatusMessage` taking up 100% of the width.  This required adjusting the placement of the refresh icon.  I think it looks fine if the message is on one line, but I'm not sure about two lines.  However, I'm unsure how to style it any differently.