### PR TITLE
Get rid of console warning triggered by SplitButton

### DIFF
--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -9,7 +9,7 @@ import {
 import { NavigationChevronDown } from '@repay/cactus-icons'
 import { BorderSize, ColorStyle, Shape, TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import React, { MutableRefObject, useRef, useState } from 'react'
+import React, { MutableRefObject, useRef } from 'react'
 import styled, {
   createGlobalStyle,
   css,
@@ -232,25 +232,23 @@ const SplitButtonBase = (props: SplitButtonProps): React.ReactElement => {
     'aria-label': ariaLabel = 'Action List',
     ...rest
   } = props
-  const [dropdownOpen, setDropdownOpen] = useState(false)
   const mainActionRef: MutableRefObject<null | HTMLButtonElement> = useRef(null)
   return (
     <div className={className} {...rest}>
-      <MainActionButton
-        className={dropdownOpen ? 'dd-open' : !disabled ? 'dd-closed' : ''}
-        ref={mainActionRef}
-        type="button"
-        disabled={disabled}
-        onClick={onSelectMainAction}
-      >
-        {MainActionIcon && <MainActionIcon iconSize="small" />}
-        {mainActionLabel}
-      </MainActionButton>
       <ReachMenu>
         {({ isOpen }: { isOpen: boolean }): React.ReactElement => {
-          setDropdownOpen(isOpen)
           return (
-            <React.Fragment>
+            <>
+              <MainActionButton
+                className={isOpen ? 'dd-open' : !disabled ? 'dd-closed' : ''}
+                ref={mainActionRef}
+                type="button"
+                disabled={disabled}
+                onClick={onSelectMainAction}
+              >
+                {MainActionIcon && <MainActionIcon iconSize="small" />}
+                {mainActionLabel}
+              </MainActionButton>
               <SplitButtonStyles />
               <DropdownButton disabled={disabled} aria-label={ariaLabel}>
                 <NavigationChevronDown iconSize="tiny" aria-hidden="true" />
@@ -277,7 +275,7 @@ const SplitButtonBase = (props: SplitButtonProps): React.ReactElement => {
               >
                 <SplitButtonList>{children}</SplitButtonList>
               </ReachMenuPopover>
-            </React.Fragment>
+            </>
           )
         }}
       </ReachMenu>

--- a/modules/cactus-web/src/SplitButton/__snapshots__/SplitButton.test.tsx.snap
+++ b/modules/cactus-web/src/SplitButton/__snapshots__/SplitButton.test.tsx.snap
@@ -252,12 +252,12 @@ exports[`component: SplitButton with theme customization dropdown should not hav
       Test
     </button>
     <button
-      aria-controls="menu--48"
+      aria-controls="menu--44"
       aria-haspopup="true"
       aria-label="Action List"
       class="c3 c4"
       data-reach-menu-button=""
-      id="menu-button--menu--48"
+      id="menu-button--menu--44"
       type="button"
     >
       <svg
@@ -391,12 +391,12 @@ exports[`component: SplitButton with theme customization should have 2px borders
       Test
     </button>
     <button
-      aria-controls="menu--53"
+      aria-controls="menu--49"
       aria-haspopup="true"
       aria-label="Action List"
       class="c3 c4"
       data-reach-menu-button=""
-      id="menu-button--menu--53"
+      id="menu-button--menu--49"
       type="button"
     >
       <svg
@@ -530,12 +530,12 @@ exports[`component: SplitButton with theme customization should have intermediat
       Test
     </button>
     <button
-      aria-controls="menu--43"
+      aria-controls="menu--39"
       aria-haspopup="true"
       aria-label="Action List"
       class="c3 c4"
       data-reach-menu-button=""
-      id="menu-button--menu--43"
+      id="menu-button--menu--39"
       type="button"
     >
       <svg
@@ -669,12 +669,12 @@ exports[`component: SplitButton with theme customization should have square shap
       Test
     </button>
     <button
-      aria-controls="menu--38"
+      aria-controls="menu--34"
       aria-haspopup="true"
       aria-label="Action List"
       class="c3 c4"
       data-reach-menu-button=""
-      id="menu-button--menu--38"
+      id="menu-button--menu--34"
       type="button"
     >
       <svg


### PR DESCRIPTION
Ticket and UAT: https://repayonline.atlassian.net/browse/CACTUS-324

Not too much to this.  Calling `setState` for a parent component while in a separate render function was causing the issue.  The solution was just to lift the `ReachMenu` component higher in the hierarchy so that we didn't need to keep `isOpen` in state.