### PR TITLE
Fix focus outline bug for Button in IE11

### DIFF
--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -202,6 +202,7 @@ export const Button = styled(ButtonBase)<ButtonProps>`
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   ${(p) => p.theme.textStyles.body};
   ${(p) => getBorder(p.theme.border)};

--- a/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`With theme changes  Should have intermediate border radius 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -73,6 +74,7 @@ exports[`With theme changes  Should have square border radius 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -139,6 +141,7 @@ exports[`With theme changes  Should not have box shadows applied 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -205,6 +208,7 @@ exports[`With theme changes  should have 2px border 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -271,6 +275,7 @@ exports[`component: Button should default to standard variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -344,6 +349,7 @@ exports[`component: Button should render Spinner when loading is true 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -483,6 +489,7 @@ exports[`component: Button should render call to action variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -549,6 +556,7 @@ exports[`component: Button should render danger variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -615,6 +623,7 @@ exports[`component: Button should render disabled variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -677,6 +686,7 @@ exports[`component: Button should render inverse call to action variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -743,6 +753,7 @@ exports[`component: Button should render inverse danger variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -808,6 +819,7 @@ exports[`component: Button should render inverse disabled variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -870,6 +882,7 @@ exports[`component: Button should render inverse standard variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -936,6 +949,7 @@ exports[`component: Button should render standard variant 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -1002,6 +1016,7 @@ exports[`component: Button should support margin space props 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;

--- a/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -518,6 +519,7 @@ exports[`Modal variant is danger snapshot 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -952,6 +954,7 @@ exports[`Modal variant is success snapshot 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;
@@ -1364,6 +1367,7 @@ exports[`Modal variant is warning snapshot 1`] = `
   padding: 2px 30px;
   outline: none;
   cursor: pointer;
+  overflow: visible;
   box-sizing: border-box;
   font-size: 18px;
   line-height: 28px;


### PR DESCRIPTION
See
https://stackoverflow.com/questions/30176560/css-after-pseudo-element-doesnt-work-inside-button-in-any-ie-version

Ticket and testing: https://repayonline.atlassian.net/browse/CACTUS-304