### PR TITLE
CACTUS-273 :: SplitButton & MenuButton Integration Tests

### DIFF
--- a/examples/mock-ebpp/src/api.tsx
+++ b/examples/mock-ebpp/src/api.tsx
@@ -26,6 +26,10 @@ export const fetchAccounts = () => {
   return accounts
 }
 
+export const fetchAccount = (id: string) => {
+  return accounts.find(acct => acct.id === id)
+}
+
 export const fetchPaymentHistory = () => {
   let payments: Array<PaymentData> = []
 

--- a/examples/mock-ebpp/src/api.tsx
+++ b/examples/mock-ebpp/src/api.tsx
@@ -26,7 +26,7 @@ export const fetchAccounts = () => {
   return accounts
 }
 
-export const fetchAccount = (id: string) => {
+export const fetchAccount = (id: string | undefined) => {
   return accounts.find(acct => acct.id === id)
 }
 

--- a/examples/mock-ebpp/src/containers/account.tsx
+++ b/examples/mock-ebpp/src/containers/account.tsx
@@ -18,14 +18,13 @@ interface State {
 }
 
 const Account = (props: AccountProps) => {
-  const [account, setAccount] = useState<State | null>(null)
+  const [account, setAccount] = useState<State | undefined>(undefined)
 
   useEffect(() => {
-    // @ts-ignore
     setAccount(fetchAccount(props.accountId))
   }, [props.accountId])
 
-  return account === null ? null : (
+  return account === undefined ? null : (
     <div>
       <Helmet>
         <title>Account {account.id}</title>

--- a/examples/mock-ebpp/src/containers/account.tsx
+++ b/examples/mock-ebpp/src/containers/account.tsx
@@ -1,0 +1,76 @@
+import { fetchAccount } from '../api'
+import { Flex, Text } from '@repay/cactus-web'
+import { Helmet } from 'react-helmet'
+import { RouteComponentProps } from '@reach/router'
+import React, { useEffect, useState } from 'react'
+
+interface AccountProps extends RouteComponentProps {
+  accountId?: string
+}
+
+interface State {
+  firstName: string
+  lastName: string
+  cardLastFour: string
+  dob: string
+  id: string
+  payments: Array<{ pnref: string; date: string }>
+}
+
+const Account = (props: AccountProps) => {
+  const [account, setAccount] = useState<State | null>(null)
+
+  useEffect(() => {
+    // @ts-ignore
+    setAccount(fetchAccount(props.accountId))
+  }, [props.accountId])
+
+  return account === null ? null : (
+    <div>
+      <Helmet>
+        <title>Account {account.id}</title>
+        <link rel="icon" type="image/png" sizes="16x16" href="src/assets/favicon.ico" />
+      </Helmet>
+
+      <Flex justifyContent="center">
+        <Flex width="90%" backgroundColor="base" alignItems="center" paddingLeft="10px">
+          <Text color="white" textStyle="h2">
+            Account {account.id}
+          </Text>
+        </Flex>
+
+        <Flex
+          borderColor="base"
+          borderWidth="2px"
+          borderStyle="solid"
+          width="90%"
+          justifyContent="center"
+        >
+          <table
+            style={{
+              width: '90%',
+              borderCollapse: 'collapse',
+              marginBottom: '20px',
+              marginTop: '20px',
+            }}
+          >
+            <tbody>
+              {(Object.keys(account) as Array<keyof typeof account>).map(key => {
+                return (
+                  key !== 'payments' && (
+                    <tr key={key}>
+                      <th>{key}</th>
+                      <td>{account[key]}</td>
+                    </tr>
+                  )
+                )
+              })}
+            </tbody>
+          </table>
+        </Flex>
+      </Flex>
+    </div>
+  )
+}
+
+export default Account

--- a/examples/mock-ebpp/src/containers/accounts.tsx
+++ b/examples/mock-ebpp/src/containers/accounts.tsx
@@ -101,11 +101,8 @@ const Accounts = (props: AccountsProps) => {
                         mainActionLabel="View Account"
                         onSelectMainAction={goToAccountPage}
                       >
-                        <SplitButton.Action
-                          onSelect={deleteAccount}
-                          data-testid={`delete-acct-${account.id}`}
-                        >
-                          Delete Acount
+                        <SplitButton.Action onSelect={deleteAccount}>
+                          Delete Account
                         </SplitButton.Action>
                       </SplitButton>
                     </td>

--- a/examples/mock-ebpp/src/containers/accounts.tsx
+++ b/examples/mock-ebpp/src/containers/accounts.tsx
@@ -1,21 +1,22 @@
 import { Account, fetchAccounts } from '../api'
-import { Box, Flex, Text } from '@repay/cactus-web'
+import { Alert, Flex, SplitButton, Text } from '@repay/cactus-web'
 import { Helmet } from 'react-helmet'
-import { RouteComponentProps } from '@reach/router'
+import { navigate, RouteComponentProps } from '@reach/router'
 import React, { useEffect, useState } from 'react'
 
 interface AccountsProps extends RouteComponentProps {}
 
 interface State {
   accounts: Array<Account>
+  alert: string
 }
 
 const Accounts = (props: AccountsProps) => {
-  const [state, setState] = useState<State>({ accounts: [] })
+  const [state, setState] = useState<State>({ accounts: [], alert: '' })
 
   useEffect(() => {
     const accounts = fetchAccounts()
-    setState({ accounts: accounts })
+    setState({ accounts: accounts, alert: '' })
   }, [])
 
   return (
@@ -24,6 +25,14 @@ const Accounts = (props: AccountsProps) => {
         <title> Accounts </title>
         <link rel="icon" type="image/png" sizes="16x16" href="src/assets/favicon.ico" />
       </Helmet>
+
+      {state.alert && (
+        <Flex justifyContent="center" mt={4} mb={4}>
+          <Alert status="success" onClose={() => setState({ ...state, alert: '' })} width="60%">
+            {state.alert}
+          </Alert>
+        </Flex>
+      )}
 
       <Flex justifyContent="center">
         <Flex width="90%" backgroundColor="base" alignItems="center" paddingLeft="10px">
@@ -54,6 +63,7 @@ const Accounts = (props: AccountsProps) => {
                 <th> Date of Birth</th>
                 <th> Last Four</th>
                 <th> ID </th>
+                <th />
               </tr>
             </thead>
 
@@ -61,8 +71,20 @@ const Accounts = (props: AccountsProps) => {
               {state.accounts.map((account: Account, index: number) => {
                 const color = index % 2 === 1 ? 'lightgrey' : 'white'
 
+                const goToAccountPage = () => {
+                  navigate(`/account/${account.id}`)
+                }
+
+                const deleteAccount = () => {
+                  setState({
+                    accounts: state.accounts.filter((acct: Account) => acct.id !== account.id),
+                    alert: `Account ${account.id} deleted successfully`,
+                  })
+                }
+
                 return (
                   <tr
+                    key={account.id}
                     style={{
                       backgroundColor: `${color}`,
                       border: '2px solid black',
@@ -74,6 +96,19 @@ const Accounts = (props: AccountsProps) => {
                     <td> {account.dob} </td>
                     <td> {account.cardLastFour} </td>
                     <td> {account.id} </td>
+                    <td>
+                      <SplitButton
+                        mainActionLabel="View Account"
+                        onSelectMainAction={goToAccountPage}
+                      >
+                        <SplitButton.Action
+                          onSelect={deleteAccount}
+                          data-testid={`delete-acct-${account.id}`}
+                        >
+                          Delete Acount
+                        </SplitButton.Action>
+                      </SplitButton>
+                    </td>
                   </tr>
                 )
               })}

--- a/examples/mock-ebpp/src/index.tsx
+++ b/examples/mock-ebpp/src/index.tsx
@@ -2,6 +2,7 @@ import { DescriptiveHome } from '@repay/cactus-icons'
 import { Flex, StyleProvider, Text } from '@repay/cactus-web'
 import { Helmet } from 'react-helmet'
 import { RouteComponentProps, Router } from '@reach/router'
+import Account from './containers/account'
 import Accounts from './containers/accounts'
 import Faq from './containers/faq'
 import Home from './containers/home'
@@ -78,6 +79,7 @@ const App = () => {
           <UIConfig path="/ui-config" />
           <Faq path="/faq" />
           <Rules path="/rules" />
+          <Account path="/account/:accountId" />
         </AppContainer>
       </Router>
     </div>

--- a/examples/mock-ebpp/tests/account-integration.test.ts
+++ b/examples/mock-ebpp/tests/account-integration.test.ts
@@ -23,6 +23,6 @@ test('navigate to account page using SplitButton', async (t: TestController) => 
 
 test('delete account with using SplitButton', async (t: TestController) => {
   await t.click(Selector('button').withAttribute('data-reach-menu-button').nth(0))
-  await t.click(queryByTestId('delete-acct-85963'))
+  await t.click(queryByText('Delete Account'))
   await t.expect(queryByText('Account 85963 deleted successfully').exists).ok()
 })

--- a/examples/mock-ebpp/tests/account-integration.test.ts
+++ b/examples/mock-ebpp/tests/account-integration.test.ts
@@ -1,0 +1,28 @@
+import * as path from 'path'
+import { queryAllByText, queryByTestId, queryByText } from '@testing-library/testcafe'
+import { Selector } from 'testcafe'
+import startStaticServer from './helpers/static-server'
+
+fixture('Account Integration Tests')
+  .before(async ctx => {
+    ctx.server = startStaticServer({
+      directory: path.join(process.cwd(), 'dist'),
+      port: 33567,
+      singlePageApp: true,
+    })
+  })
+  .after(async ctx => {
+    await ctx.server.close()
+  })
+  .page('http://localhost:33567/accounts')
+
+test('navigate to account page using SplitButton', async (t: TestController) => {
+  await t.click(queryAllByText('View Account').nth(0))
+  await t.expect(queryByText('Account 85963').exists).ok()
+})
+
+test('delete account with using SplitButton', async (t: TestController) => {
+  await t.click(Selector('button').withAttribute('data-reach-menu-button').nth(0))
+  await t.click(queryByTestId('delete-acct-85963'))
+  await t.expect(queryByText('Account 85963 deleted successfully').exists).ok()
+})

--- a/examples/standard/src/App.tsx
+++ b/examples/standard/src/App.tsx
@@ -1,33 +1,39 @@
-import React, { ChangeEvent, Component, CSSProperties } from 'react'
+import React, { Component } from 'react'
 
-import { Box, Flex, ToggleField } from '@repay/cactus-web'
+import { Box, Flex, MenuButton, ToggleField } from '@repay/cactus-web'
 import { I18nResource, I18nText } from '@repay/cactus-i18n'
 import { Link, RouteComponentProps } from '@reach/router'
 import { withFeatureFlags } from '@repay/cactus-fwk'
 import Heart from '@repay/cactus-icons/i/status-like'
 
-type AppProps = {
-  onLangChange: (event: ChangeEvent<HTMLSelectElement>) => void
+interface AppProps extends RouteComponentProps {
+  onLangChange: (lang: string) => void
   onChangeFeature: (name: string, enabled: boolean) => void
   lang: string
   include_carrot_snacks?: boolean
   children?: React.ReactNode
 }
 
-class App extends Component<RouteComponentProps<AppProps>> {
+class App extends Component<AppProps> {
   render() {
     return (
-      <>
+      <div style={{ paddingTop: '8px' }}>
         <Flex>
-          <select
-            onChange={this.props.onLangChange}
-            value={this.props.lang}
-            data-testid="select-language"
-          >
-            <option value="">Use Browser</option>
-            <option value="en-US">🇺🇸 English</option>
-            <option value="es-MX">🇲🇽 Español</option>
-          </select>
+          <I18nResource get="language-label">
+            {label => (
+              <MenuButton label={label} ml={2} mr={2} data-testid="select-language">
+                <MenuButton.Item onSelect={() => this.props.onLangChange('en-US')}>
+                  🇺🇸 English
+                </MenuButton.Item>
+                <MenuButton.Item
+                  onSelect={() => this.props.onLangChange('es-US')}
+                  data-testid="spanish-option"
+                >
+                  🇲🇽 Español
+                </MenuButton.Item>
+              </MenuButton>
+            )}
+          </I18nResource>
           <Link to="/">
             <Heart />
             <I18nText get="home-link" />
@@ -57,7 +63,7 @@ class App extends Component<RouteComponentProps<AppProps>> {
             </I18nResource>
           </div>
         </Box>
-      </>
+      </div>
     )
   }
 }

--- a/examples/standard/src/index.tsx
+++ b/examples/standard/src/index.tsx
@@ -23,8 +23,7 @@ const getInitialLang = () => {
 class RootWrapper extends Component<{}, { lang: string; features: FeatureFlagsObject }> {
   state = { lang: getInitialLang(), features: {} }
 
-  handleLangChange = (event: ChangeEvent<HTMLSelectElement>) =>
-    this.setState({ lang: event.target.value })
+  handleLangChange = (lang: string) => this.setState({ lang })
 
   handleChangeFeature = (name: string, enabled: boolean) => {
     this.setState(s => ({ features: { ...s.features, [name]: enabled } }))

--- a/examples/standard/src/locales/en/global.js
+++ b/examples/standard/src/locales/en/global.js
@@ -3,4 +3,5 @@ welcome-message = Welcome to the standard application using \`@repay/cactus-i18n
 home-link = Go Home
 feature-carrots-label = Include carrots in snacks
 terms-title = Terms and Conditions
+language-label = Language
 `

--- a/examples/standard/src/locales/es/global.js
+++ b/examples/standard/src/locales/es/global.js
@@ -4,4 +4,5 @@ welcome-message = Bienvenido a la aplicación estándar usando \`@repay/cactus-i
 home-link = Vete a página de inicio
 feature-carrots-label = Incluir zanahorias en bocadillos
 terms-title = Términos y Condiciones
+language-label = Idioma
 `

--- a/examples/standard/tests/i18n-integration.test.ts
+++ b/examples/standard/tests/i18n-integration.test.ts
@@ -1,7 +1,7 @@
-import { Selector } from 'testcafe'
-import startStaticServer from './helpers/static-server'
 import * as path from 'path'
 import { queryAllByText, queryByTestId, queryByText } from '@testing-library/testcafe'
+import { Selector } from 'testcafe'
+import startStaticServer from './helpers/static-server'
 
 fixture('I18n Integration tests')
   .before(async ctx => {
@@ -31,7 +31,7 @@ test.page('http://localhost:33567?lang=en-US')(
 test.page('http://localhost:33567?lang=en-US')(
   'we can set the language manually when navigator.language is en-US',
   async t => {
-    await t.click(queryByTestId('select-language')).click(queryAllByText(/Español/).nth(0))
+    await t.click(queryByTestId('select-language')).click(queryByTestId('spanish-option'))
     await t
       .expect(
         queryByText(

--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -93,6 +93,7 @@ const MenuList = styled(ReachMenuItems)`
   outline: none;
   ${p => getDropDownBorder(p.theme)};
   box-shadow: ${p => getBoxShadow(p.theme)};
+  background-color: ${p => p.theme.colors.white};
 
   [data-reach-menu-item] {
     position: relative;

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -147,6 +147,7 @@ const SplitButtonList = styled(ReachMenuItems)`
   ${p => getDropdownShape(p.theme.shape)}
   box-shadow: ${p => getBoxShadow(p.theme)};
   z-index: 1000;
+  background-color: ${p => p.theme.colors.white};
 
   ${p =>
     !p.theme.boxShadows &&


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-273

Working on this made a bug that we hadn't noticed before pretty obvious: the background on the dropdown in both of these components was transparent! I guess we just hadn't rendered them on anything but a white background. So that should be fixed now.

## MenuButton

I swapped the language select in `examples/standard` to the `MenuButton` & updated the integration test to work with that component

## SplitButton

For this one, I added a column to the accounts table in `examples/mock-ebpp` and filled it up with SplitButtons with and some basic actions: view the account page or delete the account. Obviously the account page I added is very basic but hey, it's just an example app 🤷‍♂️ 

## Testing

Not really much to test here, but you should probably check out this branch and run the integration tests in the `mock-ebpp` and `standard` example apps. You can also run the `mock-ebpp` app and have a look at the new functionality I added, if you're interested in it.