### PR TITLE
CACTUS-267: StatusMessage, BreadCrumb, & ConfirmModal

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
@@ -55,6 +55,9 @@ describe('component: AccessibleField', (): void => {
           label={<em>Accessible Label</em>}
           name="text_field"
           tooltip={<strong>JSX Tooltip</strong>}
+          error={<p>Error Paragraph</p>}
+          warning={<a>Warning Anchor</a>}
+          success={<b>Bold Success</b>}
         >
           {(field) => <input name={field.name} id={field.fieldId} />}
         </AccessibleField>
@@ -72,6 +75,21 @@ describe('component: AccessibleField', (): void => {
     expect(tooltipText.tagName).toBe('STRONG')
     expect(tooltipText.parentElement).toHaveAttribute('id', 'aftest-tip')
     expect(tooltipText.parentElement).toHaveAttribute('role', 'tooltip')
+
+    const errorText = getByText('Error Paragraph')
+    expect(errorText.tagName).toBe('P')
+    const errorDiv = errorText.closest('div')
+    expect(errorDiv).toHaveAttribute('id', 'aftest-status')
+    expect(errorDiv).toHaveAttribute('role', 'alert')
+    let otherStatus = null
+    try {
+      otherStatus = getByText('Warning Anchor')
+    } catch {}
+    expect(otherStatus).toBe(null)
+    try {
+      otherStatus = getByText('Bold Success')
+    } catch {}
+    expect(otherStatus).toBe(null)
 
     expect(container).toMatchSnapshot()
   })

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -17,7 +17,7 @@ interface AccessibleProps {
   tooltipId: string
   statusId: string
   status?: Status
-  statusMessage?: string
+  statusMessage?: React.ReactNode
 }
 
 type RenderFunc = (props: AccessibleProps) => JSX.Element | JSX.Element[]
@@ -28,9 +28,9 @@ export interface FieldProps {
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor' | 'id'>
   tooltip?: React.ReactNode
-  error?: string
-  warning?: string
-  success?: string
+  error?: React.ReactNode
+  warning?: React.ReactNode
+  success?: React.ReactNode
 }
 
 interface AccessibleFieldProps extends FieldProps, MarginProps, WidthProps {
@@ -55,7 +55,7 @@ export function useAccessibleField({
   const tooltipId = `${fieldId}-tip`
 
   let status: Status | undefined
-  let statusMessage: string | undefined
+  let statusMessage: React.ReactNode | undefined
   if (error) {
     status = 'error'
     statusMessage = error
@@ -158,9 +158,9 @@ AccessibleField.propTypes = {
   name: PropTypes.string.isRequired,
   className: PropTypes.string,
   id: PropTypes.string,
-  success: PropTypes.string,
-  warning: PropTypes.string,
-  error: PropTypes.string,
+  success: PropTypes.node,
+  warning: PropTypes.node,
+  error: PropTypes.node,
   tooltip: PropTypes.node,
 }
 

--- a/modules/cactus-web/src/AccessibleField/__snapshots__/AccessibleField.test.tsx.snap
+++ b/modules/cactus-web/src/AccessibleField/__snapshots__/AccessibleField.test.tsx.snap
@@ -12,6 +12,28 @@ exports[`component: AccessibleField alternate prop types 1`] = `
   color: hsl(200,10%,20%);
 }
 
+.c10 {
+  vertical-align: middle;
+}
+
+.c8 {
+  padding: 2px 4px;
+  position: relative;
+  box-sizing: border-box;
+  overflow-wrap: break-word;
+  display: inline-block;
+  font-size: 15px;
+  line-height: 1.6;
+  background-color: hsla(353,84%,44%,0.3);
+}
+
+.c8 .c9,
+.c8 .sc-fzoCCn,
+.c8 .sc-paXsP {
+  margin-right: 4px;
+  vertical-align: -2px;
+}
+
 .c6 {
   vertical-align: middle;
   color: hsl(200,96%,35%);
@@ -35,7 +57,7 @@ exports[`component: AccessibleField alternate prop types 1`] = `
   font-size: 16px;
 }
 
-.c2 .sc-qYSYK {
+.c2 .c7 {
   margin-top: 4px;
 }
 
@@ -43,6 +65,13 @@ exports[`component: AccessibleField alternate prop types 1`] = `
   .c4 {
     font-size: 18px;
     line-height: 1.5;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c8 {
+    font-size: 15px;
+    line-height: 1.6;
   }
 }
 
@@ -88,6 +117,31 @@ exports[`component: AccessibleField alternate prop types 1`] = `
       id="aftest"
       name="text_field"
     />
+    <div>
+      <div
+        class="c7 c8"
+        id="aftest-status"
+        role="alert"
+      >
+        <svg
+          aria-hidden="true"
+          class="c9 c10"
+          fill="currentcolor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M11.1055728,1.5527864 C11.4740971,0.815737865 12.5259029,0.815737865 12.8944272,1.5527864 L22.8944272,21.5527864 C23.2268777,22.2176875 22.743382,23 22,23 L2,23 C1.25661798,23 0.773122263,22.2176875 1.10557281,21.5527864 L11.1055728,1.5527864 Z M3.61803399,21 L20.381966,21 L12,4.23606798 L3.61803399,21 Z M12,18 C11.4477153,18 11,17.5522847 11,17 C11,16.4477153 11.4477153,16 12,16 C12.5522847,16 13,16.4477153 13,17 C13,17.5522847 12.5522847,18 12,18 Z M13,14 C13,14.5522847 12.5522847,15 12,15 C11.4477153,15 11,14.5522847 11,14 L11,11 C11,10.4477153 11.4477153,10 12,10 C12.5522847,10 13,10.4477153 13,11 L13,14 Z"
+          />
+        </svg>
+        <span>
+          <p>
+            Error Paragraph
+          </p>
+        </span>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -30,19 +30,16 @@ interface AccordionProps
   extends MarginProps,
     MaxWidthProps,
     WidthProps,
-    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+    React.HTMLAttributes<HTMLDivElement> {
   defaultOpen?: boolean
   variant?: AccordionVariants
 }
 
-interface AccordionHeaderProps
-  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+interface AccordionHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
   render?: (opts: { isOpen: boolean; headerId: string }) => JSX.Element
 }
 
-interface AccordionBodyProps
-  extends MarginProps,
-    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {}
+interface AccordionBodyProps extends MarginProps, React.HTMLAttributes<HTMLDivElement> {}
 
 interface AccordionContext {
   isOpen: boolean
@@ -594,11 +591,9 @@ const simpleBorderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
   `,
 }
 
-const getShape = (shape: Shape): ReturnType<typeof css> => shapeMap[shape]
-const getOutlineBorder = (borderSize: BorderSize): ReturnType<typeof css> =>
-  outlineBorderMap[borderSize]
-const getSimpleBorder = (borderSize: BorderSize): ReturnType<typeof css> =>
-  simpleBorderMap[borderSize]
+const getShape = (shape: Shape) => shapeMap[shape]
+const getOutlineBorder = (borderSize: BorderSize) => outlineBorderMap[borderSize]
+const getSimpleBorder = (borderSize: BorderSize) => simpleBorderMap[borderSize]
 
 const accordionVariantMap: VariantMap = {
   simple: css`

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -12,15 +12,10 @@ import IconButton from '../IconButton/IconButton'
 export type Status = 'error' | 'warning' | 'info' | 'success'
 export type Type = 'general' | 'push'
 
-interface AlertProps
-  extends MarginProps,
-    WidthProps,
-    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+interface AlertProps extends MarginProps, WidthProps, React.HTMLAttributes<HTMLDivElement> {
   status?: Status
   type?: Type
   onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void
-  className?: string
-  children?: React.ReactNode
   shadow?: boolean
   closeLabel?: string
 }

--- a/modules/cactus-web/src/Breadcrumb/Breadcrumb.story.tsx
+++ b/modules/cactus-web/src/Breadcrumb/Breadcrumb.story.tsx
@@ -9,7 +9,7 @@ storiesOf('Breadcrumb', module).add(
   (): ReactElement => (
     <Breadcrumb>
       <Breadcrumb.Item label={text('Label 1', 'Account')} linkTo="/" />
-      <Breadcrumb.Item label={text('Label 2', 'Make a Payment')} linkTo="/" active />
+      <Breadcrumb.Item label={<em>{text('Label 2', 'Make a Payment')}</em>} linkTo="/" active />
     </Breadcrumb>
   )
 )

--- a/modules/cactus-web/src/Breadcrumb/Breadcrumb.tsx
+++ b/modules/cactus-web/src/Breadcrumb/Breadcrumb.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import styled, { StyledComponentBase } from 'styled-components'
 
 interface BreadcrumbItemProps {
-  label: string
+  label: React.ReactNode
   linkTo: string
   className?: string
   active?: boolean

--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -7,16 +7,10 @@ import { margin, MarginProps } from 'styled-system'
 import { omitMargins } from '../helpers/omit'
 import { textStyle } from '../helpers/theme'
 import Spinner from '../Spinner/Spinner'
-import { Omit } from '../types'
 
 export type ButtonVariants = 'standard' | 'action' | 'danger' | 'warning' | 'success'
 
-interface ButtonProps
-  extends Omit<
-      React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-      'ref' | 'disabled'
-    >,
-    MarginProps {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, MarginProps {
   variant?: ButtonVariants
   /** !important */
   disabled?: boolean
@@ -167,9 +161,7 @@ const getShape = (shape: Shape): FlattenSimpleInterpolation => shapeMap[shape]
 
 const getBorder = (size: BorderSize): FlattenSimpleInterpolation => borderMap[size]
 
-const variantOrDisabled = (
-  props: ButtonProps
-): ReturnType<typeof css> | FlattenSimpleInterpolation | undefined => {
+const variantOrDisabled = (props: ButtonProps) => {
   const map = props.inverse ? inverseVariantMap : variantMap
   if (props.disabled) {
     return disabled

--- a/modules/cactus-web/src/CheckBox/CheckBox.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.tsx
@@ -7,19 +7,12 @@ import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
 import { boxShadow } from '../helpers/theme'
-import { Omit } from '../types'
 
-export interface CheckBoxProps
-  extends Omit<
-      React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
-      'ref'
-    >,
-    MarginProps {
+export interface CheckBoxProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
   id: string
-  disabled?: boolean
 }
 
-interface StyledCheckBoxProps extends React.HTMLProps<HTMLSpanElement> {
+interface StyledCheckBoxProps {
   disabled?: boolean
 }
 
@@ -105,7 +98,6 @@ export const CheckBox = styled(CheckBoxBase)`
   ${margin}
 `
 
-// @ts-ignore
 CheckBox.propTypes = {
   id: PropTypes.string.isRequired,
   disabled: PropTypes.bool,

--- a/modules/cactus-web/src/ConfirmModal/ConfirmModal.story.tsx
+++ b/modules/cactus-web/src/ConfirmModal/ConfirmModal.story.tsx
@@ -42,6 +42,7 @@ const ConfirmModalExample = (): React.ReactElement => {
       cancelButtonText={cancelText}
       iconName={iconName}
       iconSize={iconSize}
+      title={text('Title', '')}
     >
       <Text as="h4" fontWeight="normal">
         {descriptionText}

--- a/modules/cactus-web/src/ConfirmModal/ConfirmModal.tsx
+++ b/modules/cactus-web/src/ConfirmModal/ConfirmModal.tsx
@@ -1,8 +1,8 @@
 import * as icons from '@repay/cactus-icons'
-import { CactusTheme, ColorStyle } from '@repay/cactus-theme'
+import { ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, ThemeProps } from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import Button from '../Button/Button'
 import Flex from '../Flex/Flex'
@@ -16,12 +16,10 @@ export type IconNames = keyof typeof icons
 const iconNames: IconNames[] = Object.keys(icons) as (keyof typeof icons)[]
 
 interface ConfirmModalProps extends ModalProps {
-  cancelButtonText?: string
-  children?: React.ReactNode
-  confirmButtonText?: string
-  description?: string
+  cancelButtonText?: React.ReactNode
+  confirmButtonText?: React.ReactNode
   onConfirm: () => void
-  title?: string
+  title?: React.ReactNode
   iconName?: IconNames
   iconSize?: IconSizes
 }
@@ -30,7 +28,7 @@ interface IconProps {
   iconSize?: IconSizes
   iconName?: IconNames
   className?: string
-  variant?: string
+  variant?: ModalProps['variant']
 }
 
 const IconBase = ({ className, iconSize, iconName }: IconProps): React.ReactElement => {
@@ -48,9 +46,7 @@ const getIconWidthAndHeight = ({ iconSize }: IconProps): '56px' | '88px' | undef
   }
 }
 
-const getFlexDirection = ({
-  iconSize,
-}: ConfirmModalProps & ThemeProps<CactusTheme>): 'row' | 'column' =>
+const getFlexDirection = ({ iconSize }: ConfirmModalProps): 'row' | 'column' =>
   iconSize === 'medium' ? 'row' : 'column'
 
 const ConfirmModalBase: React.FunctionComponent<ConfirmModalProps> = ({
@@ -139,25 +135,23 @@ const Icon = styled(IconBase)<IconProps>`
   })}
 `
 ConfirmModal.propTypes = {
-  cancelButtonText: PropTypes.string,
+  cancelButtonText: PropTypes.node,
   className: PropTypes.string,
   closeLabel: PropTypes.string,
-  confirmButtonText: PropTypes.string,
-  description: PropTypes.string,
+  confirmButtonText: PropTypes.node,
   iconName: PropTypes.oneOf([...iconNames]),
   iconSize: PropTypes.oneOf(['medium', 'large']),
   isOpen: PropTypes.bool.isRequired,
   modalLabel: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
-  title: PropTypes.string,
+  title: PropTypes.node,
   variant: PropTypes.oneOf(['action', 'danger', 'warning', 'success']),
 }
 
 ConfirmModal.defaultProps = {
   cancelButtonText: 'Cancel',
   confirmButtonText: 'Confirm',
-  description: undefined,
   iconName: undefined,
   iconSize: 'medium',
   title: 'Modal Title',

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -5,17 +5,10 @@ import {
   NotificationError,
   StatusCheck,
 } from '@repay/cactus-icons'
-import { CactusTheme, Shape, TextStyle } from '@repay/cactus-theme'
+import { CactusTheme, Shape } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { MutableRefObject, useEffect, useRef, useState } from 'react'
-import styled, {
-  css,
-  DefaultTheme,
-  FlattenInterpolation,
-  FlattenSimpleInterpolation,
-  StyledComponentBase,
-  ThemedStyledProps,
-} from 'styled-components'
+import styled, { css, StyledComponentBase } from 'styled-components'
 import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 'styled-system'
 
 import Avatar from '../Avatar/Avatar'
@@ -28,7 +21,7 @@ import { IconButton } from '../IconButton/IconButton'
 import Spinner from '../Spinner/Spinner'
 import StatusMessage from '../StatusMessage/StatusMessage'
 import { TextButton } from '../TextButton/TextButton'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler, Omit } from '../types'
+import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler } from '../types'
 
 const FILE_TYPE_ERR = 'FileTypeError'
 const NOT_FOUND_ERR = 'NotFoundError'
@@ -52,17 +45,14 @@ export interface FileInputProps
   extends MarginProps,
     MaxWidthProps,
     WidthProps,
-    Omit<
-      React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
-      'onChange' | 'onError' | 'onFocus' | 'onBlur' | 'ref'
-    > {
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onError' | 'onFocus' | 'onBlur'> {
   name: string
   accept?: string[]
   labels?: { delete?: string; loading?: string; loaded?: string }
   buttonText?: string
   prompt?: string
   onChange?: FieldOnChangeHandler<FileObject[]>
-  onError?: (type: ErrorType, accept?: string[]) => string
+  onError?: (type: ErrorType, accept?: string[]) => React.ReactChild
   onFocus?: FieldOnFocusHandler
   onBlur?: FieldOnBlurHandler
   rawFiles?: boolean
@@ -83,7 +73,7 @@ interface FileBoxProps {
   status: FileStatus
   labels: { delete?: string; loading?: string; loaded?: string }
   className?: string
-  errorMsg?: string
+  errorMsg?: React.ReactChild
   disabled?: boolean
 }
 
@@ -96,7 +86,7 @@ export interface FileObject {
   fileName: string
   contents: File | string | null
   status: FileStatus
-  errorMsg?: string
+  errorMsg?: React.ReactChild
 }
 
 interface State {
@@ -131,37 +121,26 @@ const EmptyPrompts = styled(EmptyPromptsBase)`
   }
 `
 
-type FileBoxPropsWithForwardRef = ThemedStyledProps<
-  FileBoxProps & React.RefAttributes<HTMLDivElement>,
-  DefaultTheme
->
-type FileBoxMap = {
-  [K in FileStatus | 'disabled']: FlattenInterpolation<FileBoxPropsWithForwardRef>
-}
-
-const fileBoxMap: FileBoxMap = {
-  loading: css<FileBoxPropsWithForwardRef>`
-    background-color: ${(P): string => P.theme.colors.lightContrast};
+const fileBoxMap = {
+  loading: css`
+    background-color: ${(p): string => p.theme.colors.lightContrast};
   `,
-  loaded: css<FileBoxPropsWithForwardRef>`
+  loaded: css`
     border: ${(p): string => border(p.theme, p.theme.colors.success)};
     background-color: ${(p): string => p.theme.colors.transparentSuccess};
   `,
-  error: css<FileBoxPropsWithForwardRef>`
+  error: css`
     border: ${(p): string => border(p.theme, p.theme.colors.error)};
     background-color: ${(p): string => p.theme.colors.transparentError};
   `,
-  disabled: css<FileBoxPropsWithForwardRef>`
+  disabled: css`
     border: ${(p): string => border(p.theme, p.theme.colors.mediumGray)};
     background-color: ${(p): string => p.theme.colors.lightGray};
   `,
 }
 
-const fileStatus = (
-  props: FileBoxPropsWithForwardRef
-): FlattenInterpolation<
-  ThemedStyledProps<FileBoxProps & React.RefAttributes<HTMLDivElement>, DefaultTheme>
-> => (props.disabled ? fileBoxMap.disabled : fileBoxMap[props.status])
+const fileStatus = (props: FileBoxProps) =>
+  props.disabled ? fileBoxMap.disabled : fileBoxMap[props.status]
 
 const FileBoxBase = React.forwardRef<HTMLDivElement, FileBoxProps>(
   (props, ref): React.ReactElement => {
@@ -215,7 +194,7 @@ const FileBox = styled(FileBoxBase)`
   span {
     margin-left: 8px;
     margin-right: 8px;
-    ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
+    ${(p) => textStyle(p.theme, 'body')};
   }
 
   ${Avatar} {
@@ -663,7 +642,7 @@ FileInput.propTypes = {
       fileName: PropTypes.string.isRequired,
       content: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
       status: PropTypes.oneOf(['loading', 'loaded', 'error']),
-      errorMsg: PropTypes.string,
+      errorMsg: PropTypes.node,
     })
   ),
 }

--- a/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
+++ b/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
@@ -1,8 +1,7 @@
 import { NotificationAlert, NotificationError, StatusCheck } from '@repay/cactus-icons'
-import { TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import { textStyle } from '../helpers/theme'
 
@@ -10,7 +9,7 @@ export type Status = 'success' | 'warning' | 'error'
 
 export const StatusPropType = PropTypes.oneOf<Status>(['success', 'warning', 'error'])
 
-interface StatusMessageProps {
+interface StatusMessageProps extends React.HTMLAttributes<HTMLDivElement> {
   status: Status
 }
 
@@ -28,16 +27,14 @@ const statusMap: StatusMap = {
   `,
 }
 
-const statusColors: any = (props: StatusMessageProps): ReturnType<typeof css> => {
-  const { status } = props
-  return statusMap[status as Status]
-}
-
 const Noop = (): null => null
 
-const StatusMessageBase: React.FC<
-  StatusMessageProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>
-> = ({ status, className, children, ...rest }): React.ReactElement => {
+const StatusMessageBase: React.FC<StatusMessageProps> = ({
+  status,
+  className,
+  children,
+  ...rest
+}): React.ReactElement => {
   let StatusIcon: React.ElementType<any> = Noop
   switch (status) {
     case 'error': {
@@ -61,14 +58,14 @@ const StatusMessageBase: React.FC<
   )
 }
 
-const StatusMessage = styled(StatusMessageBase)<StatusMessageProps>`
+const StatusMessage = styled(StatusMessageBase)`
   padding: 2px 4px;
   position: relative;
   box-sizing: border-box;
   overflow-wrap: break-word;
   display: inline-block;
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'small')};
-  ${statusColors}
+  ${(p) => textStyle(p.theme, 'small')};
+  ${(p) => statusMap[p.status]}
 
   ${NotificationError}, ${NotificationAlert}, ${StatusCheck} {
     margin-right: 4px;

--- a/modules/cactus-web/src/TextArea/TextArea.story.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.story.tsx
@@ -3,7 +3,8 @@ import { boolean, select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
-import TextArea, { Status } from './TextArea'
+import { Status } from '../StatusMessage/StatusMessage'
+import TextArea from './TextArea'
 
 type StatusOptions = { [k in Status | 'none']: Status | null }
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -11,19 +11,10 @@ import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
 import { textStyle } from '../helpers/theme'
-import { StatusPropType } from '../StatusMessage/StatusMessage'
-import { Omit } from '../types'
-
-export type Status = 'success' | 'warning' | 'error'
+import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
 export interface TextAreaProps
-  extends Omit<
-      React.DetailedHTMLProps<
-        React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-        HTMLTextAreaElement
-      >,
-      'ref'
-    >,
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
     MarginProps {
   disabled?: boolean
   status?: Status | null


### PR DESCRIPTION
Most of the other changes are removing redundant props definitions & removing invalid props (mostly `ref` from components that don't actually support refs; I didn't consider this a breaking change because even though Typescript would allow the ref, React would complain about it). One breaking change on ConfirmModal, removing an unused prop that was part of the original modal design, but should have been removed when we made the split.