### PR TITLE
CACTUS-267: Tooltip

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
@@ -50,7 +50,12 @@ describe('component: AccessibleField', (): void => {
   test('alternate prop types', (): void => {
     const { container, getByText } = render(
       <StyleProvider>
-        <AccessibleField id="aftest" label={<em>Accessible Label</em>} name="text_field">
+        <AccessibleField
+          id="aftest"
+          label={<em>Accessible Label</em>}
+          name="text_field"
+          tooltip={<strong>JSX Tooltip</strong>}
+        >
           {(field) => <input name={field.name} id={field.fieldId} />}
         </AccessibleField>
       </StyleProvider>
@@ -62,6 +67,12 @@ describe('component: AccessibleField', (): void => {
     expect(label?.tagName).toBe('LABEL')
     const input = container.querySelector(`#${label?.getAttribute('for')}`)
     expect(input).toHaveAttribute('name', 'text_field')
+
+    const tooltipText = getByText('JSX Tooltip')
+    expect(tooltipText.tagName).toBe('STRONG')
+    expect(tooltipText.parentElement).toHaveAttribute('id', 'aftest-tip')
+    expect(tooltipText.parentElement).toHaveAttribute('role', 'tooltip')
+
     expect(container).toMatchSnapshot()
   })
 })

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -27,7 +27,7 @@ export interface FieldProps {
   name: string
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor' | 'id'>
-  tooltip?: string
+  tooltip?: React.ReactNode
   error?: string
   warning?: string
   success?: string
@@ -161,7 +161,7 @@ AccessibleField.propTypes = {
   success: PropTypes.string,
   warning: PropTypes.string,
   error: PropTypes.string,
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.node,
 }
 
 export default AccessibleField

--- a/modules/cactus-web/src/AccessibleField/__snapshots__/AccessibleField.test.tsx.snap
+++ b/modules/cactus-web/src/AccessibleField/__snapshots__/AccessibleField.test.tsx.snap
@@ -12,6 +12,11 @@ exports[`component: AccessibleField alternate prop types 1`] = `
   color: hsl(200,10%,20%);
 }
 
+.c6 {
+  vertical-align: middle;
+  color: hsl(200,96%,35%);
+}
+
 .c2 {
   position: relative;
 }
@@ -23,7 +28,7 @@ exports[`component: AccessibleField alternate prop types 1`] = `
   padding-right: 28px;
 }
 
-.c2 .sc-pReKu {
+.c2 .c5 {
   position: absolute;
   right: 8px;
   top: 2px;
@@ -54,6 +59,31 @@ exports[`component: AccessibleField alternate prop types 1`] = `
         Accessible Label
       </em>
     </label>
+    <span
+      class="c5 "
+      data-reach-tooltip-trigger=""
+    >
+      <svg
+        class="sc-fzpdbB c6"
+        fill="currentcolor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M22,12 C22,6.47714622 17.5223159,2 12,2 C6.47523326,2 2,6.47577095 2,12 C2,17.524229 6.47523326,22 12,22 C17.5223159,22 22,17.5228538 22,12 Z M24,12 C24,18.6274771 18.6268316,24 12,24 C5.37060996,24 0,18.6287448 0,12 C0,5.37125524 5.37060996,0 12,0 C18.6268316,0 24,5.37252293 24,12 Z M11.057,15.6442233 L11.057,12.5 L9.27493729,12.5 C8.72265254,12.5 8.27493729,12.0522847 8.27493729,11.5 C8.27493729,10.9477153 8.72265254,10.5 9.27493729,10.5 L12.057,10.5 C12.6092847,10.5 13.057,10.9477153 13.057,11.5 L13.057,15.6442233 L15.0505322,15.6442233 C15.602817,15.6442233 16.0505322,16.0919386 16.0505322,16.6442233 C16.0505322,17.1965081 15.602817,17.6442233 15.0505322,17.6442233 L9,17.6442233 C8.44771525,17.6442233 8,17.1965081 8,16.6442233 C8,16.0919386 8.44771525,15.6442233 9,15.6442233 L11.057,15.6442233 Z M11.5,9 C10.6715729,9 10,8.32842712 10,7.5 C10,6.67157288 10.6715729,6 11.5,6 C12.3284271,6 13,6.67157288 13,7.5 C13,8.32842712 12.3284271,9 11.5,9 Z"
+        />
+      </svg>
+    </span>
+    <span
+      id="aftest-tip"
+      role="tooltip"
+      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+    >
+      <strong>
+        JSX Tooltip
+      </strong>
+    </span>
     <input
       id="aftest"
       name="text_field"

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -15,7 +15,7 @@ interface FileInputFieldProps extends FileInputProps, MarginProps {
   className?: string
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
-  tooltip?: string
+  tooltip?: React.ReactNode
 }
 
 const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
@@ -69,7 +69,7 @@ export const FileInputField = styled(FileInputFieldBase)`
 FileInputField.propTypes = {
   label: PropTypes.node.isRequired,
   labelProps: PropTypes.object,
-  tooltip: PropTypes.string,
+  tooltip: PropTypes.node,
   name: PropTypes.string.isRequired,
   accept: PropTypes.arrayOf(PropTypes.string) as PropTypes.Validator<string[] | undefined>,
   labels: PropTypes.shape({

--- a/modules/cactus-web/src/Tooltip/Tooltip.story.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.story.tsx
@@ -1,4 +1,3 @@
-import { NotificationInfo } from '@repay/cactus-icons'
 import { boolean, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
@@ -14,17 +13,11 @@ tooltipStories
       <Tooltip
         label={text('label', 'Some tooltip text here')}
         disabled={boolean('disabled', false)}
-      >
-        <NotificationInfo />
-      </Tooltip>
+      />
     )
   )
   .add(
     'Collision Detection',
-    (): React.ReactElement => (
-      <Tooltip label={text('label', 'Some tooltip text here')}>
-        <NotificationInfo />
-      </Tooltip>
-    ),
+    (): React.ReactElement => <Tooltip label={text('label', 'Some tooltip text here')} />,
     { cactus: { overrides: { height: '200vh', width: '200vw' } } }
   )


### PR DESCRIPTION
Make `Tooltip` accept JSX; stop ignoring `position` prop. Thanks to the change I made previously with `FieldProps`, the change to the prop type in `AccessibleField` is propagated to all the components that use it. There was quite a bit of unused/unnecessary complexity in the types in that file.

BREAKING CHANGE: Removed unused props from `Tooltip`; the component's behavior is unchanged so it shouldn't break anything functionally, but the type signature is different so it could break Typescript builds. As a result, I had to remove the `children` from the `Tooltip` stories.

(Note that if I were designing the interface, I would have made the `children` be the content of the tooltip, and had an optional prop for changing the icon.)