### PR TITLE
refactor(cactus-web): Standardize box shadows using boxShadow helper

### DIFF
--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useRef, useSt
 
 import { assignRef } from '@reach/utils'
 import { BorderSize, Shape } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { CactusTheme } from '@repay/cactus-theme'
 import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 'styled-system'
 import { NavigationChevronDown, NavigationChevronRight } from '@repay/cactus-icons'
@@ -612,12 +613,10 @@ export const Accordion = styled(AccordionBase)`
   box-sizing: border-box;
   width: 100%;
 
-  ${(p) =>
-    p.theme.boxShadows &&
-    `&.box-shadow {
+  &.box-shadow {
     border: 0px;
-    box-shadow: 0 3px 8px ${p.theme.colors.callToAction};
-  }`}
+    ${(p) => boxShadow(p.theme, 1)};
+  }
 
 
 

--- a/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`component: Accordion Component Should render Accordion 1`] = `
 
 .c0.box-shadow {
   border: 0px;
-  box-shadow: 0 3px 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c0:first-of-type {
@@ -231,7 +231,7 @@ exports[`component: Accordion Component Should render outline accordion 1`] = `
 
 .c1.box-shadow {
   border: 0px;
-  box-shadow: 0 3px 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1 + .c0 {
@@ -389,7 +389,7 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 .c1.box-shadow {
   border: 0px;
-  box-shadow: 0 3px 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1 + .c0 {
@@ -538,7 +538,7 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 .c1.box-shadow {
   border: 0px;
-  box-shadow: 0 3px 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1 + .c0 {
@@ -691,7 +691,7 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 .c1.box-shadow {
   border: 0px;
-  box-shadow: 0 3px 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1 + .c0 {
@@ -832,6 +832,10 @@ exports[`component: Accordion with theme customization outline accordion should 
   border: 1px solid;
   border-color: hsl(200,29%,90%);
   border-radius: 8px;
+}
+
+.c1.box-shadow {
+  border: 0px;
 }
 
 .c1 + .c0 {
@@ -975,7 +979,7 @@ exports[`component: Accordion with theme customization simple accordion should h
 
 .c1.box-shadow {
   border: 0px;
-  box-shadow: 0 3px 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1:first-of-type {

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { boxShadow } from '../helpers/theme'
 import { CactusTheme } from '@repay/cactus-theme'
 import { margin, MarginProps, width, WidthProps } from 'styled-system'
 import Avatar from '../Avatar/Avatar'
@@ -98,7 +99,7 @@ export const Alert = styled(AlertBase)<AlertProps>`
   background: ${backgroundColor};
   border: 2px solid ${borderColor};
   ${typeVariant}
-  box-shadow: ${(p) => p.shadow && `0 9px 24px ${p.theme.colors.callToAction};`};
+  ${(p) => p.shadow && boxShadow(p.theme, 2)};
   border-radius: 8px;
   ${margin}
   ${width}

--- a/modules/cactus-web/src/Card/Card.tsx
+++ b/modules/cactus-web/src/Card/Card.tsx
@@ -1,4 +1,5 @@
 import { BorderSize, CactusTheme, Shape } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { margin, MarginProps, width, WidthProps } from 'styled-system'
 import styled, { css } from 'styled-components'
 
@@ -30,10 +31,10 @@ const getShape = (shape: Shape) => shapeMap[shape]
 const getBoxShadow = (theme: CactusTheme) => {
   return theme.boxShadows
     ? css`
-        box-shadow: 0 3px 6px 0 ${(p) => p.theme.colors.callToAction};
+        ${(p) => `${boxShadow(p.theme, 1)};
         :hover {
-          box-shadow: 0 4px 8px 0 ${(p) => p.theme.colors.callToAction};
-        }
+          ${boxShadow(p.theme, 2)};
+        }`}
       `
     : css`
     ${getBorder(theme.border)}

--- a/modules/cactus-web/src/Card/__snapshots__/Card.test.tsx.snap
+++ b/modules/cactus-web/src/Card/__snapshots__/Card.test.tsx.snap
@@ -18,11 +18,11 @@ exports[`component: Card should support margin space props 1`] = `
   color: hsl(200,10%,20%);
   border-radius: 8px;
   padding: 16px;
-  box-shadow: 0 3px 6px 0 hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1:hover {
-  box-shadow: 0 4px 8px 0 hsl(200,96%,35%);
+  box-shadow: 0px 9px 24px hsla(200,96%,35%,0.3);
 }
 
 .c1 > .c0 {
@@ -51,11 +51,11 @@ exports[`component: Card snapshot 1`] = `
   color: hsl(200,10%,20%);
   border-radius: 8px;
   padding: 16px;
-  box-shadow: 0 3px 6px 0 hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1:hover {
-  box-shadow: 0 4px 8px 0 hsl(200,96%,35%);
+  box-shadow: 0px 9px 24px hsla(200,96%,35%,0.3);
 }
 
 .c1 > .c0 {
@@ -123,11 +123,11 @@ exports[`component: Card with theme customization should have 1px border radius 
   color: hsl(200,10%,20%);
   border-radius: 1px;
   padding: 16px;
-  box-shadow: 0 3px 6px 0 hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1:hover {
-  box-shadow: 0 4px 8px 0 hsl(200,96%,35%);
+  box-shadow: 0px 9px 24px hsla(200,96%,35%,0.3);
 }
 
 .c1 > .c0 {
@@ -184,11 +184,11 @@ exports[`component: Card with theme customization should have 4px border radius 
   color: hsl(200,10%,20%);
   border-radius: 4px;
   padding: 16px;
-  box-shadow: 0 3px 6px 0 hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1:hover {
-  box-shadow: 0 4px 8px 0 hsl(200,96%,35%);
+  box-shadow: 0px 9px 24px hsla(200,96%,35%,0.3);
 }
 
 .c1 > .c0 {

--- a/modules/cactus-web/src/CheckBox/CheckBox.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { BorderSize } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { margin, MarginProps } from 'styled-system'
 import { Omit } from '../types'
 import { omitMargins } from '../helpers/omit'
@@ -95,7 +96,7 @@ export const CheckBox = styled(CheckBoxBase)`
   }
 
   input:focus ~ span {
-    ${(p) => p.theme.boxShadows && `box-shadow: 0 0 8px ${p.theme.colors.callToAction};`}
+    ${(p) => boxShadow(p.theme, 1)};
   }
 
   ${margin}

--- a/modules/cactus-web/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
+++ b/modules/cactus-web/src/CheckBox/__snapshots__/CheckBox.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`component: CheckBox should render a checkbox 1`] = `
 }
 
 .c0 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <label
@@ -141,7 +141,7 @@ exports[`component: CheckBox should render a disabled checkbox 1`] = `
 }
 
 .c0 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <label
@@ -233,7 +233,7 @@ exports[`component: CheckBox should support margin space props 1`] = `
 }
 
 .c0 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <label
@@ -318,7 +318,7 @@ exports[`component: CheckBox with theme customization should have 2px border 1`]
 }
 
 .c0 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <label

--- a/modules/cactus-web/src/CheckBoxField/__snapshots__/CheckBoxField.test.tsx.snap
+++ b/modules/cactus-web/src/CheckBoxField/__snapshots__/CheckBoxField.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`component: CheckBoxField should render a checkbox field 1`] = `
 }
 
 .c4 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1 + .c0 {
@@ -172,7 +172,7 @@ exports[`component: CheckBoxField should render a disabled checkbox field 1`] = 
 }
 
 .c4 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1 + .c0 {
@@ -303,7 +303,7 @@ exports[`component: CheckBoxField should support margin space props 1`] = `
 }
 
 .c4 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c1 + .c0 {

--- a/modules/cactus-web/src/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/modules/cactus-web/src/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -176,7 +176,7 @@ exports[`component: DataGrid snapshot 1`] = `
 
 .c4.c4.c4 tr:focus td,
 .c4.c4.c4 tr:focus th {
-  background-color: hsla(200,96%,35%,0.25);
+  background-color: hsla(200,96%,35%,0.3);
   border-color: hsl(200,96%,35%);
 }
 

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -1,6 +1,7 @@
 import React, { Component, Fragment, MouseEventHandler, useMemo } from 'react'
 
 import { BorderSize, CactusTheme, Shape } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system'
 import {
   DateType,
@@ -322,7 +323,7 @@ const getPopupShape = (shape: Shape) => popupShapeMap[shape]
 const getPopupBoxShadowStyles = (theme: CactusTheme) => {
   return theme.boxShadows
     ? css`
-        box-shadow: 0 3px 9px 0 ${theme.colors.callToAction};
+        ${(p) => boxShadow(p.theme, 1)};
       `
     : css`
         ${borderMap[theme.border]}

--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { BorderSize, Shape } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { CactusTheme } from '@repay/cactus-theme'
 import { getScrollX } from '../helpers/scrollOffset'
 import { getTopPosition } from '../helpers/positionPopover'
@@ -58,10 +59,6 @@ const getBorder = (size: BorderSize) => borderMap[size]
 
 const getDropShape = (shape: Shape) => dropShapeMap[shape]
 
-const getBoxShadow = (theme: CactusTheme) => {
-  return theme.boxShadows ? `0 3px 6px 0 ${theme.colors.callToAction}` : {}
-}
-
 const getDropDownBorder = (theme: CactusTheme) => {
   if (!theme.boxShadows) {
     return css`
@@ -87,7 +84,7 @@ const MenuList = styled(ReachMenuItems)`
   margin-top: 8px;
   outline: none;
   ${(p) => getDropDownBorder(p.theme)};
-  box-shadow: ${(p) => getBoxShadow(p.theme)};
+  ${(p) => boxShadow(p.theme, 1)};
   background-color: ${(p) => p.theme.colors.white};
 
   [data-reach-menu-item] {

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -1,4 +1,5 @@
 import { BorderSize, CactusTheme, Shape } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { DialogContent, DialogOverlay, DialogProps } from '@reach/dialog'
 import { NavigationClose } from '@repay/cactus-icons'
 import Flex from '../Flex/Flex'
@@ -102,7 +103,7 @@ export const ModalPopUp = styled(DialogOverlay)<ModalPopupProps>`
     ${(p) => getBorder(p.theme.border)};
     ${(p) => getShape(p.theme.shape)};
     background: white;
-    box-shadow: ${(p) => p.theme.boxShadows && `0px 9px 24px ${p.theme.colors.transparentCTA}`};
+    ${(p) => boxShadow(p.theme, 2)};
     margin: auto;
     max-width: 80%;
     outline: none;

--- a/modules/cactus-web/src/RadioButton/RadioButton.tsx
+++ b/modules/cactus-web/src/RadioButton/RadioButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { boxShadow } from '../helpers/theme'
 import { margin, MarginProps } from 'styled-system'
 import { Omit } from '../types'
 import { omitMargins } from '../helpers/omit'
@@ -82,7 +83,7 @@ export const RadioButton = styled(RadioButtonBase)`
   }
 
   input:focus ~ span {
-    ${(p) => p.theme.boxShadows && `box-shadow: 0 0 8px ${p.theme.colors.callToAction};`}
+    ${(p) => boxShadow(p.theme, 1)}
   }
 
   ${margin}

--- a/modules/cactus-web/src/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/modules/cactus-web/src/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`component: RadioButton should render a disabled radio button 1`] = `
 }
 
 .c0 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <label
@@ -126,7 +126,7 @@ exports[`component: RadioButton should render a radio button 1`] = `
 }
 
 .c0 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <label
@@ -200,7 +200,7 @@ exports[`component: RadioButton should support margin space props 1`] = `
 }
 
 .c0 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <label

--- a/modules/cactus-web/src/RadioButtonField/__snapshots__/RadioButtonField.test.tsx.snap
+++ b/modules/cactus-web/src/RadioButtonField/__snapshots__/RadioButtonField.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`component: RadioButtonField should render a disabled radio button field
 }
 
 .c4 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c9 + .c2 {
@@ -175,7 +175,7 @@ exports[`component: RadioButtonField should render a radio button field 1`] = `
 }
 
 .c4 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c3 + .c2 {
@@ -278,7 +278,7 @@ exports[`component: RadioButtonField should support margin space props 1`] = `
 }
 
 .c4 input:focus ~ span {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c9 + .c2 {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -4,6 +4,7 @@ import '../helpers/polyfills'
 import { ActionsAdd, NavigationChevronDown, NavigationClose } from '@repay/cactus-icons'
 import { assignRef } from '@reach/utils'
 import { BorderSize, CactusTheme, Shape } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler, Omit } from '../types'
 import { getScrollX, getScrollY } from '../helpers/scrollOffset'
 import { isResponsiveTouchDevice } from '../helpers/constants'
@@ -448,7 +449,7 @@ const ListWrapper = styled.div`
   ${(p) => getListShape(p.theme.shape)}
   max-height: 400px;
   max-width: 100vw;
-  ${(p) => p.theme.boxShadows && `box-shadow: 0 3px 9px 0 ${p.theme.colors.callToAction};`}
+  ${(p) => boxShadow(p.theme, 1)};
   background-color: ${(p) => p.theme.colors.white};
 
   ${() =>

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -1,6 +1,7 @@
 import React, { MutableRefObject, useRef, useState } from 'react'
 
 import { BorderSize, Shape } from '@repay/cactus-theme'
+import { boxShadow } from '../helpers/theme'
 import { getScrollX } from '../helpers/scrollOffset'
 import { getTopPosition } from '../helpers/positionPopover'
 import { margin, MarginProps } from 'styled-system'
@@ -132,16 +133,13 @@ const dropdownShapeMap: { [K in Shape]: FlattenSimpleInterpolation } = {
 }
 
 const getDropdownShape = (shape: Shape) => dropdownShapeMap[shape]
-const getBoxShadow = (theme: DefaultTheme) => {
-  return theme.boxShadows ? `0 3px 6px 0 ${theme.colors.callToAction}` : {}
-}
 
 const SplitButtonList = styled(ReachMenuItems)`
   padding: 8px 0;
   margin-top: 8px;
   outline: none;
   ${(p) => getDropdownShape(p.theme.shape)}
-  box-shadow: ${(p) => getBoxShadow(p.theme)};
+  ${(p) => boxShadow(p.theme, 1)};
   z-index: 1000;
   background-color: ${(p) => p.theme.colors.white};
 
@@ -163,7 +161,7 @@ const SplitButtonList = styled(ReachMenuItems)`
     text-align: center;
 
     &[data-selected] {
-    ${(p) => p.theme.colorStyles.callToAction};
+      ${(p) => p.theme.colorStyles.callToAction};
     }
   }
 `

--- a/modules/cactus-web/src/StepAvatar/StepAvatar.tsx
+++ b/modules/cactus-web/src/StepAvatar/StepAvatar.tsx
@@ -1,3 +1,4 @@
+import { boxShadow } from '../helpers/theme'
 import { margin, MarginProps } from 'styled-system'
 import styled, { css, DefaultTheme, FlattenInterpolation, ThemeProps } from 'styled-components'
 
@@ -15,7 +16,7 @@ const stepColorMap: StepColor = {
   `,
   inProcess: css`
     ${(p) => p.theme.colorStyles.callToAction};
-    box-shadow: 0px 2px 5px 4px ${(p) => p.theme.colors.lightContrast};
+    ${(p) => boxShadow(p.theme, 1)};
   `,
   done: css`
     ${(p) => p.theme.colorStyles.base};

--- a/modules/cactus-web/src/StepAvatar/__snapshots__/StepAvatar.test.tsx.snap
+++ b/modules/cactus-web/src/StepAvatar/__snapshots__/StepAvatar.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`component: StepAvatar Step Avatar, In Process 1`] = `
   border: none;
   background-color: hsl(200,96%,35%);
   color: hsl(0,0%,100%);
-  box-shadow: 0px 2px 5px 4px hsl(200,29%,90%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 <div>

--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { boxShadow } from '../helpers/theme'
 import { margin, MarginProps } from 'styled-system'
 import { NavigationClose, StatusCheck } from '@repay/cactus-icons'
 import { Omit } from '../types'
@@ -57,7 +58,7 @@ export const Toggle = styled(ToggleBase)`
   cursor: ${(p) => (p.disabled ? 'cursor' : 'pointer')};
 
   &:focus {
-    ${(p) => p.theme.boxShadows && `box-shadow: 0 0 8px ${p.theme.colors.callToAction};`}
+    ${(p) => boxShadow(p.theme, 1)};
   }
 
   ::after {

--- a/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`component: Toggle should initialize value to true 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c0::after {
@@ -195,7 +195,7 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c0::after {
@@ -317,7 +317,7 @@ exports[`component: Toggle should render a toggle 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c0::after {
@@ -479,7 +479,7 @@ exports[`component: Toggle should support margin space props 1`] = `
 }
 
 .c0:focus {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c0::after {

--- a/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
+++ b/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`component: ToggleField snapshot 1`] = `
 }
 
 .c4:focus {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c4::after {
@@ -219,7 +219,7 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
 }
 
 .c4:focus {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c4::after {
@@ -386,7 +386,7 @@ exports[`component: ToggleField snapshot when value=true 1`] = `
 }
 
 .c4:focus {
-  box-shadow: 0 0 8px hsl(200,96%,35%);
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
 .c4::after {

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -1,5 +1,6 @@
 import React, { cloneElement } from 'react'
 
+import { boxShadow } from '../helpers/theme'
 import { getScrollX, getScrollY } from '../helpers/scrollOffset'
 import { margin, MarginProps, maxWidth } from 'styled-system'
 import { NotificationInfo } from '@repay/cactus-icons'
@@ -132,7 +133,7 @@ export const TooltipPopup = styled(ReachTooltipPopup)`
   position: absolute;
   padding: 16px;
   border-radius: 8px 8px 8px 8px;
-  box-shadow: 0 9px 24px -8px ${(p) => p.theme.colors.callToAction};
+  ${(p) => boxShadow(p.theme, 2)};
   font-size: 15px;
   ${(p) => p.theme.colorStyles.standard};
   border: 2px solid ${(p) => p.theme.colors.callToAction};

--- a/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`component: Tooltip should render tooltip on hover 1`] = `
   position: absolute;
   padding: 16px;
   border-radius: 8px 8px 8px 8px;
-  box-shadow: 0 9px 24px -8px hsl(200,96%,35%);
+  box-shadow: 0px 9px 24px hsla(200,96%,35%,0.3);
   font-size: 15px;
   background-color: hsl(0,0%,100%);
   color: hsl(200,10%,20%);


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-294

## Testing
View the following components & compare them to what's shown & described in the style guide:
- Accordion (Outline Variant)
- Alert
- Card
- DateInput
- MenuButton
- Modal
- RadioButton (focus)
- Select (dropdown)
- SplitButton
- StepAvatar (in process)
- Toggle (focus)
- Tooltip

Note that there may still be a typo in the Figma style guide that says the `Select` should use the `S2` shadow, when it really is supposed to use `S1`.