### PR TITLE
CACTUS-272 :: Publish Theme Addon With Storybooks

### DIFF
--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -8,7 +8,8 @@
   "repository": "https://github.com/repaygithub/cactus/tree/master/modules/cactus-web",
   "license": "MIT",
   "sideEffects": [
-    "./dist/helpers/polyfills.js"
+    "./dist/helpers/polyfills.js",
+    "./cactus-addon/register.jsx"
   ],
   "scripts": {
     "cleanup": "rm -rf dist coverage .storybook/dist",


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-272

So obviously this required very little actual changes to get it to work. Most of my time was spent understanding how the stories are built/published & then doing research to figure out how to get the custom addon to be built with everything else.

The thread that ultimately led to me figuring this out can be found here: https://github.com/storybookjs/storybook/issues/6413

### Testing
Bring up the published storybooks for `cactus-web` (https://repaygithub.github.io/cactus/stories/cactus-web/?path=/story/accessiblefield--basic-usage) and notice that the "Cactus Theme" tab is now available in the bottom section. Play around with the theme on some components that make use of those theme properties & make sure they're still being adjusted w/ the theme.