### PR TITLE
Remove mini breakpoint from docs

### DIFF
--- a/website/src/pages/design-system/shared-styles.tsx
+++ b/website/src/pages/design-system/shared-styles.tsx
@@ -277,16 +277,6 @@ export default () => {
         </thead>
         <tbody>
           <tr>
-            <td>mini</td>
-            <td> &gt;320px</td>
-            <td> 320</td>
-            <td> 64</td>
-            <td> 4</td>
-            <td> 8</td>
-            <td> 16</td>
-          </tr>
-
-          <tr>
             <td>small</td>
             <td> &gt;768px</td>
             <td> 708</td>


### PR DESCRIPTION
We don't use a mini breakpoint, so this just removes that from the docs