### PR TITLE
CACTUS-311 :: Update Styled Components and TypeScript

### DIFF
--- a/examples/mock-ebpp/package.json
+++ b/examples/mock-ebpp/package.json
@@ -51,7 +51,7 @@
     "prop-types": "^15.7.2",
     "testcafe": "^1.8.5",
     "testcafe-browser-provider-browserstack": "^1.13.0",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "@reach/router": "^1.2.1",

--- a/examples/mock-ebpp/package.json
+++ b/examples/mock-ebpp/package.json
@@ -43,6 +43,7 @@
     "@testing-library/testcafe": "^4.1.0",
     "@types/reach__router": "^1.2.4",
     "@types/rimraf": "^2.0.2",
+    "@types/styled-components": "^5.1.1",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "commander": "^5.1.0",
@@ -59,6 +60,7 @@
     "@repay/cactus-theme": "^0.5.0",
     "@repay/cactus-web": "^0.9.1",
     "react": "^16.10.2",
-    "react-dom": "^16.10.2"
+    "react-dom": "^16.10.2",
+    "styled-components": "^5.1.1"
   }
 }

--- a/examples/standard/package.json
+++ b/examples/standard/package.json
@@ -21,7 +21,8 @@
     "@repay/cactus-theme": "^0.5.0",
     "@repay/cactus-web": "^0.9.1",
     "react": "^16.10.2",
-    "react-dom": "^16.10.2"
+    "react-dom": "^16.10.2",
+    "styled-components": "^5.1.1"
   },
   "devDependencies": {
     "@repay/babel-preset": "^1.0.0",
@@ -30,6 +31,7 @@
     "@types/reach__router": "^1.2.4",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.2",
+    "@types/styled-components": "^5.1.1",
     "commander": "^5.1.0",
     "dotenv": "^8.2.0",
     "prop-types": "^15.7.2",

--- a/examples/standard/package.json
+++ b/examples/standard/package.json
@@ -35,6 +35,6 @@
     "prop-types": "^15.7.2",
     "testcafe": "^1.8.4",
     "testcafe-browser-provider-browserstack": "^1.12.0",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.7"
   }
 }

--- a/examples/theme-components/package.json
+++ b/examples/theme-components/package.json
@@ -18,6 +18,7 @@
     "@types/reach__router": "^1.2.4",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.2",
+    "@types/styled-components": "^5.1.1",
     "csstype": "^2.6.11",
     "prop-types": "^15.7.2",
     "typescript": "^3.9.7"
@@ -29,9 +30,6 @@
     "@repay/cactus-web": "^0.9.1",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "styled-components": "^4.4.1"
-  },
-  "resolutions": {
-    "styled-components": "^4.1.2"
+    "styled-components": "^5.1.1"
   }
 }

--- a/examples/theme-components/package.json
+++ b/examples/theme-components/package.json
@@ -18,8 +18,9 @@
     "@types/reach__router": "^1.2.4",
     "@types/react": "^16.9.5",
     "@types/react-dom": "^16.9.2",
+    "csstype": "^2.6.11",
     "prop-types": "^15.7.2",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "@reach/router": "^1.2.1",

--- a/examples/theme-components/src/containers/Flex.tsx
+++ b/examples/theme-components/src/containers/Flex.tsx
@@ -1,6 +1,7 @@
 import { RouteComponentProps } from '@reach/router'
 import NavigationChevronLeft from '@repay/cactus-icons/i/navigation-chevron-left'
 import { Flex, SelectField, Text } from '@repay/cactus-web'
+import { FlexDirectionProperty, FlexWrapProperty } from 'csstype'
 import React, { useCallback, useState } from 'react'
 
 import Link from '../components/Link'
