### PR TITLE
CACTUS-267: Label

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
@@ -9,12 +9,14 @@ describe('component: AccessibleField', (): void => {
     const { getByLabelText } = render(
       <StyleProvider>
         <AccessibleField label="Accessible Label" name="text_field">
-          <input name="text_field" data-is="accessible" />
+          <input data-is="accessible" />
         </AccessibleField>
       </StyleProvider>
     )
 
-    expect(getByLabelText('Accessible Label')).toHaveAttribute('data-is', 'accessible')
+    const input = getByLabelText('Accessible Label')
+    expect(input).toHaveAttribute('data-is', 'accessible')
+    expect(input).toHaveAttribute('name', 'text_field')
   })
 
   test('provides accessible status message', (): void => {
@@ -27,8 +29,7 @@ describe('component: AccessibleField', (): void => {
     )
 
     expect(getByLabelText('Accessible Label').getAttribute('aria-describedby')).toContain(
-      //@ts-ignore
-      getByText('This field has an error').closest('[id]').id
+      getByText('This field has an error').closest('[id]')?.id
     )
   })
 
@@ -42,8 +43,25 @@ describe('component: AccessibleField', (): void => {
     )
 
     expect(getByLabelText('Accessible Label').getAttribute('aria-describedby')).toContain(
-      //@ts-ignore
-      getByText('woot tooltips!').closest('[id]').id
+      getByText('woot tooltips!').closest('[id]')?.id
     )
+  })
+
+  test('alternate prop types', (): void => {
+    const { container, getByText } = render(
+      <StyleProvider>
+        <AccessibleField id="aftest" label={<em>Accessible Label</em>} name="text_field">
+          {(field) => <input name={field.name} id={field.fieldId} />}
+        </AccessibleField>
+      </StyleProvider>
+    )
+
+    const labelText = getByText('Accessible Label')
+    expect(labelText.tagName).toBe('EM')
+    const label = labelText.parentElement
+    expect(label?.tagName).toBe('LABEL')
+    const input = container.querySelector(`#${label?.getAttribute('for')}`)
+    expect(input).toHaveAttribute('name', 'text_field')
+    expect(container).toMatchSnapshot()
   })
 })

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -5,7 +5,7 @@ import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { FieldWrapper } from '../FieldWrapper/FieldWrapper'
 import useId from '../helpers/useId'
-import { Label } from '../Label/Label'
+import Label, { LabelProps } from '../Label/Label'
 import StatusMessage, { Status } from '../StatusMessage/StatusMessage'
 import { Tooltip } from '../Tooltip/Tooltip'
 
