### PR TITLE
CACTUS-267: SplitButton

### DIFF
--- a/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
@@ -39,8 +39,7 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
 
 .c11 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;

--- a/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
+++ b/modules/cactus-web/src/ConfirmModal/__snapshots__/ConfirmModal.test.tsx.snap
@@ -318,9 +318,8 @@ exports[`Modal renders TextInput and Description snapshot 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c14::-moz-focus-inner {
@@ -774,9 +773,8 @@ exports[`Modal variant is danger snapshot 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c11::-moz-focus-inner {
@@ -1205,9 +1203,8 @@ exports[`Modal variant is success snapshot 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c11::-moz-focus-inner {
@@ -1616,9 +1613,8 @@ exports[`Modal variant is warning snapshot 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c11::-moz-focus-inner {

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -36,9 +36,8 @@ exports[`component: FileInput should render a disabled file input 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c5::-moz-focus-inner {
@@ -213,9 +212,8 @@ exports[`component: FileInput should render a file input 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c5::-moz-focus-inner {
@@ -473,9 +471,8 @@ exports[`component: FileInput should render a file with an error 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c15::-moz-focus-inner {
@@ -824,9 +821,8 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c12::-moz-focus-inner {
@@ -1086,9 +1082,8 @@ exports[`component: FileInput should render a loading file 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c6::-moz-focus-inner {

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -40,9 +40,8 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c12::-moz-focus-inner {
@@ -375,9 +374,8 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c22::-moz-focus-inner {
@@ -802,9 +800,8 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c19::-moz-focus-inner {
@@ -1140,9 +1137,8 @@ exports[`component: FileInputField should render a loading file 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c13::-moz-focus-inner {
@@ -1454,9 +1450,8 @@ exports[`component: FileInputField should render file input field 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c12::-moz-focus-inner {

--- a/modules/cactus-web/src/Grid/Grid.tsx
+++ b/modules/cactus-web/src/Grid/Grid.tsx
@@ -1,21 +1,17 @@
 import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import React from 'react'
-import styled, { css, FlattenSimpleInterpolation, StyledComponentBase } from 'styled-components'
+import styled, { StyledComponentBase } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 const GUTTER_WIDTH = 16
 
 type ColumnNum = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 
-interface GridProps
-  extends MarginProps,
-    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+interface GridProps extends MarginProps {
   justify?: 'start' | 'center' | 'end' | 'normal'
 }
 
-interface ItemProps
-  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+interface ItemProps {
   tiny: ColumnNum
   small?: ColumnNum
   medium?: ColumnNum
@@ -23,33 +19,29 @@ interface ItemProps
   extraLarge?: ColumnNum
 }
 
-const calculateFlexItemSize = (columnNum: ColumnNum): FlattenSimpleInterpolation =>
-  css`calc(${(columnNum / 12) * 100}% - ${GUTTER_WIDTH}px)`
+const calculateFlexItemSize = (columnNum: ColumnNum) =>
+  `calc(${(columnNum / 12) * 100}% - ${GUTTER_WIDTH}px)`
 
 export const Item = styled.div<ItemProps>`
   box-sizing: border-box;
 
   margin: ${GUTTER_WIDTH / 2}px ${GUTTER_WIDTH / 2}px;
-  width: ${(p): FlattenSimpleInterpolation => calculateFlexItemSize(p.tiny)};
+  width: ${(p) => calculateFlexItemSize(p.tiny)};
 
   @media (min-width: 769px) {
-    width: ${(p): FlattenSimpleInterpolation | undefined =>
-      p.small ? calculateFlexItemSize(p.small) : undefined};
+    width: ${(p) => (p.small ? calculateFlexItemSize(p.small) : undefined)};
   }
 
   @media (min-width: 1025px) {
-    width: ${(p): FlattenSimpleInterpolation | undefined =>
-      p.medium ? calculateFlexItemSize(p.medium) : undefined};
+    width: ${(p) => (p.medium ? calculateFlexItemSize(p.medium) : undefined)};
   }
 
   @media (min-width: 1201px) {
-    width: ${(p): FlattenSimpleInterpolation | undefined =>
-      p.large ? calculateFlexItemSize(p.large) : undefined};
+    width: ${(p) => (p.large ? calculateFlexItemSize(p.large) : undefined)};
   }
 
   @media (min-width: 1441px) {
-    width: ${(p): FlattenSimpleInterpolation | undefined =>
-      p.extraLarge ? calculateFlexItemSize(p.extraLarge) : undefined};
+    width: ${(p) => (p.extraLarge ? calculateFlexItemSize(p.extraLarge) : undefined)};
   }
 
   @supports (display: grid) {
@@ -93,7 +85,7 @@ const flexJustifyMap = {
 }
 
 interface GridComponent extends StyledComponentBase<'div', CactusTheme, GridProps> {
-  Item: React.ComponentType<ItemProps>
+  Item: typeof Item
 }
 
 export const Grid = styled.div<GridProps>`
@@ -121,9 +113,10 @@ export const Grid = styled.div<GridProps>`
   }
 
   ${margin}
-` as any
+`
 
-Grid.Item = Item
+const DefaultGrid = Grid as any
+DefaultGrid.Item = Item
 
 Grid.propTypes = {
   justify: PropTypes.oneOf(['start', 'center', 'end', 'normal']),
@@ -133,4 +126,4 @@ Grid.defaultProps = {
   justify: 'normal',
 }
 
-export default Grid as GridComponent
+export default DefaultGrid as GridComponent

--- a/modules/cactus-web/src/Link/Link.tsx
+++ b/modules/cactus-web/src/Link/Link.tsx
@@ -4,22 +4,16 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { Omit } from '../types'
 
-interface LinkProps
-  extends MarginProps,
-    Omit<
-      React.DetailedHTMLProps<React.LinkHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
-      'href'
-    > {
+interface LinkProps extends MarginProps, Omit<React.LinkHTMLAttributes<HTMLAnchorElement>, 'href'> {
   to: string
 }
 
-const LinkBase = (props: LinkProps): React.ReactElement => {
+const LinkBase = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   const { to, ...rest } = omitMargins(props)
 
-  return <a href={to} {...rest} />
-}
+  return <a ref={ref} href={to} {...rest} />
+})
 
 export const Link = styled(LinkBase)`
   font-style: italic;
@@ -46,7 +40,6 @@ export const Link = styled(LinkBase)`
   ${margin};
 `
 
-// @ts-ignore
 Link.propTypes = {
   to: PropTypes.string.isRequired,
 }

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -1,12 +1,11 @@
 import { DialogContent, DialogOverlay, DialogProps } from '@reach/dialog'
 import { NavigationClose } from '@repay/cactus-icons'
-import { BorderSize, Shape } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { FunctionComponent } from 'react'
-import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import Flex from '../Flex/Flex'
-import { boxShadow } from '../helpers/theme'
+import { border, boxShadow } from '../helpers/theme'
 import variant from '../helpers/variant'
 import IconButton from '../IconButton/IconButton'
 
@@ -24,29 +23,11 @@ interface ModalPopupProps extends DialogProps {
   variant: ModalType
 }
 
-const borderMap = {
-  thin: css`
-    border: 1px solid;
-  `,
-  thick: css`
-    border: 2px solid;
-  `,
-}
-
 const shapeMap = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 8px;
-  `,
-  round: css`
-    border-radius: 20px;
-  `,
+  square: 'border-radius: 1px;',
+  intermediate: 'border-radius: 8px;',
+  round: 'border-radius: 20px;',
 }
-const getShape = (shape: Shape): FlattenSimpleInterpolation => shapeMap[shape]
-
-const getBorder = (size: BorderSize): FlattenSimpleInterpolation => borderMap[size]
 
 const Modalbase: FunctionComponent<ModalProps> = (props): React.ReactElement => {
   const { variant = 'action', children, isOpen, onClose, modalLabel, closeLabel, ...rest } = props
@@ -88,8 +69,8 @@ export const ModalPopUp = styled(DialogOverlay)<ModalPopupProps>`
   > [data-reach-dialog-content] {
     flex-basis: 100%;
     width: 100%;
-    ${(p): FlattenSimpleInterpolation => getBorder(p.theme.border)};
-    ${(p): FlattenSimpleInterpolation => getShape(p.theme.shape)};
+    border: ${(p) => border(p.theme, '')};
+    ${(p) => shapeMap[p.theme.shape]};
     background: white;
     ${(p): string => boxShadow(p.theme, 2)};
     margin: auto;

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -7,33 +7,22 @@ import {
   MenuPopover as ReachMenuPopover,
 } from '@reach/menu-button'
 import { NavigationChevronDown } from '@repay/cactus-icons'
-import { BorderSize, ColorStyle, Shape, TextStyle } from '@repay/cactus-theme'
+import { ColorStyle, Shape } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { MutableRefObject, useRef } from 'react'
-import styled, {
-  createGlobalStyle,
-  css,
-  DefaultTheme,
-  FlattenSimpleInterpolation,
-  StyledComponent,
-} from 'styled-components'
+import styled, { createGlobalStyle, DefaultTheme, StyledComponent } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { getTopPosition } from '../helpers/positionPopover'
 import { getScrollX } from '../helpers/scrollOffset'
-import { boxShadow, textStyle } from '../helpers/theme'
+import { border, boxShadow, textStyle } from '../helpers/theme'
 
 export interface IconProps {
   iconSize: 'tiny' | 'small' | 'medium' | 'large'
 }
 
-interface SplitButtonProps
-  extends Omit<
-      React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
-      'aria-label'
-    >,
-    MarginProps {
-  mainActionLabel: string
+interface SplitButtonProps extends React.HTMLAttributes<HTMLDivElement>, MarginProps {
+  mainActionLabel: React.ReactChild
   onSelectMainAction: (event: React.MouseEvent<HTMLButtonElement>) => void
   mainActionIcon?: React.FunctionComponent<IconProps>
   disabled?: boolean
@@ -47,38 +36,20 @@ interface SplitButtonActionProps extends Omit<MenuItemImplProps, 'onSelect'> {
   icon?: React.FunctionComponent<IconProps>
 }
 
-const borderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
-  thin: css`
-    border: 1px solid;
-  `,
-  thick: css`
-    border: 2px solid;
-  `,
+const mainShapeMap: { [K in Shape]: string } = {
+  square: 'border-radius: 1px;',
+  intermediate: 'border-radius: 8px 1px 1px 8px;',
+  round: 'border-radius: 20px 1px 1px 20px;',
 }
-
-const mainShapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 8px 1px 1px 8px;
-  `,
-  round: css`
-    border-radius: 20px 1px 1px 20px;
-  `,
-}
-
-const getBorder = (borderSize: BorderSize): ReturnType<typeof css> => borderMap[borderSize]
-const getMainShape = (shape: Shape): ReturnType<typeof css> => mainShapeMap[shape]
 
 const MainActionButton = styled.button`
   box-sizing: border-box;
-  ${(p): ReturnType<typeof css> => getBorder(p.theme.border)}
-  ${(p): ReturnType<typeof css> => getMainShape(p.theme.shape)}
+  border: ${(p) => border(p.theme, '')};
+  ${(p) => mainShapeMap[p.theme.shape]}
   background-color: ${(p): string => p.theme.colors.white};
   height: 32px;
   outline: none;
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
+  ${(p) => textStyle(p.theme, 'body')};
   font-weight: 400;
   cursor: pointer;
   padding-left: 12px;
@@ -123,34 +94,22 @@ const SplitButtonStyles = createGlobalStyle`
   }
 `
 
-const dropdownShapeMap: { [K in Shape]: FlattenSimpleInterpolation } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 4px;
-  `,
-  round: css`
-    border-radius: 8px;
-  `,
+const dropdownShapeMap: { [K in Shape]: string } = {
+  square: 'border-radius: 1px;',
+  intermediate: 'border-radius: 4px;',
+  round: 'border-radius: 8px;',
 }
-
-const getDropdownShape = (shape: Shape): FlattenSimpleInterpolation => dropdownShapeMap[shape]
 
 const SplitButtonList = styled(ReachMenuItems)`
   padding: 8px 0;
   margin-top: 8px;
   outline: none;
-  ${(p): FlattenSimpleInterpolation => getDropdownShape(p.theme.shape)}
+  ${(p) => dropdownShapeMap[p.theme.shape]}
   ${(p): string => boxShadow(p.theme, 1)};
   z-index: 1000;
   background-color: ${(p): string => p.theme.colors.white};
 
-  ${(p): string =>
-    !p.theme.boxShadows
-      ? `${getBorder(p.theme.border)};
-        border-color: ${p.theme.colors.lightContrast};`
-      : ''}
+  border: ${(p) => (!p.theme.boxShadows ? border(p.theme, 'lightContrast') : '0')};
 
   [data-reach-menu-item] {
     position: relative;
@@ -158,7 +117,7 @@ const SplitButtonList = styled(ReachMenuItems)`
     cursor: pointer;
     text-decoration: none;
     overflow-wrap: break-word;
-    ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'small')};
+    ${(p) => textStyle(p.theme, 'small')};
     ${(p): ColorStyle => p.theme.colorStyles.standard};
     outline: none;
     padding: 4px 16px;
@@ -170,27 +129,18 @@ const SplitButtonList = styled(ReachMenuItems)`
   }
 `
 
-const dropdownButtonShapeMap: { [K in Shape]: FlattenSimpleInterpolation } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 1px 8px 8px 1px;
-  `,
-  round: css`
-    border-radius: 1px 20px 20px 1px;
-  `,
+const dropdownButtonShapeMap: { [K in Shape]: string } = {
+  square: 'border-radius: 1px;',
+  intermediate: 'border-radius: 1px 8px 8px 1px;',
+  round: 'border-radius: 1px 20px 20px 1px;',
 }
-
-const getDropdownButtonShape = (shape: Shape): FlattenSimpleInterpolation =>
-  dropdownButtonShapeMap[shape]
 
 const DropdownButton = styled(ReachMenuButton)`
   box-sizing: border-box;
   background-color: ${(p): string => p.theme.colors.darkestContrast};
   height: 32px;
   width: 36px;
-  ${(p): FlattenSimpleInterpolation => getDropdownButtonShape(p.theme.shape)}
+  ${(p) => dropdownButtonShapeMap[p.theme.shape]}
   margin-left: 1px;
   border: 0px;
   outline: none;
@@ -322,7 +272,7 @@ export const SplitButton = styled(SplitButtonBase)`
 ` as any
 
 SplitButton.propTypes = {
-  mainActionLabel: PropTypes.string.isRequired,
+  mainActionLabel: PropTypes.node.isRequired,
   onSelectMainAction: PropTypes.func.isRequired,
   mainActionIcon: PropTypes.elementType,
   disabled: PropTypes.bool,

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -1,16 +1,11 @@
-import { BorderSize, CactusTheme, Shape, TextStyle } from '@repay/cactus-theme'
+import { CactusTheme, Shape } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, {
-  css,
-  FlattenInterpolation,
-  FlattenSimpleInterpolation,
-  ThemeProps,
-} from 'styled-components'
+import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { textStyle } from '../helpers/theme'
+import { border, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
 export interface TextAreaProps
@@ -50,43 +45,21 @@ const displayStatus = (
   }
 }
 
-const borderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
-  thin: css`
-    border: 1px solid;
-  `,
-  thick: css`
-    border: 2px solid;
-  `,
+const shapeMap: { [K in Shape]: string } = {
+  square: 'border-radius: 1px;',
+  intermediate: 'border-radius: 4px;',
+  round: 'border-radius: 8px;',
 }
-
-const shapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 4px;
-  `,
-  round: css`
-    border-radius: 8px;
-  `,
-}
-
-const getBorder = (borderSize: BorderSize): FlattenInterpolation<ThemeProps<CactusTheme>> =>
-  borderMap[borderSize]
-const getShape = (shape: Shape): FlattenInterpolation<ThemeProps<CactusTheme>> => shapeMap[shape]
 
 const Area = styled.textarea<TextAreaProps>`
-  ${(p): FlattenInterpolation<ThemeProps<CactusTheme>> => getBorder(p.theme.border)}
-  border-color: ${(p): string =>
-    p.disabled ? p.theme.colors.lightGray : p.theme.colors.darkContrast};
-  ${(p): FlattenInterpolation<ThemeProps<CactusTheme>> => getShape(p.theme.shape)}
+  border: ${(p) => border(p.theme, p.disabled ? 'lightGray' : 'darkContrast')};
+  ${(p) => shapeMap[p.theme.shape]}
   min-height: 100px;
-  ${(p): string => (p.theme.mediaQueries ? p.theme.mediaQueries.small : '')}{
+  ${(p): string => (p.theme.mediaQueries ? p.theme.mediaQueries.small : '')} {
     min-width: 336px;
-
   }
   box-sizing: border-box;
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')}
+  ${(p) => textStyle(p.theme, 'body')}
   padding: 8px 16px;
   outline: none;
   background-color: ${(p): string =>
@@ -128,7 +101,6 @@ export const TextArea = styled(TextAreaBase)`
   ${margin}
 `
 
-// @ts-ignore
 TextArea.propTypes = {
   disabled: PropTypes.bool,
   status: StatusPropType,

--- a/modules/cactus-web/src/TextArea/__snapshots__/TextArea.test.tsx.snap
+++ b/modules/cactus-web/src/TextArea/__snapshots__/TextArea.test.tsx.snap
@@ -2,8 +2,7 @@
 
 exports[`component: TextArea should render a disabled textarea 1`] = `
 .c1 {
-  border: 1px solid;
-  border-color: hsl(0,0%,90%);
+  border: 1px solid hsl(0,0%,90%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -78,8 +77,7 @@ exports[`component: TextArea should render a disabled textarea 1`] = `
 
 exports[`component: TextArea should render a success textarea 1`] = `
 .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -155,8 +153,7 @@ exports[`component: TextArea should render a success textarea 1`] = `
 
 exports[`component: TextArea should render a textarea 1`] = `
 .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -230,8 +227,7 @@ exports[`component: TextArea should render a textarea 1`] = `
 
 exports[`component: TextArea should render a textarea with a placeholder 1`] = `
 .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -306,8 +302,7 @@ exports[`component: TextArea should render a textarea with a placeholder 1`] = `
 
 exports[`component: TextArea should render a warning textarea 1`] = `
 .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -383,8 +378,7 @@ exports[`component: TextArea should render a warning textarea 1`] = `
 
 exports[`component: TextArea should render an error textarea 1`] = `
 .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -460,8 +454,7 @@ exports[`component: TextArea should render an error textarea 1`] = `
 
 exports[`component: TextArea should support margin space props 1`] = `
 .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -537,8 +530,7 @@ exports[`component: TextArea should support margin space props 1`] = `
 exports[`component: TextArea with theme customization should have 1px border radius 1`] = `
 <DocumentFragment>
   .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 1px;
   min-height: 100px;
   box-sizing: border-box;
@@ -612,8 +604,7 @@ exports[`component: TextArea with theme customization should have 1px border rad
 exports[`component: TextArea with theme customization should have 2px border 1`] = `
 <DocumentFragment>
   .c1 {
-  border: 2px solid;
-  border-color: hsl(200,9%,35%);
+  border: 2px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;
@@ -687,8 +678,7 @@ exports[`component: TextArea with theme customization should have 2px border 1`]
 exports[`component: TextArea with theme customization should have 8px border radius 1`] = `
 <DocumentFragment>
   .c1 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 4px;
   min-height: 100px;
   box-sizing: border-box;

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -88,7 +88,6 @@ export const TextAreaField = styled(TextAreaFieldBase)`
   ${margin}
 `
 
-// @ts-ignore
 TextAreaField.propTypes = {
   label: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,

--- a/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
+++ b/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
@@ -40,8 +40,7 @@ exports[`component: TextAreaField should render a TextAreaField 1`] = `
 }
 
 .c9 {
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   min-height: 100px;
   box-sizing: border-box;

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -1,25 +1,13 @@
-import { BorderSize, Shape } from '@repay/cactus-theme'
-import { CactusTheme, TextStyle } from '@repay/cactus-theme'
+import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import styled, {
-  css,
-  FlattenInterpolation,
-  FlattenSimpleInterpolation,
-  ThemeProps,
-} from 'styled-components'
+import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { textStyle } from '../helpers/theme'
-import { Omit } from '../types'
+import { border, textStyle } from '../helpers/theme'
 
 export type TextButtonVariants = 'standard' | 'action' | 'danger'
 
-interface TextButtonProps
-  extends Omit<
-      React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-      'ref'
-    >,
-    MarginProps {
+interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, MarginProps {
   variant?: TextButtonVariants
   /** !important */
   disabled?: boolean
@@ -41,29 +29,11 @@ const variantMap: VariantMap = {
   `,
 }
 
-const borderMap = {
-  thin: css`
-    border: 1px solid;
-  `,
-  thick: css`
-    border: 2px solid;
-  `,
-}
-
 const shapeMap = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 8px;
-  `,
-  round: css`
-    border-radius: 20px;
-  `,
+  square: 'border-radius: 1px;',
+  intermediate: 'border-radius: 8px;',
+  round: 'border-radius: 20px;',
 }
-const getShape = (shape: Shape): FlattenSimpleInterpolation => shapeMap[shape]
-
-const getBorder = (size: BorderSize): FlattenSimpleInterpolation => borderMap[size]
 
 const inverseVariantMap: VariantMap = {
   action: css`
@@ -81,9 +51,7 @@ const disabled: FlattenInterpolation<ThemeProps<CactusTheme>> = css`
   cursor: not-allowed;
 `
 
-const variantOrDisabled = (
-  props: TextButtonProps
-): FlattenInterpolation<ThemeProps<CactusTheme>> | undefined => {
+const variantOrDisabled = (props: TextButtonProps) => {
   const { variant, inverse } = props
   if (variant === 'danger' && inverse) {
     throw new Error('A danger variant does not exist for an inverse TextButton.')
@@ -97,7 +65,7 @@ const variantOrDisabled = (
 }
 
 export const TextButton = styled.button<TextButtonProps>`
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
+  ${(p) => textStyle(p.theme, 'body')};
   position: relative;
   border: none;
   padding: 4px;
@@ -121,9 +89,8 @@ export const TextButton = styled.button<TextButtonProps>`
       width: 100%;
       top: 0px;
       left: 0px;
-      ${(p): FlattenSimpleInterpolation => getBorder(p.theme.border)};
-      ${(p): FlattenSimpleInterpolation => getShape(p.theme.shape)};
-      border-color: ${(p): string => p.theme.colors.callToAction};
+      border: ${(p) => border(p.theme, 'callToAction')};
+      ${(p) => shapeMap[p.theme.shape]};
     }
   }
 
@@ -141,7 +108,6 @@ export const TextButton = styled.button<TextButtonProps>`
   ${margin}
 `
 
-// @ts-ignore
 TextButton.propTypes = {
   variant: PropTypes.oneOf(['standard', 'action', 'danger']),
   disabled: PropTypes.bool,

--- a/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
+++ b/modules/cactus-web/src/TextButton/__snapshots__/TextButton.test.tsx.snap
@@ -31,9 +31,8 @@ exports[`With theme changes  Should have 2px border 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 2px solid;
+  border: 2px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -93,9 +92,8 @@ exports[`With theme changes  Should have intermediate shape 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 8px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -155,9 +153,8 @@ exports[`With theme changes  Should have square shape 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 1px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -217,9 +214,8 @@ exports[`component: TextButton should default to standard variant 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -283,9 +279,8 @@ exports[`component: TextButton should render a disabled text+icon button 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -360,9 +355,8 @@ exports[`component: TextButton should render a text+icon button 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -433,9 +427,8 @@ exports[`component: TextButton should render call to action variant 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -495,9 +488,8 @@ exports[`component: TextButton should render danger variant 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -553,9 +545,8 @@ exports[`component: TextButton should render disabled variant 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -617,9 +608,8 @@ exports[`component: TextButton should render inverse call to action variant 1`] 
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -675,9 +665,8 @@ exports[`component: TextButton should render inverse disabled variant 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -738,9 +727,8 @@ exports[`component: TextButton should render inverse standard variant 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -800,9 +788,8 @@ exports[`component: TextButton should render standard variant 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {
@@ -863,9 +850,8 @@ exports[`component: TextButton should support space props 1`] = `
   width: 100%;
   top: 0px;
   left: 0px;
-  border: 1px solid;
+  border: 1px solid hsl(200,96%,35%);
   border-radius: 20px;
-  border-color: hsl(200,96%,35%);
 }
 
 .c0::-moz-focus-inner {

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -1,25 +1,14 @@
-import { BorderSize, CactusTheme, Shape, TextStyle } from '@repay/cactus-theme'
+import { CactusTheme, Shape } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, {
-  css,
-  FlattenInterpolation,
-  FlattenSimpleInterpolation,
-  ThemeProps,
-} from 'styled-components'
+import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { textStyle } from '../helpers/theme'
+import { border, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
-import { Omit } from '../types'
 
-export interface TextInputProps
-  extends Omit<
-      React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
-      'ref'
-    >,
-    MarginProps {
+export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
   /** !important */
   disabled?: boolean
   status?: Status | null
@@ -47,9 +36,7 @@ const statusMap: StatusMap = {
   `,
 }
 
-const displayStatus = (
-  props: TextInputProps
-): FlattenInterpolation<ThemeProps<CactusTheme>> | string => {
+const displayStatus = (props: TextInputProps) => {
   if (props.status && !props.disabled) {
     return statusMap[props.status]
   } else {
@@ -69,41 +56,21 @@ const TextInputBase = React.forwardRef<HTMLInputElement, TextInputProps>(
   }
 )
 
-const borderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
-  thin: css`
-    border: 1px solid;
-  `,
-  thick: css`
-    border: 2px solid;
-  `,
+const shapeMap: { [K in Shape]: string } = {
+  square: 'border-radius: 1px;',
+  intermediate: 'border-radius: 8px;',
+  round: 'border-radius: 20px;',
 }
-
-const shapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 8px;
-  `,
-  round: css`
-    border-radius: 20px;
-  `,
-}
-
-const getBorder = (borderSize: BorderSize): ReturnType<typeof css> => borderMap[borderSize]
-const getShape = (shape: Shape): ReturnType<typeof css> => shapeMap[shape]
 
 const Input = styled.input<InputProps>`
   box-sizing: border-box;
-  ${(p): ReturnType<typeof css> => getBorder(p.theme.border)}
-  border-color: ${(p): string =>
-    p.disabled ? p.theme.colors.lightGray : p.theme.colors.darkContrast};
-  ${(p): ReturnType<typeof css> => getShape(p.theme.shape)}
+  border: ${(p) => border(p.theme, p.disabled ? 'lightGray' : 'darkContrast')};
+  ${(p) => shapeMap[p.theme.shape]};
   height: 32px;
   outline: none;
   box-sizing: border-box;
   padding: 7px 28px 7px 15px;
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
+  ${(p) => textStyle(p.theme, 'body')};
   width: ${(p): string | number => p.width || 'auto'};
   background-color: ${(p): string => p.theme.colors.white};
 
@@ -129,7 +96,6 @@ export const TextInput = styled(TextInputBase)`
   ${margin}
 `
 
-// @ts-ignore
 TextInput.propTypes = {
   disabled: PropTypes.bool,
   status: StatusPropType,

--- a/modules/cactus-web/src/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/modules/cactus-web/src/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -4,8 +4,7 @@ exports[`component: TextInput should render a disabled input 1`] = `
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(0,0%,90%);
+  border: 1px solid hsl(0,0%,90%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -72,8 +71,7 @@ exports[`component: TextInput should render a success input 1`] = `
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -141,8 +139,7 @@ exports[`component: TextInput should render a text input 1`] = `
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -208,8 +205,7 @@ exports[`component: TextInput should render an error input 1`] = `
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -277,8 +273,7 @@ exports[`component: TextInput should render an input with a placeholder 1`] = `
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -345,8 +340,7 @@ exports[`component: TextInput should render an warning input 1`] = `
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -414,8 +408,7 @@ exports[`component: TextInput should support margin space props 1`] = `
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -482,8 +475,7 @@ exports[`component: TextInput with theme customization should have 1px border ra
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 1px;
   height: 32px;
   outline: none;
@@ -549,8 +541,7 @@ exports[`component: TextInput with theme customization should have 2px border 1`
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 2px solid;
-  border-color: hsl(200,9%,35%);
+  border: 2px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;
@@ -616,8 +607,7 @@ exports[`component: TextInput with theme customization should have 8px border ra
 <DocumentFragment>
   .c1 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 8px;
   height: 32px;
   outline: none;

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -88,7 +88,6 @@ export const TextInputField = styled(TextInputFieldBase)`
   ${margin}
 `
 
-// @ts-ignore
 TextInputField.propTypes = {
   label: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,

--- a/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
+++ b/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
@@ -41,8 +41,7 @@ exports[`component: TextInputField should render a TextInputField 1`] = `
 
 .c9 {
   box-sizing: border-box;
-  border: 1px solid;
-  border-color: hsl(200,9%,35%);
+  border: 1px solid hsl(200,9%,35%);
   border-radius: 20px;
   height: 32px;
   outline: none;


### PR DESCRIPTION
Last one. Combining `border`/`border-color` led to a lot of snapshot updates. While cleaning up `Link` I also decided to add a `forwardRef`; it was similar to the other cases where Typescript accepted the ref but React did not, but in this case I decided it made more sense to add the ref to React than remove it from Typescript.