### PR TITLE
Fix examples of error view component in error boundaries

### DIFF
--- a/docs/Framework/API/Error Boundary.md
+++ b/docs/Framework/API/Error Boundary.md
@@ -9,7 +9,7 @@ The `ErrorBoundary` component will catch and handle uncaught errors in its child
 | Prop        | Required | Type                                                  | Default Value |
 | ----------- | -------- | ----------------------------------------------------- | ------------- |
 | `onError`   | Y        | Function of the form `(error, info) => void`          | N/A           |
-| `errorView` | N        | Function of the form `(error, info) => React.Element` | `undefined`   |
+| `errorView` | N        | Function of the form `({ error, info }) => React.Element` | `undefined`   |
 
 ### Example
 
@@ -23,7 +23,7 @@ export default function Container() {
     // Send error to Sentry/another API to record it
   }
 
-  const errorView = (error, info) => (
+  const errorView = ({ error, info }) => (
     <div>
       <h2>Whoops! Something went wrong on this page.</h2>
       <span>{error.message}</span>
@@ -49,7 +49,7 @@ These props can be passed to `AppRoot` to get the most out of the global error h
 | Prop              | Required | Type                                                  | Default Value |
 | ----------------- | -------- | ----------------------------------------------------- | ------------- |
 | `onError`         | N        | Function of the form `(error, info) => void`          | noop function |
-| `globalErrorView` | N        | Function of the form `(error, info) => React.Element` | `undefined`   |
+| `globalErrorView` | N        | Function of the form `({ error, info }) => React.Element` | `undefined`   |
 
 ### Global Example
 
@@ -62,7 +62,7 @@ export default function MainContainer() {
     // Send error to Sentry/another API to record it
   }
 
-  const errorView = (error, info) => (
+  const errorView = ({ error, info }) => (
     <div>
       <h2>Whoops! Something went wrong with our app.</h2>
       <span>{error.message}</span>

--- a/docs/Framework/API/README.md
+++ b/docs/Framework/API/README.md
@@ -6,4 +6,5 @@ title: API Docs
 
 ## Features
 
+- [Error Boundary](./Error%20Boundary.md)
 - [Feature Flags](./Feature%20Flags.md)

--- a/docs/Framework/README.md
+++ b/docs/Framework/README.md
@@ -9,6 +9,7 @@ The Cactus Framework implements a set of common front-end necessities at a top l
 ## Quick Links
 
 - [API Documentation](./API/README.md)
+  - [Error Boundary](./API/Error%20Boundary.md)
   - [Feature Flags](./API/Feature%20Flags.md)
 - [Source Code](../../modules/cactus-fwk/)
 


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-191

Not much to test.  Just run `yarn docs start` and make sure all the links to the Error Boundary page work (and that the docs were updated as in the ticket).