@@ -22,15 +22,19 @@ interface AccessibleProps {
 
 type RenderFunc = (props: AccessibleProps) => JSX.Element | JSX.Element[]
 
-interface AccessibleFieldProps extends MarginProps, WidthProps {
-  id?: string
+// These are the props commonly used by components that wrap AccessibleField.
+export interface FieldProps {
   name: string
   label: React.ReactNode
-  labelProps?: Omit<React.ComponentPropsWithoutRef<typeof Label>, 'children'>
+  labelProps?: Omit<LabelProps, 'children' | 'htmlFor' | 'id'>
   tooltip?: string
   error?: string
   warning?: string
   success?: string
+}
+
+interface AccessibleFieldProps extends FieldProps, MarginProps, WidthProps {
+  id?: string
   className?: string
   children: JSX.Element | RenderFunc
 }

--- a/modules/cactus-web/src/AccessibleField/__snapshots__/AccessibleField.test.tsx.snap
+++ b/modules/cactus-web/src/AccessibleField/__snapshots__/AccessibleField.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`component: AccessibleField alternate prop types 1`] = `
+.c1 + .c0 {
+  margin-top: 16px;
+}
+
+.c4 {
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(200,10%,20%);
+}
+
+.c2 {
+  position: relative;
+}
+
+.c2 .c3 {
+  display: block;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 28px;
+}
+
+.c2 .sc-pReKu {
+  position: absolute;
+  right: 8px;
+  top: 2px;
+  font-size: 16px;
+}
+
+.c2 .sc-qYSYK {
+  margin-top: 4px;
+}
+
+@media screen and (min-width:1024px) {
+  .c4 {
+    font-size: 18px;
+    line-height: 1.5;
+  }
+}
+
+<div>
+  <div
+    class="c0 c1 c2"
+  >
+    <label
+      class="c3 c4"
+      for="aftest"
+      id="aftest-label"
+    >
+      <em>
+        Accessible Label
+      </em>
+    </label>
+    <input
+      id="aftest"
+      name="text_field"
+    />
+  </div>
+</div>
+`;

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
@@ -15,7 +15,7 @@ interface CheckBoxFieldProps
   extends Omit<CheckBoxProps, 'id' | 'onChange' | 'onBlur' | 'onFocus' | 'disabled'>,
     MarginProps {
   label: React.ReactNode
-  labelProps?: LabelProps
+  labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
   name: string
   onChange?: FieldOnChangeHandler<boolean>
@@ -67,7 +67,7 @@ const CheckBoxFieldBase = (props: CheckBoxFieldProps): React.ReactElement => {
         onFocus={handleFocus}
         onBlur={handleBlur}
       />
-      <Label htmlFor={checkboxId} {...labelProps}>
+      <Label {...labelProps} htmlFor={checkboxId}>
         {label}
       </Label>
     </FieldWrapper>

--- a/modules/cactus-web/src/DateInputField/DateInputField.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.tsx
@@ -3,28 +3,20 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
-import AccessibleField from '../AccessibleField/AccessibleField'
+import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import DateInput from '../DateInput/DateInput'
 import { omitMargins } from '../helpers/omit'
-import Label from '../Label/Label'
-import { Omit } from '../types'
 
 interface DateInputFieldProps
   extends MarginProps,
     WidthProps,
+    FieldProps,
     Omit<
-      React.ComponentPropsWithoutRef<typeof DateInput>,
-      'id' | 'status' | keyof MarginProps | keyof WidthProps
+      React.ComponentProps<typeof DateInput>,
+      'id' | 'status' | 'ref' | keyof MarginProps | keyof WidthProps
     > {
-  label: React.ReactNode
-  labelProps?: Omit<React.ComponentPropsWithoutRef<typeof Label>, 'children'>
-  name: string
   className?: string
   id?: string
-  success?: string
-  warning?: string
-  error?: string
-  tooltip?: string
 }
 
 function DateInputFieldBase(props: DateInputFieldProps): React.ReactElement {

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -14,7 +14,7 @@ import { Omit } from '../types'
 interface FileInputFieldProps extends FileInputProps, MarginProps {
   className?: string
   label: React.ReactNode
-  labelProps?: LabelProps
+  labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   tooltip?: string
 }
 
@@ -33,7 +33,7 @@ const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
 
   return (
     <FieldWrapper className={className} ref={containerRef}>
-      <Label htmlFor={inputId} {...labelProps}>
+      <Label {...labelProps} htmlFor={inputId}>
         {label}
       </Label>
       {tooltip && (

--- a/modules/cactus-web/src/Label/Label.tsx
+++ b/modules/cactus-web/src/Label/Label.tsx
@@ -1,20 +1,13 @@
-import { TextStyle } from '@repay/cactus-theme'
 import React from 'react'
-import styled, { FlattenSimpleInterpolation } from 'styled-components'
+import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { textStyle } from '../helpers/theme'
-import { Omit } from '../types'
 
-export interface LabelProps
-  extends Omit<
-      React.DetailedHTMLProps<React.LabelHTMLAttributes<HTMLLabelElement>, HTMLLabelElement>,
-      'ref'
-    >,
-    MarginProps {}
+export interface LabelProps extends React.ComponentPropsWithoutRef<'label'>, MarginProps {}
 
 export const Label = styled.label<LabelProps>`
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
+  ${(p) => textStyle(p.theme, 'body')};
   font-weight: 600;
   color: ${(p): string => p.theme.colors.darkestContrast};
 

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
@@ -16,7 +16,7 @@ export interface RadioButtonFieldProps
     MarginProps {
   label: React.ReactNode
   name: string
-  labelProps?: LabelProps
+  labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
   onChange?: FieldOnChangeHandler<string>
   onFocus?: FieldOnFocusHandler
@@ -65,7 +65,7 @@ const RadioButtonFieldBase = (props: RadioButtonFieldProps): React.ReactElement 
         onBlur={handleBlur}
         {...radioButtonProps}
       />
-      <Label htmlFor={radioButtonId} {...labelProps}>
+      <Label {...labelProps} htmlFor={radioButtonId}>
         {label}
       </Label>
     </FieldWrapper>

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -3,26 +3,19 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
-import AccessibleField from '../AccessibleField/AccessibleField'
+import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import { omitMargins } from '../helpers/omit'
-import { LabelProps } from '../Label/Label'
 import Select, { OptionType, SelectProps, SelectValueType } from '../Select/Select'
-import { FieldOnChangeHandler, Omit } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
 interface SelectFieldProps
   extends MarginProps,
     WidthProps,
+    FieldProps,
     Omit<SelectProps, 'id' | 'onChange' | keyof MarginProps | keyof WidthProps> {
-  label: React.ReactNode
-  labelProps?: LabelProps
-  name: string
   options: (OptionType | string)[]
   className?: string
   id?: string
-  success?: string
-  warning?: string
-  error?: string
-  tooltip?: string
   multiple?: boolean
   onChange?: FieldOnChangeHandler<SelectValueType>
 }

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -3,23 +3,16 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { AccessibleField } from '../AccessibleField/AccessibleField'
+import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import handleEvent from '../helpers/eventHandler'
 import { omitMargins } from '../helpers/omit'
-import { LabelProps } from '../Label/Label'
 import TextArea, { TextAreaProps } from '../TextArea/TextArea'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler, Omit } from '../types'
+import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler } from '../types'
 
 interface TextAreaFieldProps
   extends MarginProps,
-    Omit<TextAreaProps, 'status' | 'onChange' | 'onFocus' | 'onBlur'> {
-  label: React.ReactNode
-  name: string
-  labelProps?: LabelProps
-  success?: string
-  warning?: string
-  error?: string
-  tooltip?: string
+    FieldProps,
+    Omit<TextAreaProps, 'name' | 'status' | 'onChange' | 'onFocus' | 'onBlur'> {
   onChange?: FieldOnChangeHandler<string>
   onFocus?: FieldOnFocusHandler
   onBlur?: FieldOnBlurHandler

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -3,23 +3,16 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import AccessibleField from '../AccessibleField/AccessibleField'
+import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import handleEvent from '../helpers/eventHandler'
 import { omitMargins } from '../helpers/omit'
-import { LabelProps } from '../Label/Label'
 import { TextInput, TextInputProps } from '../TextInput/TextInput'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler, Omit } from '../types'
+import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler } from '../types'
 
 interface TextInputFieldProps
   extends MarginProps,
-    Omit<TextInputProps, 'status' | 'onChange' | 'onFocus' | 'onBlur'> {
-  label: React.ReactNode
-  name: string
-  labelProps?: LabelProps
-  success?: string
-  warning?: string
-  error?: string
-  tooltip?: string
+    FieldProps,
+    Omit<TextInputProps, 'name' | 'status' | 'onChange' | 'onFocus' | 'onBlur'> {
   onChange?: FieldOnChangeHandler<string>
   onFocus?: FieldOnFocusHandler
   onBlur?: FieldOnBlurHandler


### PR DESCRIPTION
All usages of `Label` already accepted JSX, but while I was double-checking that I figured I'd standardize the usages & types. I also added some tests that cover the JSX case.

I'm planning on removing mapping types (`Pick`, `Omit`) where possible, and reducing nesting in others, for a couple of reasons:

- It improves readability of type errors, because `Pick`s can get pretty long, and `Omit`s even longer.
- While I was testing something, I found that running `Pick<React.ComponentProps<typeof Component>, 'some' | 'fields'>` changed optional fields to required. That's a pretty edge-case quirk that doesn't apply to simple types & interfaces, so I figured it would be best to simplify where possible.

Along with that, I'm changing `Omit` references from the one in our code to the builtin Omit, which I'm pretty sure is identical.