### PR TITLE
style(cactus-web): fixed text overflow in dropdowns

### DIFF
--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -100,6 +100,8 @@ const MenuList = styled(ReachMenuItems)`
     display: block;
     cursor: pointer;
     text-decoration: none;
+    overflow-wrap: break-word;
+    background-color: ${p => p.theme.colors.white};
 
     ${p => p.theme.textStyles.small};
     color: ${p => p.theme.colors.darkestContrast};

--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -147,7 +147,7 @@ function MenuButtonBase(props: MenuButtonProps) {
           const scrollX = getScrollX()
 
           return {
-            width: targetRect.width > popoverRect.width ? targetRect.width : popoverRect.width,
+            width: targetRect.width,
             left: targetRect.left + scrollX,
             ...getTopPosition(targetRect, popoverRect),
           }

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -414,6 +414,7 @@ const Option = styled.li`
   text-align: left;
   box-shadow: none;
   padding: 4px 16px;
+  overflow-wrap: break-word;
 
   ${p =>
     isResponsiveTouchDevice &&

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -160,6 +160,7 @@ const SplitButtonList = styled(ReachMenuItems)`
     cursor: pointer;
     text-decoration: none;
     background-color: ${p => p.theme.colors.white};
+    overflow-wrap: break-word;
 
     ${p => p.theme.textStyles.small};
     color: ${p => p.theme.colors.darkestContrast};


### PR DESCRIPTION
Text overflow now breaks instead of overflowing. Fixed MenuButton dropdown showing up behind text
[CACTUS-274]

[CACTUS-274]: https://repayonline.atlassian.net/browse/CACTUS-274