@@ -71,10 +72,8 @@ const FlexExample: React.FC<RouteComponentProps> = () => {
         border="1px solid red"
         justifyContent={state.justifyOptions}
         alignItems={state.alignOptions}
-        // @ts-ignore
-        flexWrap={state.flexWrapOptions}
-        // @ts-ignore
-        flexDirection={state.directionOptions}
+        flexWrap={state.flexWrapOptions as FlexWrapProperty}
+        flexDirection={state.directionOptions as FlexDirectionProperty}
       >
         {[...Array(state.items > 0 ? state.items : 2)].map((_, i) => (
           <Flex p={5} colors={colors[i]} height="100px" width="100px" key={i} />

--- a/modules/cactus-fwk/package.json
+++ b/modules/cactus-fwk/package.json
@@ -47,14 +47,14 @@
     "@repay/scripts": "^2.0.0",
     "@testing-library/jest-dom": "^4.1.2",
     "@testing-library/react": "^10.4.3",
-    "@types/jest": "^24.0.11",
+    "@types/jest": "^24.9.1",
     "@types/prop-types": "^15.7.1",
     "@types/react": "^16.9.5",
     "jest": "^24.7.1",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",

--- a/modules/cactus-fwk/src/ErrorBoundary.tsx
+++ b/modules/cactus-fwk/src/ErrorBoundary.tsx
@@ -72,7 +72,7 @@ const withErrorBoundary = <BaseProps extends any>(
     throw new Error('You must pass the `onError` prop when using `withErrorBoundary`!')
   }
 
-  const Wrapped = (props: BaseProps) => (
+  const Wrapped = (props: React.PropsWithChildren<BaseProps>) => (
     <ErrorBoundary onError={onError} errorView={errorView}>
       <BaseComponent {...props} />
     </ErrorBoundary>

--- a/modules/cactus-fwk/src/featureFlags.tsx
+++ b/modules/cactus-fwk/src/featureFlags.tsx
@@ -17,7 +17,7 @@ const useFeatureFlags = <FeatureFlags extends string[]>(...features: FeatureFlag
   return result
 }
 
-const withFeatureFlags = <FeatureFlags extends string[], Props extends any>(
+const withFeatureFlags = <FeatureFlags extends string[], Props extends object>(
   features: FeatureFlags,
   Component: ComponentType<Props>
 ) => {
@@ -34,7 +34,7 @@ const withFeatureFlags = <FeatureFlags extends string[], Props extends any>(
             flags[key] = Boolean(featureFlags[key])
           }
         }
-        let propsWithFlags = { ...props, ...flags } as Props
+        let propsWithFlags = { ...props, ...flags } as React.PropsWithChildren<Props>
         return <Component {...propsWithFlags} />
       }}
     </FeatureFlagContext.Consumer>

--- a/modules/cactus-i18n/package.json
+++ b/modules/cactus-i18n/package.json
@@ -45,13 +45,13 @@
     "@testing-library/react": "^10.4.3",
     "@types/fluent__bundle": "^0.14.2",
     "@types/fluent__langneg": "^0.3.0",
-    "@types/jest": "^24.0.11",
+    "@types/jest": "^24.9.1",
     "@types/react": "^16.9.5",
     "jest": "^24.7.1",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "@fluent/bundle": "^0.14.0",

--- a/modules/cactus-icons/package.json
+++ b/modules/cactus-icons/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "prop-types": ">=15.0.0",
     "react": "^16.8.3",
-    "styled-components": "^4.1.4"
+    "styled-components": "^4.1.4 || ^5.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",
@@ -64,15 +64,16 @@
     "@types/jest": "^24.9.1",
     "@types/node": "^12.12.21",
     "@types/storybook__react": "^4.0.2",
+    "@types/styled-components": "^5.1.1",
     "@types/styled-system": "^5.1.2",
     "babel-jest": "^24.7.1",
     "fast-glob": "^2.2.6",
     "jest": "^24.7.1",
-    "jest-styled-components": "^6.2.1",
+    "jest-styled-components": "^7.0.2",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "styled-components": "^4.4.1",
+    "styled-components": "^5.1.1",
     "typescript": "^3.9.7"
   },
   "dependencies": {

--- a/modules/cactus-icons/package.json
+++ b/modules/cactus-icons/package.json
@@ -61,6 +61,7 @@
     "@storybook/react": "5.3.19",
     "@svgr/core": "^4.2.0",
     "@testing-library/react": "^10.4.3",
+    "@types/jest": "^24.9.1",
     "@types/node": "^12.12.21",
     "@types/storybook__react": "^4.0.2",
     "@types/styled-system": "^5.1.2",
@@ -72,7 +73,7 @@
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "styled-components": "^4.4.1",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "styled-system": "^5.1.1"

--- a/modules/cactus-theme/package.json
+++ b/modules/cactus-theme/package.json
@@ -23,8 +23,9 @@
   "devDependencies": {
     "@repay/babel-preset": "^1.0.0",
     "@repay/scripts": "^2.0.0",
+    "@types/jest": "^24.9.1",
     "color": "^3.1.2",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "jest": {
     "transform": {

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -69,25 +69,25 @@
     "@types/react": "^16.9.5",
     "@types/storybook__addon-viewport": "^4.1.0",
     "@types/storybook__react": "^4.0.2",
-    "@types/styled-components": "^4.1.14",
+    "@types/styled-components": "^5.1.1",
     "@types/styled-system": "^5.1.2",
     "@types/user-event": "^4.1.0",
     "babel-jest": "^24.7.1",
     "babel-loader": "^8.0.5",
     "csstype": "^2.6.11",
     "jest": "^24.7.1",
-    "jest-styled-components": "^6.2.1",
+    "jest-styled-components": "^7.0.2",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "rollup-plugin-commonjs": "^9.3.4",
-    "styled-components": "^4.4.1",
+    "styled-components": "^5.1.1",
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",
     "react": "^16.8.3",
-    "styled-components": "^4.1.4"
+    "styled-components": "^4.1.4 || ^5.0.0"
   },
   "dependencies": {
     "@reach/dialog": "^0.10.4",

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -64,6 +64,7 @@
     "@testing-library/jest-dom": "^4.1.2",
     "@testing-library/react": "^10.4.3",
     "@testing-library/user-event": "^12.0.11",
+    "@types/jest": "^24.9.1",
     "@types/lodash": "^4.14.138",
     "@types/react": "^16.9.5",
     "@types/storybook__addon-viewport": "^4.1.0",
@@ -73,7 +74,7 @@
     "@types/user-event": "^4.1.0",
     "babel-jest": "^24.7.1",
     "babel-loader": "^8.0.5",
-    "csstype": "^2.6.4",
+    "csstype": "^2.6.11",
     "jest": "^24.7.1",
     "jest-styled-components": "^6.2.1",
     "prop-types": "^15.7.2",
@@ -81,7 +82,7 @@
     "react-dom": "^16.10.2",
     "rollup-plugin-commonjs": "^9.3.4",
     "styled-components": "^4.4.1",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.7"
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -137,7 +137,7 @@ export const AccessibleField = styled(AccessibleFieldBase)`
 
   ${Tooltip}  {
     position: absolute;
-    right: 8px
+    right: 8px;
     top: 2px;
     font-size: 16px;
   }

--- a/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -363,22 +363,6 @@ exports[`component: Accordion with theme customization outline accordion should 
   border-color: hsl(200,29%,90%);
 }
 
-.c5 + .c0 {
-  margin-top: 8px;
-}
-
-.c6 + .c0 {
-  margin-top: 8px;
-}
-
-.c7 + .c0 {
-  margin-top: 8px;
-}
-
-.c8 + .c0 {
-  margin-top: 8px;
-}
-
 .c1 {
   box-sizing: border-box;
   width: 100%;
@@ -518,14 +502,6 @@ exports[`component: Accordion with theme customization outline accordion should 
 .c2.outline-variant.is-open {
   border-bottom: 2px solid;
   border-color: hsl(200,29%,90%);
-}
-
-.c5 + .c0 {
-  margin-top: 8px;
-}
-
-.c6 + .c0 {
-  margin-top: 8px;
 }
 
 .c1 {
@@ -669,18 +645,6 @@ exports[`component: Accordion with theme customization outline accordion should 
   border-color: hsl(200,29%,90%);
 }
 
-.c5 + .c0 {
-  margin-top: 8px;
-}
-
-.c6 + .c0 {
-  margin-top: 8px;
-}
-
-.c7 + .c0 {
-  margin-top: 8px;
-}
-
 .c1 {
   box-sizing: border-box;
   width: 100%;
@@ -822,10 +786,6 @@ exports[`component: Accordion with theme customization outline accordion should 
   border-color: hsl(200,29%,90%);
 }
 
-.c5 + .c0 {
-  margin-top: 8px;
-}
-
 .c1 {
   box-sizing: border-box;
   width: 100%;
@@ -886,11 +846,11 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 exports[`component: Accordion with theme customization simple accordion should have 2px border 1`] = `
 <DocumentFragment>
-  .c4 {
+  .c3 {
   vertical-align: middle;
 }
 
-.c3 {
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -914,19 +874,19 @@ exports[`component: Accordion with theme customization simple accordion should h
   font-size: 16px;
 }
 
-.c3::-moz-focus-inner {
+.c2::-moz-focus-inner {
   border: 0;
 }
 
-.c3:focus {
+.c2:focus {
   background-color: hsla(200,96%,35%,0.3);
 }
 
-.c3:hover {
+.c2:hover {
   color: hsl(200,96%,35%);
 }
 
-.c2 {
+.c1 {
   box-sizing: border-box;
   width: 100%;
   min-height: 48px;
@@ -944,61 +904,57 @@ exports[`component: Accordion with theme customization simple accordion should h
   outline: none;
 }
 
-.c2::-moz-focus-inner {
+.c1::-moz-focus-inner {
   border: 0;
 }
 
-.c2 p,
-.c2 h1,
-.c2 h2,
-.c2 h3,
-.c2 h4 {
+.c1 p,
+.c1 h1,
+.c1 h2,
+.c1 h3,
+.c1 h4 {
   margin: 0;
 }
 
-.c2.outline-variant {
+.c1.outline-variant {
   padding-left: 16px;
   padding-right: 16px;
 }
 
-.c2.outline-variant.is-open {
+.c1.outline-variant.is-open {
   border-bottom: 2px solid;
   border-color: hsl(200,29%,90%);
 }
 
-.c5 + .c0 {
-  margin-top: 8px;
-}
-
-.c1 {
+.c0 {
   box-sizing: border-box;
   width: 100%;
   border-bottom: 2px solid;
   border-color: hsl(200,29%,90%);
 }
 
-.c1.box-shadow {
+.c0.box-shadow {
   border: 0px;
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c1:first-of-type {
+.c0:first-of-type {
   border-top: 2px solid hsl(200,29%,90%);
 }
 
 <div
-    class="c0 c1 "
+    class="c0 "
     id="accordion"
   >
     <div
-      class="c2  "
+      class="c1  "
       id="accordion-header"
     >
       <button
         aria-controls="accordion-body"
         aria-expanded="false"
         aria-labelledby="accordion-header"
-        class="c3"
+        class="c2"
         data-role="accordion-button"
         role="button"
         type="button"
@@ -1006,7 +962,7 @@ exports[`component: Accordion with theme customization simple accordion should h
       >
         <svg
           aria-hidden="true"
-          class="c4"
+          class="c3"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"

--- a/modules/cactus-web/src/Alert/__snapshots__/Alert.test.tsx.snap
+++ b/modules/cactus-web/src/Alert/__snapshots__/Alert.test.tsx.snap
@@ -6,10 +6,6 @@ exports[`component: Alert should render general error alert 1`] = `
   vertical-align: middle;
 }
 
-.c4 .c2 {
-  padding-bottom: 4px;
-}
-
 .c1 {
   box-sizing: border-box;
   width: 40px;
@@ -71,7 +67,7 @@ exports[`component: Alert should render general error alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c5 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -134,7 +130,7 @@ exports[`component: Alert should render general info alert 1`] = `
   color: hsl(200,10%,20%);
 }
 
-.c1 .c3 {
+.c1 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -174,7 +170,7 @@ exports[`component: Alert should render general info alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c4 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -237,7 +233,7 @@ exports[`component: Alert should render general success alert 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c1 .c3 {
+.c1 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -277,7 +273,7 @@ exports[`component: Alert should render general success alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c4 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -340,7 +336,7 @@ exports[`component: Alert should render general warning alert 1`] = `
   background-color: hsla(47,82%,47%,0.3);
 }
 
-.c1 .c3 {
+.c1 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -380,7 +376,7 @@ exports[`component: Alert should render general warning alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c4 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -422,10 +418,6 @@ exports[`component: Alert should render push notification error alert 1`] = `
   vertical-align: middle;
 }
 
-.c4 .c2 {
-  padding-bottom: 4px;
-}
-
 .c1 {
   box-sizing: border-box;
   width: 40px;
@@ -448,14 +440,6 @@ exports[`component: Alert should render push notification error alert 1`] = `
 }
 
 .c1 .c2 {
-  padding-bottom: 4px;
-}
-
-.c5 .c2 {
-  padding-bottom: 4px;
-}
-
-.c6 .c2 {
   padding-bottom: 4px;
 }
 
@@ -494,7 +478,7 @@ exports[`component: Alert should render push notification error alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c7 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -557,7 +541,7 @@ exports[`component: Alert should render push notification info alert 1`] = `
   color: hsl(200,10%,20%);
 }
 
-.c1 .c3 {
+.c1 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -596,7 +580,7 @@ exports[`component: Alert should render push notification info alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c4 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -659,7 +643,7 @@ exports[`component: Alert should render push notification success alert 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c1 .c3 {
+.c1 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -698,7 +682,7 @@ exports[`component: Alert should render push notification success alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c4 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -761,7 +745,7 @@ exports[`component: Alert should render push notification warning alert 1`] = `
   background-color: hsla(47,82%,47%,0.3);
 }
 
-.c1 .c3 {
+.c1 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -800,7 +784,7 @@ exports[`component: Alert should render push notification warning alert 1`] = `
   margin-top: 8px;
 }
 
-.c0 .c4 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;
@@ -863,7 +847,7 @@ exports[`component: Alert should render the default props, general info alert 1`
   color: hsl(200,10%,20%);
 }
 
-.c1 .c3 {
+.c1 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -903,7 +887,7 @@ exports[`component: Alert should render the default props, general info alert 1`
   margin-top: 8px;
 }
 
-.c0 .c4 {
+.c0 .sc-qQxXP {
   -webkit-flex: 0;
   -ms-flex: 0;
   flex: 0;

--- a/modules/cactus-web/src/Avatar/__snapshots__/Avatar.test.tsx.snap
+++ b/modules/cactus-web/src/Avatar/__snapshots__/Avatar.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`component: Avatars Alert Avatar, Alert 1`] = `
   background-color: hsla(47,82%,47%,0.3);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -77,7 +77,7 @@ exports[`component: Avatars Alert Avatar, Alert, disabled 1`] = `
   background-color: hsl(0,0%,70%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -127,7 +127,7 @@ exports[`component: Avatars Alert Avatar, Check 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -177,7 +177,7 @@ exports[`component: Avatars Alert Avatar, Check, disabled 1`] = `
   background-color: hsl(0,0%,70%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -204,22 +204,6 @@ exports[`component: Avatars Alert Avatar, Error 1`] = `
 .c2 {
   font-size: 24px;
   vertical-align: middle;
-}
-
-.c3 .c1 {
-  padding-bottom: 4px;
-}
-
-.c4 .c1 {
-  padding-bottom: 4px;
-}
-
-.c5 .c1 {
-  padding-bottom: 4px;
-}
-
-.c6 .c1 {
-  padding-bottom: 4px;
 }
 
 .c0 {
@@ -270,34 +254,6 @@ exports[`component: Avatars Alert Avatar, Error, disabled 1`] = `
 .c2 {
   font-size: 24px;
   vertical-align: middle;
-}
-
-.c3 .c1 {
-  padding-bottom: 4px;
-}
-
-.c4 .c1 {
-  padding-bottom: 4px;
-}
-
-.c5 .c1 {
-  padding-bottom: 4px;
-}
-
-.c6 .c1 {
-  padding-bottom: 4px;
-}
-
-.c7 .c1 {
-  padding-bottom: 4px;
-}
-
-.c8 .c1 {
-  padding-bottom: 4px;
-}
-
-.c9 .c1 {
-  padding-bottom: 4px;
 }
 
 .c0 {
@@ -371,7 +327,7 @@ exports[`component: Avatars Alert Avatar, Information 1`] = `
   color: hsl(200,10%,20%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -421,7 +377,7 @@ exports[`component: Avatars Alert Avatar, Information, disabled 1`] = `
   background-color: hsl(0,0%,70%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -471,7 +427,7 @@ exports[`component: Avatars Default Avatar 1`] = `
   color: hsl(200,10%,20%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -521,7 +477,7 @@ exports[`component: Avatars Default Avatar, disabled 1`] = `
   background-color: hsl(0,0%,70%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -571,7 +527,7 @@ exports[`component: Avatars Feed Back Avatar, Alert 1`] = `
   color: hsl(200,10%,20%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -621,7 +577,7 @@ exports[`component: Avatars Feed Back Avatar, Alert, disabled 1`] = `
   background-color: hsl(0,0%,70%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -671,7 +627,7 @@ exports[`component: Avatars Feed Back Avatar, Check 1`] = `
   color: hsl(0,0%,100%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -721,7 +677,7 @@ exports[`component: Avatars Feed Back Avatar, Check, disabled 1`] = `
   background-color: hsl(0,0%,70%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -748,10 +704,6 @@ exports[`component: Avatars Feed Back Avatar, Error 1`] = `
 .c2 {
   font-size: 24px;
   vertical-align: middle;
-}
-
-.c3 .c1 {
-  padding-bottom: 4px;
 }
 
 .c0 {
@@ -802,34 +754,6 @@ exports[`component: Avatars Feed Back Avatar, Error, disabled 1`] = `
 .c2 {
   font-size: 24px;
   vertical-align: middle;
-}
-
-.c3 .c1 {
-  padding-bottom: 4px;
-}
-
-.c4 .c1 {
-  padding-bottom: 4px;
-}
-
-.c5 .c1 {
-  padding-bottom: 4px;
-}
-
-.c6 .c1 {
-  padding-bottom: 4px;
-}
-
-.c7 .c1 {
-  padding-bottom: 4px;
-}
-
-.c8 .c1 {
-  padding-bottom: 4px;
-}
-
-.c9 .c1 {
-  padding-bottom: 4px;
 }
 
 .c0 {
@@ -903,7 +827,7 @@ exports[`component: Avatars Feed Back Avatar, Information 1`] = `
   color: hsl(200,10%,20%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -953,7 +877,7 @@ exports[`component: Avatars Feed Back Avatar, Information, disabled 1`] = `
   background-color: hsl(0,0%,70%);
 }
 
-.c0 .c2 {
+.c0 .sc-fzqOul {
   padding-bottom: 4px;
 }
 

--- a/modules/cactus-web/src/Box/Box.story.tsx
+++ b/modules/cactus-web/src/Box/Box.story.tsx
@@ -1,6 +1,7 @@
 import cactusTheme, { TextStyleCollection } from '@repay/cactus-theme'
 import { select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
+import { PositionProperty, ZIndexProperty } from 'csstype'
 import React from 'react'
 
 import Box from './Box'
@@ -35,8 +36,7 @@ const textStyles = Object.keys(cactusTheme.textStyles)
 storiesOf('Box', module)
   .add('Basic Usage with theme build-in values', () => (
     <Box
-      // @ts-ignore
-      position={select('position', positionOptions, 'initial')}
+      position={select('position', positionOptions, 'initial') as PositionProperty}
       display={select('display', displayOptions, 'initial')}
       top={text('top', '')}
       right={text('right', '')}
@@ -57,8 +57,7 @@ storiesOf('Box', module)
       borderRadius={text('borderRadius', '')}
       borderStyle={text('borderStyle', 'solid')}
       textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
-      // @ts-ignore
-      zIndex={text('zIndex', '')}
+      zIndex={text('zIndex', '') as ZIndexProperty}
     >
       {text('children', 'Example Content')}
     </Box>
@@ -66,7 +65,6 @@ storiesOf('Box', module)
   .add('Using colorStyles for color and background', () => (
     <Box
       colors={select('colors', colorStyles, 'callToAction')}
-      // @ts-ignore
       margin={select('margin', sizes, 0)}
       padding={select('padding', sizes, 4)}
       width={text('width', '100px')}

--- a/modules/cactus-web/src/Button/Button.test.tsx
+++ b/modules/cactus-web/src/Button/Button.test.tsx
@@ -99,7 +99,7 @@ describe('component: Button', () => {
     const button = render(
       <StyleProvider>
         <Button disabled inverse>
-          }>Click me!
+          Click me!
         </Button>
       </StyleProvider>
     )

--- a/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`With theme changes  Should have intermediate border radius 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -115,7 +115,7 @@ exports[`With theme changes  Should have square border radius 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -189,7 +189,7 @@ exports[`With theme changes  Should not have box shadows applied 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -263,7 +263,7 @@ exports[`With theme changes  should have 2px border 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -337,7 +337,7 @@ exports[`component: Button should default to standard variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -375,8 +375,8 @@ exports[`component: Button should render Spinner when loading is true 1`] = `
   .c2 {
   font-size: 16px;
   vertical-align: middle;
-  -webkit-animation: iVXCSc 0.75s linear infinite;
-  animation: iVXCSc 0.75s linear infinite;
+  -webkit-animation: bKPVWD 0.75s linear infinite;
+  animation: bKPVWD 0.75s linear infinite;
 }
 
 .c0 {
@@ -432,62 +432,6 @@ exports[`component: Button should render Spinner when loading is true 1`] = `
   border-color: hsl(200,96%,11%);
 }
 
-.c3 .c1 {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -8px;
-  margin-top: -8px;
-}
-
-.c4 .c1 {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -8px;
-  margin-top: -8px;
-}
-
-.c5 .c1 {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -8px;
-  margin-top: -8px;
-}
-
-.c6 .c1 {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -8px;
-  margin-top: -8px;
-}
-
-.c7 .c1 {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -8px;
-  margin-top: -8px;
-}
-
-.c8 .c1 {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -8px;
-  margin-top: -8px;
-}
-
-.c9 .c1 {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  margin-left: -8px;
-  margin-top: -8px;
-}
-
 @media screen and (min-width:1024px) {
   .c0 {
     font-size: 18px;
@@ -509,7 +453,7 @@ exports[`component: Button should render Spinner when loading is true 1`] = `
     </span>
     <svg
       aria-label="loading"
-      class="c1 c2"
+      class="sc-qYiqT c1 c2"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -565,7 +509,7 @@ exports[`component: Button should render call to action variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -639,7 +583,7 @@ exports[`component: Button should render danger variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -714,7 +658,7 @@ exports[`component: Button should render disabled variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -783,7 +727,7 @@ exports[`component: Button should render inverse call to action variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -857,7 +801,7 @@ exports[`component: Button should render inverse danger variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -931,7 +875,7 @@ exports[`component: Button should render inverse disabled variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -1000,7 +944,7 @@ exports[`component: Button should render inverse standard variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -1074,7 +1018,7 @@ exports[`component: Button should render standard variant 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -1149,7 +1093,7 @@ exports[`component: Button should support margin space props 1`] = `
   margin-top: -4px;
 }
 
-.c0 .c1 {
+.c0 .sc-psCJM {
   position: absolute;
   left: 50%;
   top: 50%;

--- a/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
+++ b/modules/cactus-web/src/Button/__snapshots__/Button.test.tsx.snap
@@ -953,7 +953,7 @@ exports[`component: Button should render inverse disabled variant 1`] = `
     type="button"
   >
     <span>
-      }&gt;Click me!
+      Click me!
     </span>
   </button>
 </DocumentFragment>

--- a/modules/cactus-web/src/Card/__snapshots__/Card.test.tsx.snap
+++ b/modules/cactus-web/src/Card/__snapshots__/Card.test.tsx.snap
@@ -1,16 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component: Card should support margin space props 1`] = `
-.c2 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c2 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
 .c1 {
   box-sizing: border-box;
   margin: 4px;
@@ -77,47 +67,7 @@ exports[`component: Card snapshot 1`] = `
 
 exports[`component: Card with theme customization should have 1px border radius 1`] = `
 <DocumentFragment>
-  .c2 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c2 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c3 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c3 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c4 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c4 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c5 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c5 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c1 {
+  .c1 {
   box-sizing: border-box;
   background-color: hsl(0,0%,100%);
   color: hsl(200,10%,20%);
@@ -148,37 +98,7 @@ exports[`component: Card with theme customization should have 1px border radius 
 
 exports[`component: Card with theme customization should have 4px border radius 1`] = `
 <DocumentFragment>
-  .c2 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c2 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c3 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c3 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c4 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c4 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c1 {
+  .c1 {
   box-sizing: border-box;
   background-color: hsl(0,0%,100%);
   color: hsl(200,10%,20%);
@@ -209,27 +129,7 @@ exports[`component: Card with theme customization should have 4px border radius 
 
 exports[`component: Card with theme customization should have no box shadow & 2px borders 1`] = `
 <DocumentFragment>
-  .c2 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c2 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c3 > .c0 {
-  padding: 24px;
-  color: pink;
-}
-
-.c3 > .c0 > .c0 {
-  padding: 32px;
-  color: blue;
-}
-
-.c1 {
+  .c1 {
   box-sizing: border-box;
   background-color: hsl(0,0%,100%);
   color: hsl(200,10%,20%);

--- a/modules/cactus-web/src/CheckBoxField/__snapshots__/CheckBoxField.test.tsx.snap
+++ b/modules/cactus-web/src/CheckBoxField/__snapshots__/CheckBoxField.test.tsx.snap
@@ -193,15 +193,6 @@ exports[`component: CheckBoxField should render a disabled checkbox field 1`] = 
   color: hsl(200,10%,20%);
 }
 
-.c10 + .c2 {
-  margin-top: 8px;
-}
-
-.c10 .c8 {
-  cursor: pointer;
-  padding-left: 8px;
-}
-
 .c3 + .c2 {
   margin-top: 8px;
 }
@@ -329,24 +320,6 @@ exports[`component: CheckBoxField should support margin space props 1`] = `
   line-height: 1.5;
   font-weight: 600;
   color: hsl(200,10%,20%);
-}
-
-.c10 + .c2 {
-  margin-top: 8px;
-}
-
-.c10 .c8 {
-  cursor: pointer;
-  padding-left: 8px;
-}
-
-.c11 + .c2 {
-  margin-top: 8px;
-}
-
-.c11 .c8 {
-  cursor: not-allowed;
-  padding-left: 8px;
 }
 
 .c3 {

--- a/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
@@ -2,7 +2,27 @@
 
 exports[`Modal renders TextInput and Description snapshot 1`] = `
 <body>
-  <div
+  @media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+<div
     aria-hidden="true"
   />
   .c7 {
@@ -105,7 +125,7 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
   margin-top: -4px;
 }
 
-.c13 .c17 {
+.c13 .sc-pReKu {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -223,22 +243,6 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
 
 .c3:hover {
   color: hsl(200,96%,35%);
-}
-
-.c15 > [data-reach-dialog-content] .c2 {
-  height: 16px;
-  position: absolute;
-  right: 24px;
-  top: 24px;
-  width: 16px;
-}
-
-.c16 > [data-reach-dialog-content] .c2 {
-  height: 16px;
-  position: absolute;
-  right: 24px;
-  top: 24px;
-  width: 16px;
 }
 
 .c0 {
@@ -361,26 +365,6 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
 }
 
 @media screen and (min-width:1024px) {
-  .c15 > [data-reach-dialog-content] .c2 {
-    height: 24px;
-    position: absolute;
-    right: 40px;
-    top: 40px;
-    width: 24px;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c16 > [data-reach-dialog-content] .c2 {
-    height: 24px;
-    position: absolute;
-    right: 40px;
-    top: 40px;
-    width: 24px;
-  }
-}
-
-@media screen and (min-width:1024px) {
   .c0 > [data-reach-dialog-content] {
     padding: 40px 88px;
     max-width: 30%;
@@ -457,11 +441,11 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
               </svg>
             </button>
             <div
-              class="c5"
+              class="sc-oTBUA c5"
               display="flex"
             >
               <div
-                class="c6 title-icon"
+                class="sc-oTBUA c6 title-icon"
                 display="flex"
               >
                 <h1
@@ -471,7 +455,7 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
                 </h1>
               </div>
               <div
-                class="c8 children"
+                class="sc-oTBUA c8 children"
                 display="flex"
               >
                 <h4
@@ -493,7 +477,7 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
                 </div>
               </div>
               <div
-                class="c12"
+                class="sc-oTBUA c12"
                 display="flex"
               >
                 <button
@@ -528,7 +512,23 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
 
 exports[`Modal variant is danger snapshot 1`] = `
 <body>
-  <div
+  @media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+<div
     aria-hidden="true"
   />
   .c7 {
@@ -579,7 +579,7 @@ exports[`Modal variant is danger snapshot 1`] = `
   margin-top: -4px;
 }
 
-.c10 .c14 {
+.c10 .sc-pReKu {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -699,22 +699,6 @@ exports[`Modal variant is danger snapshot 1`] = `
   color: hsl(200,96%,35%);
 }
 
-.c12 > [data-reach-dialog-content] .c2 {
-  height: 16px;
-  position: absolute;
-  right: 24px;
-  top: 24px;
-  width: 16px;
-}
-
-.c13 > [data-reach-dialog-content] .c2 {
-  height: 16px;
-  position: absolute;
-  right: 24px;
-  top: 24px;
-  width: 16px;
-}
-
 .c0 {
   background: rgba(46,53,56,0.33);
   bottom: 0;
@@ -828,26 +812,6 @@ exports[`Modal variant is danger snapshot 1`] = `
 }
 
 @media screen and (min-width:1024px) {
-  .c12 > [data-reach-dialog-content] .c2 {
-    height: 24px;
-    position: absolute;
-    right: 40px;
-    top: 40px;
-    width: 24px;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c13 > [data-reach-dialog-content] .c2 {
-    height: 24px;
-    position: absolute;
-    right: 40px;
-    top: 40px;
-    width: 24px;
-  }
-}
-
-@media screen and (min-width:1024px) {
   .c0 > [data-reach-dialog-content] {
     padding: 40px 88px;
     max-width: 30%;
@@ -924,11 +888,11 @@ exports[`Modal variant is danger snapshot 1`] = `
               </svg>
             </button>
             <div
-              class="c5"
+              class="sc-oTBUA c5"
               display="flex"
             >
               <div
-                class="c6 title-icon"
+                class="sc-oTBUA c6 title-icon"
                 display="flex"
               >
                 <h1
@@ -938,11 +902,11 @@ exports[`Modal variant is danger snapshot 1`] = `
                 </h1>
               </div>
               <div
-                class="c8 children"
+                class="sc-oTBUA c8 children"
                 display="flex"
               />
               <div
-                class="c9"
+                class="sc-oTBUA c9"
                 display="flex"
               >
                 <button
@@ -977,7 +941,23 @@ exports[`Modal variant is danger snapshot 1`] = `
 
 exports[`Modal variant is success snapshot 1`] = `
 <body>
-  <div
+  @media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
+
+}
+
+<div
     aria-hidden="true"
   />
   .c7 {
@@ -1028,7 +1008,7 @@ exports[`Modal variant is success snapshot 1`] = `
   margin-top: -4px;
 }
 
-.c10 .c13 {
+.c10 .sc-pReKu {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -1148,14 +1128,6 @@ exports[`Modal variant is success snapshot 1`] = `
   color: hsl(200,96%,35%);
 }
 
-.c12 > [data-reach-dialog-content] .c2 {
-  height: 16px;
-  position: absolute;
-  right: 24px;
-  top: 24px;
-  width: 16px;
-}
-
 .c0 {
   background: rgba(46,53,56,0.33);
   bottom: 0;
@@ -1269,16 +1241,6 @@ exports[`Modal variant is success snapshot 1`] = `
 }
 
 @media screen and (min-width:1024px) {
-  .c12 > [data-reach-dialog-content] .c2 {
-    height: 24px;
-    position: absolute;
-    right: 40px;
-    top: 40px;
-    width: 24px;
-  }
-}
-
-@media screen and (min-width:1024px) {
   .c0 > [data-reach-dialog-content] {
     padding: 40px 88px;
     max-width: 30%;
@@ -1355,11 +1317,11 @@ exports[`Modal variant is success snapshot 1`] = `
               </svg>
             </button>
             <div
-              class="c5"
+              class="sc-oTBUA c5"
               display="flex"
             >
               <div
-                class="c6 title-icon"
+                class="sc-oTBUA c6 title-icon"
                 display="flex"
               >
                 <h1
@@ -1369,11 +1331,11 @@ exports[`Modal variant is success snapshot 1`] = `
                 </h1>
               </div>
               <div
-                class="c8 children"
+                class="sc-oTBUA c8 children"
                 display="flex"
               />
               <div
-                class="c9"
+                class="sc-oTBUA c9"
                 display="flex"
               >
                 <button
@@ -1455,7 +1417,7 @@ exports[`Modal variant is warning snapshot 1`] = `
   margin-top: -4px;
 }
 
-.c10 .c12 {
+.c10 .sc-pReKu {
   position: absolute;
   left: 50%;
   top: 50%;
@@ -1768,11 +1730,11 @@ exports[`Modal variant is warning snapshot 1`] = `
               </svg>
             </button>
             <div
-              class="c5"
+              class="sc-oTBUA c5"
               display="flex"
             >
               <div
-                class="c6 title-icon"
+                class="sc-oTBUA c6 title-icon"
                 display="flex"
               >
                 <h1
@@ -1782,11 +1744,11 @@ exports[`Modal variant is warning snapshot 1`] = `
                 </h1>
               </div>
               <div
-                class="c8 children"
+                class="sc-oTBUA c8 children"
                 display="flex"
               />
               <div
-                class="c9"
+                class="sc-oTBUA c9"
                 display="flex"
               >
                 <button

--- a/modules/cactus-web/src/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/modules/cactus-web/src/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -506,6 +506,10 @@ exports[`component: DataGrid snapshot 1`] = `
 }
 
 @media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
   .c17,
   .c17:link {
     font-size: 15px;

--- a/modules/cactus-web/src/DateInput/__snapshots__/DateInput.test.tsx.snap
+++ b/modules/cactus-web/src/DateInput/__snapshots__/DateInput.test.tsx.snap
@@ -378,20 +378,6 @@ exports[`component: DateInput with theme customization should have 2px border 1`
   cursor: pointer;
 }
 
-.c10 > .c4 {
-  margin-left: 0;
-}
-
-.c10 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c10 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
 .c0 {
   position: relative;
   color: hsl(200,9%,35%);
@@ -683,34 +669,6 @@ exports[`component: DateInput with theme customization should match intermediate
   cursor: pointer;
 }
 
-.c10 > .c4 {
-  margin-left: 0;
-}
-
-.c10 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c10 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
-.c11 > .c4 {
-  margin-left: 0;
-}
-
-.c11 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c11 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
 .c0 {
   position: relative;
   color: hsl(200,9%,35%);
@@ -1000,48 +958,6 @@ exports[`component: DateInput with theme customization should match square shape
   appearance: none;
   border: none;
   cursor: pointer;
-}
-
-.c10 > .c4 {
-  margin-left: 0;
-}
-
-.c10 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c10 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
-.c11 > .c4 {
-  margin-left: 0;
-}
-
-.c11 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c11 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
-.c12 > .c4 {
-  margin-left: 0;
-}
-
-.c12 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c12 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
 }
 
 .c0 {
@@ -1431,48 +1347,6 @@ exports[`component: DateInput with theme customization should not have box shado
 }
 
 .c0 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
-.c10 > .c4 {
-  margin-left: 0;
-}
-
-.c10 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c10 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
-.c11 > .c4 {
-  margin-left: 0;
-}
-
-.c11 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c11 .c6 {
-  margin-right: -2px;
-  margin-left: auto;
-}
-
-.c12 > .c4 {
-  margin-left: 0;
-}
-
-.c12 .c1 {
-  font-size: 16px;
-  margin-right: 8px;
-}
-
-.c12 .c6 {
   margin-right: -2px;
   margin-left: auto;
 }

--- a/modules/cactus-web/src/DateInputField/__snapshots__/DateInputField.test.tsx.snap
+++ b/modules/cactus-web/src/DateInputField/__snapshots__/DateInputField.test.tsx.snap
@@ -35,14 +35,14 @@ exports[`component: DateInputField snapshot 1`] = `
   padding-right: 28px;
 }
 
-.c2 .c18 {
+.c2 .sc-pReKu {
   position: absolute;
   right: 8px;
   top: 2px;
   font-size: 16px;
 }
 
-.c2 .c17 {
+.c2 .sc-qYSYK {
   margin-top: 4px;
 }
 

--- a/modules/cactus-web/src/FieldWrapper/FieldWrapper.story.tsx
+++ b/modules/cactus-web/src/FieldWrapper/FieldWrapper.story.tsx
@@ -191,7 +191,7 @@ const ExampleForm = ({ withValidations }: { withValidations?: boolean }) => {
         minWidth="350px"
         margin="0 auto"
         py={5}
-        onSubmit={(event) => event.preventDefault()}
+        onSubmit={(event: React.FormEvent<HTMLFormElement>) => event.preventDefault()}
       >
         {fields.map((field) => {
           const Field = fieldTypeMap[field.type]

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -51,13 +51,6 @@ exports[`component: FileInput should render a disabled file input 1`] = `
   margin-right: 4px;
 }
 
-.c7 .c2 {
-  position: absolute;
-  top: 30%;
-  left: 15%;
-  color: hsl(200,96%,35%);
-}
-
 .c1 {
   width: 300px;
   height: 100px;
@@ -75,17 +68,6 @@ exports[`component: FileInput should render a disabled file input 1`] = `
   top: 20%;
   left: 37%;
   color: hsl(0,0%,70%);
-}
-
-.c8.empty .c4 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c8.notEmpty .c4 {
-  position: relative;
-  margin: 16px 0 16px 0;
 }
 
 .c0 {
@@ -384,10 +366,6 @@ exports[`component: FileInput should render a file with an error 1`] = `
   vertical-align: middle;
 }
 
-.c17 .c5 {
-  padding-bottom: 4px;
-}
-
 .c4 {
   box-sizing: border-box;
   width: 40px;
@@ -460,8 +438,8 @@ exports[`component: FileInput should render a file with an error 1`] = `
 }
 
 .c12 .c5,
-.c12 .sc-kafWEX,
-.c12 .c21 {
+.c12 .sc-fzqzEs,
+.c12 .sc-pZBmh {
   margin-right: 4px;
   vertical-align: -2px;
 }
@@ -510,54 +488,6 @@ exports[`component: FileInput should render a file with an error 1`] = `
   margin-right: 4px;
 }
 
-.c18 .c3 {
-  height: 24px;
-  width: 24px;
-}
-
-.c18 .c3 .c5 {
-  height: 16px;
-  width: 16px;
-}
-
-.c18 .c3 .c21 {
-  height: 18px;
-  width: 18px;
-}
-
-.c18 .c7 {
-  margin-left: auto;
-}
-
-.c18 .c9 {
-  height: 12px;
-  width: 12px;
-}
-
-.c19 .c3 {
-  height: 24px;
-  width: 24px;
-}
-
-.c19 .c3 .c5 {
-  height: 16px;
-  width: 16px;
-}
-
-.c19 .c3 .c21 {
-  height: 18px;
-  width: 18px;
-}
-
-.c19 .c7 {
-  margin-left: auto;
-}
-
-.c19 .c9 {
-  height: 12px;
-  width: 12px;
-}
-
 .c2 {
   box-sizing: border-box;
   width: 100%;
@@ -599,12 +529,12 @@ exports[`component: FileInput should render a file with an error 1`] = `
   width: 16px;
 }
 
-.c2 .c3 .c21 {
+.c2 .c3 .sc-pZBmh {
   height: 18px;
   width: 18px;
 }
 
-.c2 .c22 {
+.c2 .sc-qYSYK {
   height: 12px;
   width: 12px;
 }
@@ -670,17 +600,6 @@ exports[`component: FileInput should render a file with an error 1`] = `
 
 .c0 input {
   display: none;
-}
-
-.c20.empty .c14 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c20.notEmpty .c14 {
-  position: relative;
-  margin: 16px 0 16px 0;
 }
 
 @media screen and (min-width:1024px) {
@@ -837,7 +756,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c4 .c16 {
+.c4 .sc-fzqOul {
   padding-bottom: 4px;
 }
 
@@ -920,30 +839,6 @@ exports[`component: FileInput should render a loaded file 1`] = `
   margin-right: 4px;
 }
 
-.c14 .c3 {
-  height: 24px;
-  width: 24px;
-}
-
-.c14 .c3 .c16 {
-  height: 16px;
-  width: 16px;
-}
-
-.c14 .c3 .c5 {
-  height: 18px;
-  width: 18px;
-}
-
-.c14 .c7 {
-  margin-left: auto;
-}
-
-.c14 .c9 {
-  height: 12px;
-  width: 12px;
-}
-
 .c2 {
   box-sizing: border-box;
   width: 100%;
@@ -980,7 +875,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 24px;
 }
 
-.c2 .c3 .c16 {
+.c2 .c3 .sc-fzqOul {
   height: 16px;
   width: 16px;
 }
@@ -990,7 +885,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 18px;
 }
 
-.c2 .c17 {
+.c2 .sc-qYSYK {
   height: 12px;
   width: 12px;
 }
@@ -1008,7 +903,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 100%;
 }
 
-.c1 .c18 {
+.c1 .sc-pBolk {
   position: relative;
   margin-top: 4px;
 }
@@ -1056,17 +951,6 @@ exports[`component: FileInput should render a loaded file 1`] = `
 
 .c0 input {
   display: none;
-}
-
-.c15.empty .c11 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c15.notEmpty .c11 {
-  position: relative;
-  margin: 16px 0 16px 0;
 }
 
 @media screen and (min-width:1024px) {
@@ -1169,8 +1053,8 @@ exports[`component: FileInput should render a loading file 1`] = `
 .c4 {
   vertical-align: middle;
   font-size: 40px;
-  -webkit-animation: iVXCSc 0.75s linear infinite;
-  animation: iVXCSc 0.75s linear infinite;
+  -webkit-animation: bKPVWD 0.75s linear infinite;
+  animation: bKPVWD 0.75s linear infinite;
 }
 
 .c6 {
@@ -1247,17 +1131,17 @@ exports[`component: FileInput should render a loading file 1`] = `
   line-height: 1.5;
 }
 
-.c2 .c12 {
+.c2 .sc-psCJM {
   height: 24px;
   width: 24px;
 }
 
-.c2 .c12 .c10 {
+.c2 .sc-psCJM .sc-fzqOul {
   height: 16px;
   width: 16px;
 }
 
-.c2 .c12 .c11 {
+.c2 .sc-psCJM .sc-pZBmh {
   height: 18px;
   width: 18px;
 }
@@ -1267,11 +1151,11 @@ exports[`component: FileInput should render a loading file 1`] = `
   width: 12px;
 }
 
-.c2 .c13 {
+.c2 .sc-qQxXP {
   margin-left: auto;
 }
 
-.c2 .c9 {
+.c2 .sc-fzoxnE {
   height: 12px;
   width: 12px;
 }
@@ -1280,7 +1164,7 @@ exports[`component: FileInput should render a loading file 1`] = `
   width: 100%;
 }
 
-.c1 .c14 {
+.c1 .sc-pBolk {
   position: relative;
   margin-top: 4px;
 }
@@ -1330,17 +1214,6 @@ exports[`component: FileInput should render a loading file 1`] = `
   display: none;
 }
 
-.c8.empty .c5 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c8.notEmpty .c5 {
-  position: relative;
-  margin: 16px 0 16px 0;
-}
-
 @media screen and (min-width:1024px) {
   .c6 {
     font-size: 18px;
@@ -1377,7 +1250,7 @@ exports[`component: FileInput should render a loading file 1`] = `
           boolest.md
         </span>
         <svg
-          class="c3 c4"
+          class="sc-qYiqT c3 c4"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -73,10 +73,9 @@ FileInputField.propTypes = {
   name: PropTypes.string.isRequired,
   accept: PropTypes.arrayOf(PropTypes.string) as PropTypes.Validator<string[] | undefined>,
   labels: PropTypes.shape({
-    delete: PropTypes.string,
-    retry: PropTypes.string,
-    loading: PropTypes.string,
-    loaded: PropTypes.string,
+    delete: PropTypes.string as PropTypes.Validator<string | undefined>,
+    loading: PropTypes.string as PropTypes.Validator<string | undefined>,
+    loaded: PropTypes.string as PropTypes.Validator<string | undefined>,
   }),
   buttonText: PropTypes.string,
   prompt: PropTypes.string,

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -58,7 +58,7 @@ export const FileInputField = styled(FileInputFieldBase)`
   ${Tooltip} {
     position: absolute;
     top: -2px;
-    right: 8px
+    right: 8px;
     font-size: 16px;
     ${(p) => p.disabled && `color: ${p.theme.colors.mediumGray};`}
   }

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -55,13 +55,6 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   margin-right: 4px;
 }
 
-.c14 .c9 {
-  position: absolute;
-  top: 30%;
-  left: 15%;
-  color: hsl(200,96%,35%);
-}
-
 .c8 {
   width: 300px;
   height: 100px;
@@ -79,17 +72,6 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   top: 20%;
   left: 37%;
   color: hsl(0,0%,70%);
-}
-
-.c15.empty .c11 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c15.notEmpty .c11 {
-  position: relative;
-  margin: 16px 0 16px 0;
 }
 
 .c7 {
@@ -150,20 +132,6 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   color: hsl(0,0%,70%);
 }
 
-.c16 .c3 {
-  display: block;
-  position: relative;
-  bottom: 4px;
-  padding-left: 16px;
-}
-
-.c16 .c5 {
-  position: absolute;
-  top: -2px;
-  right: 8px;
-  font-size: 16px;
-}
-
 .c2 {
   position: relative;
 }
@@ -213,7 +181,7 @@ exports[`component: FileInputField should render a disabled file input field 1`]
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6"
+        class="sc-fzoPby c6"
         disabled=""
         fill="currentcolor"
         height="1em"
@@ -300,10 +268,6 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   vertical-align: middle;
 }
 
-.c24 .c12 {
-  padding-bottom: 4px;
-}
-
 .c11 {
   box-sizing: border-box;
   width: 40px;
@@ -376,8 +340,8 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 }
 
 .c19 .c12,
-.c19 .sc-feJyhm,
-.c19 .c29 {
+.c19 .sc-fzqOul,
+.c19 .sc-oTbqq {
   margin-right: 4px;
   vertical-align: -2px;
 }
@@ -426,54 +390,6 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   margin-right: 4px;
 }
 
-.c25 .c10 {
-  height: 24px;
-  width: 24px;
-}
-
-.c25 .c10 .c12 {
-  height: 16px;
-  width: 16px;
-}
-
-.c25 .c10 .c29 {
-  height: 18px;
-  width: 18px;
-}
-
-.c25 .c14 {
-  margin-left: auto;
-}
-
-.c25 .c16 {
-  height: 12px;
-  width: 12px;
-}
-
-.c26 .c10 {
-  height: 24px;
-  width: 24px;
-}
-
-.c26 .c10 .c12 {
-  height: 16px;
-  width: 16px;
-}
-
-.c26 .c10 .c29 {
-  height: 18px;
-  width: 18px;
-}
-
-.c26 .c14 {
-  margin-left: auto;
-}
-
-.c26 .c16 {
-  height: 12px;
-  width: 12px;
-}
-
 .c9 {
   box-sizing: border-box;
   width: 100%;
@@ -515,12 +431,12 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   width: 16px;
 }
 
-.c9 .c10 .c29 {
+.c9 .c10 .sc-oTbqq {
   height: 18px;
   width: 18px;
 }
 
-.c9 .c30 {
+.c9 .sc-pBolk {
   height: 12px;
   width: 12px;
 }
@@ -588,17 +504,6 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   display: none;
 }
 
-.c27.empty .c21 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c27.notEmpty .c21 {
-  position: relative;
-  margin: 16px 0 16px 0;
-}
-
 .c4 {
   font-size: 18px;
   line-height: 1.5;
@@ -627,22 +532,6 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   top: -2px;
   right: 8px;
   font-size: 16px;
-}
-
-.c28 .c3 {
-  display: block;
-  position: relative;
-  bottom: 4px;
-  padding-left: 16px;
-  color: hsl(0,0%,70%);
-}
-
-.c28 .c5 {
-  position: absolute;
-  top: -2px;
-  right: 8px;
-  font-size: 16px;
-  color: hsl(0,0%,70%);
 }
 
 @media screen and (min-width:1024px) {
@@ -688,7 +577,7 @@ exports[`component: FileInputField should render a file with an error 1`] = `
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6"
+        class="sc-fzoPby c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -845,7 +734,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c11 .c24 {
+.c11 .sc-fzoCCn {
   padding-bottom: 4px;
 }
 
@@ -928,30 +817,6 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   margin-right: 4px;
 }
 
-.c21 .c10 {
-  height: 24px;
-  width: 24px;
-}
-
-.c21 .c10 .c24 {
-  height: 16px;
-  width: 16px;
-}
-
-.c21 .c10 .c12 {
-  height: 18px;
-  width: 18px;
-}
-
-.c21 .c14 {
-  margin-left: auto;
-}
-
-.c21 .c16 {
-  height: 12px;
-  width: 12px;
-}
-
 .c9 {
   box-sizing: border-box;
   width: 100%;
@@ -988,7 +853,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 24px;
 }
 
-.c9 .c10 .c24 {
+.c9 .c10 .sc-fzoCCn {
   height: 16px;
   width: 16px;
 }
@@ -998,7 +863,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 18px;
 }
 
-.c9 .c25 {
+.c9 .sc-pBolk {
   height: 12px;
   width: 12px;
 }
@@ -1016,7 +881,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 100%;
 }
 
-.c8 .c26 {
+.c8 .sc-pJkiN {
   position: relative;
   margin-top: 4px;
 }
@@ -1066,17 +931,6 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   display: none;
 }
 
-.c22.empty .c18 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c22.notEmpty .c18 {
-  position: relative;
-  margin: 16px 0 16px 0;
-}
-
 .c4 {
   font-size: 18px;
   line-height: 1.5;
@@ -1105,22 +959,6 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   top: -2px;
   right: 8px;
   font-size: 16px;
-}
-
-.c23 .c3 {
-  display: block;
-  position: relative;
-  bottom: 4px;
-  padding-left: 16px;
-  color: hsl(0,0%,70%);
-}
-
-.c23 .c5 {
-  position: absolute;
-  top: -2px;
-  right: 8px;
-  font-size: 16px;
-  color: hsl(0,0%,70%);
 }
 
 @media screen and (min-width:1024px) {
@@ -1159,7 +997,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6"
+        class="sc-fzoPby c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -1269,8 +1107,8 @@ exports[`component: FileInputField should render a loading file 1`] = `
 .c11 {
   vertical-align: middle;
   font-size: 40px;
-  -webkit-animation: iVXCSc 0.75s linear infinite;
-  animation: iVXCSc 0.75s linear infinite;
+  -webkit-animation: bKPVWD 0.75s linear infinite;
+  animation: bKPVWD 0.75s linear infinite;
 }
 
 .c13 {
@@ -1347,17 +1185,17 @@ exports[`component: FileInputField should render a loading file 1`] = `
   line-height: 1.5;
 }
 
-.c9 .c20 {
+.c9 .sc-qQxXP {
   height: 24px;
   width: 24px;
 }
 
-.c9 .c20 .c18 {
+.c9 .sc-qQxXP .sc-fzoCCn {
   height: 16px;
   width: 16px;
 }
 
-.c9 .c20 .c19 {
+.c9 .sc-qQxXP .sc-oTbqq {
   height: 18px;
   width: 18px;
 }
@@ -1367,11 +1205,11 @@ exports[`component: FileInputField should render a loading file 1`] = `
   width: 12px;
 }
 
-.c9 .c21 {
+.c9 .sc-qYSYK {
   margin-left: auto;
 }
 
-.c9 .c17 {
+.c9 .sc-fzoMdx {
   height: 12px;
   width: 12px;
 }
@@ -1380,7 +1218,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
   width: 100%;
 }
 
-.c8 .c22 {
+.c8 .sc-pJkiN {
   position: relative;
   margin-top: 4px;
 }
@@ -1430,17 +1268,6 @@ exports[`component: FileInputField should render a loading file 1`] = `
   display: none;
 }
 
-.c15.empty .c12 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c15.notEmpty .c12 {
-  position: relative;
-  margin: 16px 0 16px 0;
-}
-
 .c4 {
   font-size: 18px;
   line-height: 1.5;
@@ -1469,22 +1296,6 @@ exports[`component: FileInputField should render a loading file 1`] = `
   top: -2px;
   right: 8px;
   font-size: 16px;
-}
-
-.c16 .c3 {
-  display: block;
-  position: relative;
-  bottom: 4px;
-  padding-left: 16px;
-  color: hsl(0,0%,70%);
-}
-
-.c16 .c5 {
-  position: absolute;
-  top: -2px;
-  right: 8px;
-  font-size: 16px;
-  color: hsl(0,0%,70%);
 }
 
 @media screen and (min-width:1024px) {
@@ -1523,7 +1334,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6"
+        class="sc-fzoPby c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -1562,7 +1373,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
             boolest.txt
           </span>
           <svg
-            class="c10 c11"
+            class="sc-pAZqv c10 c11"
             fill="currentcolor"
             height="1em"
             viewBox="0 0 24 24"
@@ -1781,7 +1592,7 @@ exports[`component: FileInputField should render file input field 1`] = `
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6"
+        class="sc-fzoPby c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"

--- a/modules/cactus-web/src/Flex/Flex.story.tsx
+++ b/modules/cactus-web/src/Flex/Flex.story.tsx
@@ -1,5 +1,6 @@
 import { select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
+import { FlexDirectionProperty, FlexWrapProperty } from 'csstype'
 import React from 'react'
 
 import Flex from './Flex'
@@ -26,10 +27,8 @@ storiesOf('Flex', module).add(
     <Flex
       justifyContent={select('justifyContent', justifyOptions, 'flex-end')}
       alignItems={select('alignItems', alignOptions, 'center')}
-      // @ts-ignore
-      flexWrap={select('flexWrap', flexWrapOptions, 'wrap')}
-      // @ts-ignore
-      flexDirection={select('flexDirection', directionOptions, 'row')}
+      flexWrap={select('flexWrap', flexWrapOptions, 'wrap') as FlexWrapProperty}
+      flexDirection={select('flexDirection', directionOptions, 'row') as FlexDirectionProperty}
       height={text('height', '100%')}
     >
       <Flex alignSelf={select('alignSelf', alignOptions, 'unset')} p={5} colors="base" />

--- a/modules/cactus-web/src/Flex/__snapshots__/Flex.test.tsx.snap
+++ b/modules/cactus-web/src/Flex/__snapshots__/Flex.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`component: Flex should accept basic built-in props 1`] = `
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm c0"
     color="white"
     display="block"
     height="120px"
@@ -39,17 +39,6 @@ exports[`component: Flex should accept basic built-in props 1`] = `
 `;
 
 exports[`component: Flex should accept flex props 1`] = `
-.c2 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-}
-
 .c0 {
   box-sizing: border-box;
   display: -webkit-box;
@@ -86,17 +75,28 @@ exports[`component: Flex should accept flex props 1`] = `
   flex-wrap: wrap;
 }
 
+.c2 {
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm c0"
     display="flex"
   >
     <div
-      class="c1"
+      class="sc-AxjAm c1"
       display="flex"
     />
     <div
-      class="c2"
+      class="sc-AxjAm c2"
       display="flex"
     />
   </div>
@@ -117,7 +117,7 @@ exports[`component: Flex snapshot with no props 1`] = `
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm c0"
     display="flex"
   />
 </div>

--- a/modules/cactus-web/src/Grid/Grid.tsx
+++ b/modules/cactus-web/src/Grid/Grid.tsx
@@ -71,9 +71,8 @@ export const Item = styled.div<ItemProps>`
   }
 `
 
-const ColumnPropType = PropTypes.oneOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+const ColumnPropType = PropTypes.oneOf<ColumnNum>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
 
-// @ts-ignore
 Item.propTypes = {
   tiny: ColumnPropType.isRequired,
   small: ColumnPropType,
@@ -95,7 +94,7 @@ interface GridComponent extends StyledComponentBase<'div', CactusTheme, GridProp
 
 export const Grid = styled.div<GridProps>`
   box-sizing: border-box;
-  width: 100%
+  width: 100%;
 
   display: flex;
   flex-direction: row;

--- a/modules/cactus-web/src/Grid/__snapshots__/Grid.test.tsx.snap
+++ b/modules/cactus-web/src/Grid/__snapshots__/Grid.test.tsx.snap
@@ -7,28 +7,6 @@ exports[`component: Grid breakpoint styles should match larger screen sizes if t
   width: calc(25% - 16px);
 }
 
-.c3 > .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c4 > .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-}
-
 .c0 {
   box-sizing: border-box;
   width: 100%;
@@ -61,23 +39,23 @@ exports[`component: Grid breakpoint styles should match larger screen sizes if t
   }
 }
 
+@media (min-width:1025px) {
+
+}
+
+@media (min-width:1201px) {
+
+}
+
+@media (min-width:1441px) {
+
+}
+
 @supports (display:grid) {
   .c2 {
     grid-column: span 3;
     width: auto;
     margin: 0;
-  }
-}
-
-@supports (display:grid) {
-  .c3 > .c1 {
-    display: block;
-  }
-}
-
-@supports (display:grid) {
-  .c4 > .c1 {
-    display: block;
   }
 }
 
@@ -147,6 +125,18 @@ exports[`component: Grid should render extraLarge viewport design 1`] = `
   justify-content: center;
 }
 
+@media (min-width:769px) {
+
+}
+
+@media (min-width:1025px) {
+
+}
+
+@media (min-width:1201px) {
+
+}
+
 @media (min-width:1441px) {
   .c2 {
     width: calc(16.666666666666664% - 16px);
@@ -207,17 +197,6 @@ exports[`component: Grid should render tiny viewport design 1`] = `
   width: calc(25% - 16px);
 }
 
-.c3 > .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
 .c0 {
   box-sizing: border-box;
   width: 100%;
@@ -244,17 +223,27 @@ exports[`component: Grid should render tiny viewport design 1`] = `
   justify-content: flex-end;
 }
 
+@media (min-width:769px) {
+
+}
+
+@media (min-width:1025px) {
+
+}
+
+@media (min-width:1201px) {
+
+}
+
+@media (min-width:1441px) {
+
+}
+
 @supports (display:grid) {
   .c2 {
     grid-column: span 3;
     width: auto;
     margin: 0;
-  }
-}
-
-@supports (display:grid) {
-  .c3 > .c1 {
-    display: block;
   }
 }
 

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -127,7 +127,6 @@ export const IconButton = styled(IconButtonBase)<IconButtonProps>`
   ${iconSizes}
 `
 
-// @ts-ignore
 IconButton.propTypes = {
   iconSize: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
   variant: PropTypes.oneOf(['standard', 'action', 'danger']),
@@ -142,6 +141,8 @@ IconButton.propTypes = {
         `Invalid prop 'label' of type '${typeof props.label}' supplied to '${componentName}', expected 'string'.`
       )
     }
+
+    return null
   },
   'aria-labelledby': (props: IconButtonProps, propName: string, componentName: string) => {
     if (!props['aria-labelledby'] && !props.label) {
@@ -155,6 +156,8 @@ IconButton.propTypes = {
         ]}' supplied to '${componentName}', expected 'string'.`
       )
     }
+
+    return null
   },
   display: PropTypes.oneOf(['flex', 'inline-flex']),
   inverse: PropTypes.bool,

--- a/modules/cactus-web/src/MenuButton/__snapshots__/MenuButton.test.tsx.snap
+++ b/modules/cactus-web/src/MenuButton/__snapshots__/MenuButton.test.tsx.snap
@@ -7,42 +7,6 @@ exports[`With theme changes  Border should be 2px 1`] = `
   vertical-align: middle;
 }
 
-.c3[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c3 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
-}
-
-.c4[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c4 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
-}
-
-.c5[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c5 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
-}
-
 .c0 {
   position: relative;
   box-sizing: border-box;
@@ -102,6 +66,10 @@ exports[`With theme changes  Border should be 2px 1`] = `
   position: absolute;
   right: 10px;
   top: 12px;
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 @media screen and (min-width:1024px) {
@@ -205,28 +173,8 @@ exports[`With theme changes  Dropdown should not have box-shadows 1`] = `
   top: 12px;
 }
 
-.c3[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
+@media screen and (min-width:1024px) {
 
-.c3 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
-}
-
-.c4[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c4 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
 }
 
 @media screen and (min-width:1024px) {
@@ -269,30 +217,6 @@ exports[`With theme changes  Should have intermediate borders 1`] = `
   vertical-align: middle;
 }
 
-.c3[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c3 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
-}
-
-.c4[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c4 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
-}
-
 .c0 {
   position: relative;
   box-sizing: border-box;
@@ -355,6 +279,10 @@ exports[`With theme changes  Should have intermediate borders 1`] = `
 }
 
 @media screen and (min-width:1024px) {
+
+}
+
+@media screen and (min-width:1024px) {
   .c0 {
     font-size: 18px;
     line-height: 1.5;
@@ -392,18 +320,6 @@ exports[`With theme changes  Should have square borders 1`] = `
   .c2 {
   font-size: 8px;
   vertical-align: middle;
-}
-
-.c3[aria-expanded='true'] .c1 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c3 .c1 {
-  position: absolute;
-  right: 10px;
-  top: 12px;
 }
 
 .c0 {
@@ -465,6 +381,10 @@ exports[`With theme changes  Should have square borders 1`] = `
   position: absolute;
   right: 10px;
   top: 12px;
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 @media screen and (min-width:1024px) {
@@ -565,6 +485,10 @@ exports[`component: MenuButton snapshot 1`] = `
   position: absolute;
   right: 10px;
   top: 12px;
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 @media screen and (min-width:1024px) {

--- a/modules/cactus-web/src/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/modules/cactus-web/src/Modal/__snapshots__/Modal.test.tsx.snap
@@ -2,7 +2,11 @@
 
 exports[`Modal is closed when isOpen=false snapshot 1`] = `
 <body>
-  <div />
+  @media screen and (min-width:1024px) {
+
+}
+
+<div />
 </body>
 `;
 

--- a/modules/cactus-web/src/Pagination/Pagination.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.tsx
@@ -196,22 +196,25 @@ export const Pagination: React.FC<PaginationProps> = (props) => {
 
 Pagination.displayName = 'Pagination'
 
-//@ts-ignore
 Pagination.propTypes = {
-  pageCount: function (props: PaginationProps, propName, componentName) {
+  pageCount: function (props: Record<string, any>, propName, componentName) {
     const pageCount = parseInt(props.pageCount as any)
     if (pageCount < 1 || pageCount !== parseFloat(props.pageCount as any)) {
       return new Error('Prop `pageCount` must be a positive integer')
     }
+
+    return null
   },
-  currentPage: function (props: PaginationProps, propName, componentName) {
+  currentPage: function (props: Record<string, any>, propName, componentName) {
     const pageCount = parseInt(props.pageCount as any)
     const current = parseInt(props.currentPage as any)
     if (current < 1 || current > pageCount || current !== parseFloat(props.currentPage as any)) {
       return new Error('Prop `currentPage` must be an integer in the range [1, `pageCount`]')
     }
+
+    return null
   },
-  onPageChange: function (props: PaginationProps, propName, componentName) {
+  onPageChange: function (props: Record<string, any>, propName, componentName) {
     if (!props.onPageChange) {
       if (!props.linkAs) {
         return new Error('Either `linkAs` OR `onPageChange` prop is required')
@@ -219,8 +222,10 @@ Pagination.propTypes = {
     } else if (typeof props.onPageChange !== 'function') {
       return new Error('Prop `onPageChange` must be a function')
     }
+
+    return null
   },
-  linkAs: PropTypes.elementType,
+  linkAs: PropTypes.elementType as PropTypes.Requireable<React.ComponentType<PageLinkProps>>,
   label: PropTypes.string.isRequired,
   currentPageLabel: PropTypes.string.isRequired,
   prevPageLabel: PropTypes.string.isRequired,

--- a/modules/cactus-web/src/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/modules/cactus-web/src/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`component: Pagination 11 pages, first page selected 1`] = `
         class="c1"
       >
         <svg
-          class="c4"
+          class="sc-fznOgF c4"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"

--- a/modules/cactus-web/src/RadioButtonField/__snapshots__/RadioButtonField.test.tsx.snap
+++ b/modules/cactus-web/src/RadioButtonField/__snapshots__/RadioButtonField.test.tsx.snap
@@ -64,15 +64,6 @@ exports[`component: RadioButtonField should render a disabled radio button field
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c9 + .c2 {
-  margin-top: 8px;
-}
-
-.c9 .c7 {
-  cursor: pointer;
-  padding-left: 8px;
-}
-
 .c3 + .c2 {
   margin-top: 8px;
 }
@@ -293,24 +284,6 @@ exports[`component: RadioButtonField should support margin space props 1`] = `
 
 .c4 input:focus ~ span {
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
-}
-
-.c9 + .c2 {
-  margin-top: 8px;
-}
-
-.c9 .c7 {
-  cursor: pointer;
-  padding-left: 8px;
-}
-
-.c10 + .c2 {
-  margin-top: 8px;
-}
-
-.c10 .c7 {
-  cursor: not-allowed;
-  padding-left: 8px;
 }
 
 .c3 {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1525,8 +1525,8 @@ export const Select = styled(SelectBase)`
   }
 `
 
-// @ts-ignore
 Select.propTypes = {
+  // @ts-ignore
   options: PropTypes.oneOfType([
     PropTypes.arrayOf(
       PropTypes.shape({
@@ -1539,6 +1539,7 @@ Select.propTypes = {
   ]).isRequired,
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
+  // @ts-ignore
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,

--- a/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
@@ -79,6 +79,10 @@ exports[`component: Select snapshot 1`] = `
   }
 }
 
+@media screen and (min-width:1024px) {
+
+}
+
 <div
     class="c0"
   >
@@ -125,27 +129,6 @@ exports[`component: Select with theme customization should have 2px border 1`] =
   font-style: italic;
   color: hsl(200,9%,35%);
   font-size: 18px;
-}
-
-.c6:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c6:focus .c4,
-.c6[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c6[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c6 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
 }
 
 .c1 {
@@ -214,6 +197,10 @@ exports[`component: Select with theme customization should have 2px border 1`] =
   }
 }
 
+@media screen and (min-width:1024px) {
+
+}
+
 <div
     class="c0"
   >
@@ -260,48 +247,6 @@ exports[`component: Select with theme customization should match intermediate sh
   font-style: italic;
   color: hsl(200,9%,35%);
   font-size: 18px;
-}
-
-.c6:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c6:focus .c4,
-.c6[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c6[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c6 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
-}
-
-.c7:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c7:focus .c4,
-.c7[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c7[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c7 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
 }
 
 .c1 {
@@ -370,6 +315,10 @@ exports[`component: Select with theme customization should match intermediate sh
   }
 }
 
+@media screen and (min-width:1024px) {
+
+}
+
 <div
     class="c0"
   >
@@ -416,69 +365,6 @@ exports[`component: Select with theme customization should match square shape st
   font-style: italic;
   color: hsl(200,9%,35%);
   font-size: 18px;
-}
-
-.c6:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c6:focus .c4,
-.c6[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c6[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c6 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
-}
-
-.c7:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c7:focus .c4,
-.c7[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c7[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c7 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
-}
-
-.c8:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c8:focus .c4,
-.c8[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c8[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c8 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
 }
 
 .c1 {
@@ -545,6 +431,10 @@ exports[`component: Select with theme customization should match square shape st
   .c3 {
     font-size: 18px;
   }
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 <div
@@ -651,69 +541,6 @@ exports[`component: Select with theme customization should not have box shadows 
   top: 10px;
 }
 
-.c6:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c6:focus .c4,
-.c6[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c6[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c6 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
-}
-
-.c7:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c7:focus .c4,
-.c7[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c7[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c7 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
-}
-
-.c8:disabled .c2 {
-  color: hsl(0,0%,70%);
-}
-
-.c8:focus .c4,
-.c8[aria-expanded] .c4 {
-  color: hsl(200,96%,35%);
-}
-
-.c8[aria-expanded] .c4 {
-  -webkit-transform: rotate3d(1,0,0,180deg);
-  -ms-transform: rotate3d(1,0,0,180deg);
-  transform: rotate3d(1,0,0,180deg);
-}
-
-.c8 .c4 {
-  position: absolute;
-  right: 14px;
-  top: 10px;
-}
-
 .c0 {
   max-width: 100%;
 }
@@ -722,6 +549,10 @@ exports[`component: Select with theme customization should not have box shadows 
   .c3 {
     font-size: 18px;
   }
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 <div

--- a/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
+++ b/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
@@ -28,14 +28,14 @@ exports[`component: SelectField minimal snapshot 1`] = `
   padding-right: 28px;
 }
 
-.c2 .c14 {
+.c2 .sc-pReKu {
   position: absolute;
   right: 8px;
   top: 2px;
   font-size: 16px;
 }
 
-.c2 .c13 {
+.c2 .sc-qYSYK {
   margin-top: 4px;
 }
 
@@ -124,6 +124,10 @@ exports[`component: SelectField minimal snapshot 1`] = `
   .c10 {
     font-size: 18px;
   }
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 <div>

--- a/modules/cactus-web/src/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/modules/cactus-web/src/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -4,13 +4,13 @@ exports[`component: Spinner snapshot 1`] = `
 .c0 {
   vertical-align: middle;
   font-size: 40px;
-  -webkit-animation: iVXCSc 0.75s linear infinite;
-  animation: iVXCSc 0.75s linear infinite;
+  -webkit-animation: bKPVWD 0.75s linear infinite;
+  animation: bKPVWD 0.75s linear infinite;
 }
 
 <div>
   <svg
-    class="c0"
+    class="sc-qYiqT c0"
     fill="currentcolor"
     height="1em"
     viewBox="0 0 24 24"

--- a/modules/cactus-web/src/SplitButton/__snapshots__/SplitButton.test.tsx.snap
+++ b/modules/cactus-web/src/SplitButton/__snapshots__/SplitButton.test.tsx.snap
@@ -98,6 +98,10 @@ exports[`component: SplitButton snapshot 1`] = `
   }
 }
 
+@media screen and (min-width:1024px) {
+
+}
+
 <div>
   <div
     class="c0"
@@ -205,36 +209,6 @@ exports[`component: SplitButton with theme customization dropdown should not hav
   border-color: hsl(200,96%,35%);
 }
 
-.c7 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c7[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
-.c8 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c8[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
-.c9 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c9[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
 .c0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -261,6 +235,10 @@ exports[`component: SplitButton with theme customization dropdown should not hav
     font-size: 18px;
     line-height: 1.5;
   }
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 <div>
@@ -370,36 +348,6 @@ exports[`component: SplitButton with theme customization should have 2px borders
   border-color: hsl(200,96%,35%);
 }
 
-.c7 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c7[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
-.c8 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c8[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
-.c9 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c9[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
 .c0 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -426,6 +374,10 @@ exports[`component: SplitButton with theme customization should have 2px borders
     font-size: 18px;
     line-height: 1.5;
   }
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 <div>
@@ -508,36 +460,6 @@ exports[`component: SplitButton with theme customization should have intermediat
   border-color: hsl(200,96%,35%);
 }
 
-.c7 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c7[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
-.c8 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c8[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
-.c9 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c9[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
 .c4 {
   box-sizing: border-box;
   background-color: hsl(200,10%,20%);
@@ -591,6 +513,10 @@ exports[`component: SplitButton with theme customization should have intermediat
     font-size: 18px;
     line-height: 1.5;
   }
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 <div>
@@ -673,26 +599,6 @@ exports[`component: SplitButton with theme customization should have square shap
   border-color: hsl(200,96%,35%);
 }
 
-.c7 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c7[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
-.c8 .c5 {
-  width: 10px;
-  height: 10px;
-  color: hsl(0,0%,100%);
-}
-
-.c8[aria-expanded='true'] ~ .c1 {
-  border-color: hsl(200,96%,35%);
-}
-
 .c4 {
   box-sizing: border-box;
   background-color: hsl(200,10%,20%);
@@ -746,6 +652,10 @@ exports[`component: SplitButton with theme customization should have square shap
     font-size: 18px;
     line-height: 1.5;
   }
+}
+
+@media screen and (min-width:1024px) {
+
 }
 
 <div>

--- a/modules/cactus-web/src/Text/Text.story.tsx
+++ b/modules/cactus-web/src/Text/Text.story.tsx
@@ -1,6 +1,7 @@
 import cactusTheme, { CactusColor, TextStyleCollection } from '@repay/cactus-theme'
 import { select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
+import { FontWeightProperty, TextAlignProperty } from 'csstype'
 import React from 'react'
 
 import { Span, Text } from './Text'
@@ -23,11 +24,9 @@ storiesOf('Text', module)
         colors={select('colors', COLOR_STYLES, 'base')}
         margin={text('margin', '0 50px')}
         padding={text('padding', '3')}
-        // @ts-ignore
-        fontWeight={text('fontWeight', '400')}
+        fontWeight={text('fontWeight', '400') as FontWeightProperty}
         fontStyle={text('fontStyle', 'italic')}
-        // @ts-ignore
-        textAlign={text('textAlign', 'left')}
+        textAlign={text('textAlign', 'left') as TextAlignProperty}
         textStyle={select('textStyle', TEXT_STYLES, 'small') as keyof TextStyleCollection}
       >
         {text('children', sampleText)}
@@ -42,11 +41,9 @@ storiesOf('Text', module)
         colors={select('colors', COLOR_STYLES, 'base')}
         margin={text('margin', '0 50px')}
         padding={text('padding', '3')}
-        // @ts-ignore
-        fontWeight={text('fontWeight', '400')}
+        fontWeight={text('fontWeight', '400') as FontWeightProperty}
         fontStyle={text('fontStyle', 'italic')}
-        // @ts-ignore
-        textAlign={text('textAlign', 'left')}
+        textAlign={text('textAlign', 'left') as TextAlignProperty}
         textStyle={select('textStyle', TEXT_STYLES, 'small') as keyof TextStyleCollection}
       >
         {text('children', sampleText)}

--- a/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
+++ b/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`component: TextAreaField should render a TextAreaField 1`] = `
   font-size: 16px;
 }
 
-.c2 .c10 {
+.c2 .sc-qYSYK {
   margin-top: 4px;
 }
 
@@ -130,7 +130,7 @@ exports[`component: TextAreaField should render a TextAreaField 1`] = `
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c7"
+        class="sc-fzpdbB c7"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"

--- a/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
+++ b/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`component: TextInputField should render a TextInputField 1`] = `
   font-size: 16px;
 }
 
-.c2 .c10 {
+.c2 .sc-qYSYK {
   margin-top: 4px;
 }
 
@@ -122,7 +122,7 @@ exports[`component: TextInputField should render a TextInputField 1`] = `
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c7"
+        class="sc-fzpdbB c7"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"

--- a/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -87,26 +87,6 @@ exports[`component: Toggle should initialize value to true 1`] = `
   opacity: 0.5;
 }
 
-.c5[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c5[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c5 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c5 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
 <button
     aria-checked="true"
     class="c0"
@@ -115,7 +95,7 @@ exports[`component: Toggle should initialize value to true 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c1 c2"
+      class="sc-fzoxnE c1 c2"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -127,7 +107,7 @@ exports[`component: Toggle should initialize value to true 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="c3 c4"
+      class="sc-pZBmh c3 c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -161,26 +141,6 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
   top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
-}
-
-.c5[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c5[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c5 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c5 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
 }
 
 .c0 {
@@ -257,7 +217,7 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c1 c2"
+      class="sc-fzoxnE c1 c2"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -269,7 +229,7 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="c3 c4"
+      class="sc-pZBmh c3 c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -378,7 +338,7 @@ exports[`component: Toggle should render a toggle 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c1 c2"
+      class="sc-fzoxnE c1 c2"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -390,7 +350,7 @@ exports[`component: Toggle should render a toggle 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="c3 c4"
+      class="sc-pZBmh c3 c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -424,46 +384,6 @@ exports[`component: Toggle should support margin space props 1`] = `
   top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
-}
-
-.c5[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c5[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c5 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c5 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c6[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c6[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c6 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c6 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
 }
 
 .c0 {
@@ -540,7 +460,7 @@ exports[`component: Toggle should support margin space props 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="c1 c2"
+      class="sc-fzoxnE c1 c2"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -552,7 +472,7 @@ exports[`component: Toggle should support margin space props 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="c3 c4"
+      class="sc-pZBmh c3 c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -586,66 +506,6 @@ exports[`component: Toggle with theme customization should not have box shadows 
   top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
-}
-
-.c5[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c5[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c5 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c5 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c6[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c6[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c6 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c6 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c7[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c7[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c7 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c7 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
 }
 
 .c0 {
@@ -716,7 +576,7 @@ exports[`component: Toggle with theme customization should not have box shadows 
   >
     <svg
       aria-hidden="true"
-      class="c1 c2"
+      class="sc-fzoxnE c1 c2"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -728,7 +588,7 @@ exports[`component: Toggle with theme customization should not have box shadows 
     </svg>
     <svg
       aria-hidden="true"
-      class="c3 c4"
+      class="sc-pZBmh c3 c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"

--- a/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
+++ b/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
@@ -129,7 +129,7 @@ exports[`component: ToggleField snapshot 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c5 c6"
+        class="sc-fzoWqW c5 c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -141,7 +141,7 @@ exports[`component: ToggleField snapshot 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="c7 c8"
+        class="sc-paXsP c7 c8"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -192,26 +192,6 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
   top: 4px;
   left: 5px;
   color: hsl(0,0%,100%);
-}
-
-.c11[aria-checked='true'] .c5 {
-  opacity: 0;
-}
-
-.c11[aria-checked='true'] .c7 {
-  opacity: 1;
-}
-
-.c11 .c5 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c11 .c7 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
 }
 
 .c4 {
@@ -279,17 +259,6 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
   opacity: 0.5;
 }
 
-.c12 .c9 {
-  cursor: pointer;
-  margin-left: 8px;
-  line-height: 26px;
-  vertical-align: -2px;
-}
-
-.c12 .c3 {
-  vertical-align: middle;
-}
-
 .c2 .c9 {
   cursor: not-allowed;
   margin-left: 8px;
@@ -323,7 +292,7 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c5 c6"
+        class="sc-fzoWqW c5 c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -335,7 +304,7 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="c7 c8"
+        class="sc-paXsP c7 c8"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -485,7 +454,7 @@ exports[`component: ToggleField snapshot when value=true 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="c5 c6"
+        class="sc-fzoWqW c5 c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -497,7 +466,7 @@ exports[`component: ToggleField snapshot when value=true 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="c7 c8"
+        class="sc-paXsP c7 c8"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"

--- a/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`component: Tooltip should render a disabled tooltip 1`] = `
     data-reach-tooltip-trigger=""
   >
     <svg
-      class="c0"
+      class="sc-fzoCCn c0"
       disabled=""
       fill="currentcolor"
       height="1em"
@@ -39,7 +39,7 @@ exports[`component: Tooltip should render tooltip icon 1`] = `
     data-reach-tooltip-trigger=""
   >
     <svg
-      class="c0"
+      class="sc-fzoCCn c0"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@babel/core": "^7.7.5",
     "@repay/eslint-config": "^3.0.0",
+    "@typescript-eslint/parser": "^3.6.0",
     "babel-eslint": "^10.0.1",
     "commitizen": "^4.1.2",
     "conventional-commits-parser": "^3.0.5",
@@ -57,8 +58,7 @@
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.0.5",
     "prompts": "^2.2.1",
-    "typescript": "^3.7.2",
-    "@typescript-eslint/parser": "^3.6.0"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "core-js": "^3.3.2"

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,7 @@
     "@types/react-dom": "^16.9.2",
     "@types/react-helmet": "^5.0.8",
     "@types/react-motion": "^0.0.29",
-    "@types/styled-components": "^4.1.14",
+    "@types/styled-components": "^5.1.1",
     "babel-plugin-export-metadata": "^1.2.0",
     "babel-plugin-styled-components": "^1.10.6",
     "chokidar": "^2.1.5",
@@ -65,6 +65,6 @@
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-helmet": "^5.2.0",
-    "styled-components": "^4.4.1"
+    "styled-components": "^5.1.1"
   }
 }

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -3,8 +3,8 @@ import { Location, WindowLocation } from '@reach/router'
 import { NavigationChevronLeft } from '@repay/cactus-icons'
 import Close from '@repay/cactus-icons/i/navigation-close'
 import Menu from '@repay/cactus-icons/i/navigation-hamburger'
-import { Box, IconButton, StyleProvider } from '@repay/cactus-web'
-import { graphql, Link, useStaticQuery, withPrefix } from 'gatsby'
+import { Box, IconButton } from '@repay/cactus-web'
+import { graphql, Link, useStaticQuery } from 'gatsby'
 import * as React from 'react'
 import Helmet from 'react-helmet'
 import { Motion, spring } from 'react-motion'
@@ -371,8 +371,7 @@ const CactusIcon = styled(Cactus).attrs({
   vertical-align: -1px;
 `
 
-// @ts-ignore
-const Header = styled<{ isOverlayed?: boolean }>(Box)`
+const Header = styled(Box)<{ isOverlayed?: boolean }>`
   position: fixed;
 
   ${(p: any) =>

--- a/website/src/pages/design-system/shared-styles.tsx
+++ b/website/src/pages/design-system/shared-styles.tsx
@@ -7,7 +7,7 @@ import Text, { Span } from '../../components/Text'
 import ColumnImage from '../design-system/grid-columns.png'
 import GridImage from '../design-system/grid-numbered.png'
 
-interface ShadowBoxProps extends React.ComponentPropsWithRef<typeof Flex> {
+type ShadowBoxProps = React.ComponentPropsWithRef<typeof Flex> & {
   shadow: string
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,17 +5098,12 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest-diff@*":
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
-  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
-
-"@types/jest@^24.0.11":
-  version "24.0.18"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.18.tgz#9c7858d450c59e2164a8a9df0905fc5091944498"
-  integrity sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==
+"@types/jest@^24.9.1":
+  version "24.9.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.9.1.tgz#02baf9573c78f1b9974a5f36778b366aa77bd534"
+  integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
   dependencies:
-    "@types/jest-diff" "*"
+    jest-diff "^24.3.0"
 
 "@types/json-schema@^7.0.3":
   version "7.0.3"
@@ -9948,12 +9943,7 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.4:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
-  integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
-
-csstype@^2.6.7:
+csstype@^2.2.0, csstype@^2.5.7, csstype@^2.6.11, csstype@^2.6.4, csstype@^2.6.7:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
   integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
@@ -15161,7 +15151,7 @@ jest-config@^24.9.0:
     pretty-format "^24.9.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.0.0, jest-diff@^24.9.0:
+jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.9.0.tgz#931b7d0d5778a1baf7452cb816e325e3724055da"
   integrity sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==
@@ -23355,15 +23345,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.3.3, typescript@^3.9.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
-
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.3.3, typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,7 +2889,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/traverse@^7.10.4", "@babel/traverse@^7.10.5":
+"@babel/traverse@^7.10.4", "@babel/traverse@^7.10.5", "@babel/traverse@^7.4.5":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.5.tgz#77ce464f5b258be265af618d8fddf0536f20b564"
   integrity sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==
@@ -3072,7 +3072,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.1":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.1", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -3144,7 +3144,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.4.tgz#6c51afdf1dd0d73666ba09d2eb6c25c220d6fe4c"
   integrity sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==
 
-"@emotion/stylis@0.8.5":
+"@emotion/stylis@0.8.5", "@emotion/stylis@^0.8.4":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
@@ -3154,7 +3154,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
-"@emotion/unitless@0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -5068,6 +5068,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
   integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz#551a4589b6ee2cc9c1dff08056128aec29b94880"
@@ -5281,6 +5289,16 @@
   resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.14.tgz#fe029b0bfb2d26af7f9bd4dd4811b31961ff6d49"
   integrity sha512-X5t+uomPU9vxWNnfEpw2W7RtJDpsWCsBizQq95gB2QXrG5qsALV1/H7tfv4xYhTmiG5CGtcbfp4nU4yhhEqTsw==
   dependencies:
+    "@types/react" "*"
+    "@types/react-native" "*"
+    csstype "^2.2.0"
+
+"@types/styled-components@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.1.tgz#17c3b3a299aa38254189e04a72a8ee009a22e42d"
+  integrity sha512-fIjKvDU1LJExBZWEQilHqzfpOK4KUwBsj5zC79lxa94ekz8oDQSBNcayMACBImxIuevF+NbBGL9O/2CQ67Zhig==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
     "@types/react" "*"
     "@types/react-native" "*"
     csstype "^2.2.0"
@@ -9785,6 +9803,15 @@ css-to-react-native@^2.2.2:
     css-color-keywords "^1.0.0"
     postcss-value-parser "^3.3.0"
 
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
+
 css-tree@1.0.0-alpha.29:
   version "1.0.0-alpha.29"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.29.tgz#3fa9d4ef3142cbd1c301e7664c1f352bd82f5a39"
@@ -13668,6 +13695,13 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.0.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hoist-non-react-statics@^3.3.0:
   version "3.3.0"
@@ -22436,6 +22470,22 @@ styled-components@^4.4.1:
     react-is "^16.6.0"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
+styled-components@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.1.tgz#96dfb02a8025794960863b9e8e365e3b6be5518d"
+  integrity sha512-1ps8ZAYu2Husx+Vz8D+MvXwEwvMwFv+hqqUwhNlDN5ybg6A+3xyW1ECrAgywhvXapNfXiz79jJyU0x22z0FFTg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
 styled-system@^5.1.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -15436,6 +15436,13 @@ jest-styled-components@^6.2.1:
   dependencies:
     css "^2.2.4"
 
+jest-styled-components@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-7.0.2.tgz#b7711871ea74a04491b12bad123fa35cc65a2a80"
+  integrity sha512-i1Qke8Jfgx0Why31q74ohVj9S2FmMLUE8bNRSoK4DgiurKkXG6HC4NPhcOLAz6VpVd9wXkPn81hOt4aAQedqsA==
+  dependencies:
+    css "^2.2.4"
+
 jest-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.9.0.tgz#7396814e48536d2e85a37de3e4c431d7cb140162"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3072,7 +3072,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.1", "@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.8":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -3149,7 +3149,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.4", "@emotion/unitless@^0.7.0":
+"@emotion/unitless@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
@@ -5283,15 +5283,6 @@
   dependencies:
     "@types/react" "*"
     "@types/webpack-env" "*"
-
-"@types/styled-components@^4.1.14":
-  version "4.1.14"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.14.tgz#fe029b0bfb2d26af7f9bd4dd4811b31961ff6d49"
-  integrity sha512-X5t+uomPU9vxWNnfEpw2W7RtJDpsWCsBizQq95gB2QXrG5qsALV1/H7tfv4xYhTmiG5CGtcbfp4nU4yhhEqTsw==
-  dependencies:
-    "@types/react" "*"
-    "@types/react-native" "*"
-    csstype "^2.2.0"
 
 "@types/styled-components@^5.1.1":
   version "5.1.1"
@@ -9793,15 +9784,6 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
-
-css-to-react-native@^2.2.2:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.1.tgz#cf0f61e0514846e2d4dc188b0886e29d8bef64a2"
-  integrity sha512-yO+oEx1Lf+hDKasqQRVrAvzMCz825Huh1VMlEEDlRWyAhFb/FWb6I0KpEF1PkyKQ7NEdcx9d5M2ZEWgJAsgPvQ==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^3.3.0"
 
 css-to-react-native@^3.0.0:
   version "3.0.0"
@@ -14991,11 +14973,6 @@ is-valid-path@^0.1.1:
   dependencies:
     is-invalid-path "^0.1.0"
 
-is-what@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.2.3.tgz#50f76f1bd8e56967e15765d1d34302513701997b"
-  integrity sha512-c4syLgFnjXTH5qd82Fp/qtUIeM0wA69xbI0KH1QpurMIvDaZFrS8UtAa4U52Dc2qSznaMxHit0gErMp6A/Qk1w==
-
 is-whitespace-character@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
@@ -15428,13 +15405,6 @@ jest-snapshot@^24.9.0:
     natural-compare "^1.4.0"
     pretty-format "^24.9.0"
     semver "^6.2.0"
-
-jest-styled-components@^6.2.1:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/jest-styled-components/-/jest-styled-components-6.3.3.tgz#e15bbda13a6b6ff876d6b783751fe9840860c52a"
-  integrity sha512-RBMPZSJJSgPDTTJsuYzx5fsij/CULaqQNZOWkn8J/L++rX6P830o2vB9CXGzfQf/bVq9qGr1ZBNoivi+v6JPYg==
-  dependencies:
-    css "^2.2.4"
 
 jest-styled-components@^7.0.2:
   version "7.0.2"
@@ -16679,13 +16649,6 @@ meow@^4.0.0:
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
-
-merge-anything@^2.2.4:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.2.5.tgz#37ef13f36359ee64f09c657d2cef45f7e29493f9"
-  integrity sha512-WgZGR7EQ1D8pyh57uKBbkPhUCJZLGdMzbDaxL4MDTJSGsvtpGdm8myr6DDtgJwT46xiFBlHqxbveDRpFBWlKWQ==
-  dependencies:
-    is-what "^3.2.3"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -19838,7 +19801,7 @@ react-is@^16.12.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
@@ -22460,25 +22423,6 @@ style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-components@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
-  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.8.1"
-    "@emotion/unitless" "^0.7.0"
-    babel-plugin-styled-components ">= 1"
-    css-to-react-native "^2.2.2"
-    memoize-one "^5.0.0"
-    merge-anything "^2.2.4"
-    prop-types "^15.5.4"
-    react-is "^16.6.0"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
-    supports-color "^5.5.0"
-
 styled-components@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.1.tgz#96dfb02a8025794960863b9e8e365e3b6be5518d"
@@ -22522,16 +22466,6 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
-
-stylis-rule-sheet@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
-
-stylis@^3.5.0:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
-  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The upgrades to both Styled Components and TypeScript were kind of interdependent (due to upgraded Styled Component types or something like that...I don't remember now), so I've lumped them into a single PR.  The good news is that it looks like we can support Styled Components v5, so I've gone ahead and included updates to the peer dependency ranges to reflect that.  The bad news is that Styled Components v5 messed with our snapshots.  It _looks_ like all the snapshot changes have nothing to do with the actual appearance of the component, but it's hard to be 100% certain due to the number of changes.

In any case, to test this I would recommend firing up Storybook and clicking around through various components to make sure everything still looks reasonable.