### PR TITLE
CACTUS-340 :: Box border-radius

### DIFF
--- a/modules/cactus-web/src/Box/Box.mdx
+++ b/modules/cactus-web/src/Box/Box.mdx
@@ -11,6 +11,21 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 # Box
 
+## Best practices
+
+Use the theme based parameters when possible, this will prevent discrepancies should the theme update in the future.
+
+## Basic usage
+
+The `Box` component is a generic component intended to be used for spacing and alignment within an application.
+  - The default `Box` is a `div` element but can be swapped for any element type using the `as="dd"` prop.
+  - The only built-in style is `box-sizing: border-box` for intuitive sizing.
+  - With the `Box` you have the ability to make the box conform to the shape set in the theme just like most of the rest of the cactus components do.
+  To do this, just set `borderRadius="themed"`.
+  - You can also pass in custom border radius definitions to change with the theme. To do this, you can set
+  `borderRadius={{ square: '2px', intermediate: '6px', round: '12px' }}`. You can customize each individual corner this way as well, using `borderTopLeftRadius`,
+  `borderTopRightRadius`, and so on.
+
 ### Try it out
 
 export const code = `<Box
@@ -35,14 +50,6 @@ export const code = `<Box
     <LivePreview />
   </div>
 </LiveProvider>
-
-## Best practices
-
-Use the theme based parameters when possible, this will prevent discrepencies should the theme update in the future.
-
-## Basic usage
-
-The `Box` component is a generic component intended to be used for spacing and alignment within an application. The default `Box` is a `div` element but can be swapped for any element type using the `as="dd"` prop. The only built-in style is `box-sizing: border-box` for intuitive sizing.
 
 ```jsx
 import React from 'react'

--- a/modules/cactus-web/src/Box/Box.story.tsx
+++ b/modules/cactus-web/src/Box/Box.story.tsx
@@ -1,5 +1,5 @@
 import cactusTheme, { TextStyleCollection } from '@repay/cactus-theme'
-import { select, text } from '@storybook/addon-knobs'
+import { object, select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import { PositionProperty, ZIndexProperty } from 'csstype'
 import React from 'react'
@@ -32,6 +32,12 @@ const sizes = [0, 1, 2, 3, 4, 5, 6]
 const colorStyles = Object.keys(cactusTheme.colorStyles)
 const themeColors = Object.keys(cactusTheme.colors)
 const textStyles = Object.keys(cactusTheme.textStyles)
+
+const defaultBorderRadiusObj = {
+  square: '4px',
+  intermediate: '10px',
+  round: '20px',
+}
 
 storiesOf('Box', module)
   .add(
@@ -84,3 +90,23 @@ storiesOf('Box', module)
       </Box>
     )
   )
+  .add('Custom Border Radius Definitions', () => (
+    <Box
+      width={text('width', '120px')}
+      height={text('height', '120px')}
+      color={select('color', themeColors, 'darkestContrast')}
+      backgroundColor={select('backgroundColor (bg)', themeColors, 'lightContrast')}
+      borderColor={select('borderColor', themeColors, 'darkestContrast')}
+      borderWidth={text('borderWidth', '2px')}
+      borderStyle={text('borderStyle', 'solid')}
+      textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
+      padding={select('padding', sizes, 4)}
+      borderRadius={object('borderRadius', defaultBorderRadiusObj)}
+      borderTopLeftRadius={object('borderTopLeftRadius', {})}
+      borderTopRightRadius={object('borderTopRightRadius', {})}
+      borderBottomRightRadius={object('borderBottomRightRadius', {})}
+      borderBottomLeftRadius={object('borderBottomLeftRadius', {})}
+    >
+      {text('children', 'Example Content')}
+    </Box>
+  ))

--- a/modules/cactus-web/src/Box/Box.test.tsx
+++ b/modules/cactus-web/src/Box/Box.test.tsx
@@ -1,3 +1,4 @@
+import { generateTheme } from '@repay/cactus-theme'
 import { render } from '@testing-library/react'
 import * as React from 'react'
 
@@ -44,5 +45,79 @@ describe('component: Box', (): void => {
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  test('borderRadius prop should accept themed arg & custom shape definitions', () => {
+    const { getByText, rerender } = render(
+      <StyleProvider theme={generateTheme({ primaryHue: 200, shape: 'intermediate' })}>
+        <Box borderRadius="themed">Content</Box>
+      </StyleProvider>
+    )
+
+    let myBox = getByText('Content')
+    let boxStyles = window.getComputedStyle(myBox)
+    expect(boxStyles.borderRadius).toBe('4px')
+
+    rerender(
+      <StyleProvider theme={generateTheme({ primaryHue: 200, shape: 'intermediate' })}>
+        <Box borderRadius={{ square: '4px', intermediate: '12px', round: '25px' }}>Content</Box>
+      </StyleProvider>
+    )
+
+    myBox = getByText('Content')
+    boxStyles = window.getComputedStyle(myBox)
+    expect(boxStyles.borderRadius).toBe('12px')
+
+    rerender(
+      <StyleProvider theme={generateTheme({ primaryHue: 200, shape: 'round' })}>
+        <Box borderRadius={{ square: '4px', intermediate: '12px', round: '25px' }}>Content</Box>
+      </StyleProvider>
+    )
+
+    myBox = getByText('Content')
+    boxStyles = window.getComputedStyle(myBox)
+    expect(boxStyles.borderRadius).toBe('25px')
+  })
+
+  test('individual border radius props should accept custom shape definitions', () => {
+    const { getByText, rerender } = render(
+      <StyleProvider theme={generateTheme({ primaryHue: 200, shape: 'intermediate' })}>
+        <Box
+          borderTopLeftRadius={{ square: '1px', intermediate: '10px', round: '20px' }}
+          borderTopRightRadius={{ square: '20px', intermediate: '10px', round: '1px' }}
+          borderBottomRightRadius={{ square: '1px', intermediate: '10px', round: '20px' }}
+          borderBottomLeftRadius={{ square: '20px', intermediate: '10px', round: '1px' }}
+        >
+          Content
+        </Box>
+      </StyleProvider>
+    )
+
+    let myBox = getByText('Content')
+    let boxStyles = window.getComputedStyle(myBox)
+    expect(boxStyles.borderTopLeftRadius).toBe('10px')
+    expect(boxStyles.borderTopRightRadius).toBe('10px')
+    expect(boxStyles.borderBottomRightRadius).toBe('10px')
+    expect(boxStyles.borderBottomLeftRadius).toBe('10px')
+
+    rerender(
+      <StyleProvider theme={generateTheme({ primaryHue: 200, shape: 'square' })}>
+        <Box
+          borderTopLeftRadius={{ square: '1px', intermediate: '10px', round: '20px' }}
+          borderTopRightRadius={{ square: '20px', intermediate: '10px', round: '1px' }}
+          borderBottomRightRadius={{ square: '1px', intermediate: '10px', round: '20px' }}
+          borderBottomLeftRadius={{ square: '20px', intermediate: '10px', round: '1px' }}
+        >
+          Content
+        </Box>
+      </StyleProvider>
+    )
+
+    myBox = getByText('Content')
+    boxStyles = window.getComputedStyle(myBox)
+    expect(boxStyles.borderTopLeftRadius).toBe('1px')
+    expect(boxStyles.borderTopRightRadius).toBe('20px')
+    expect(boxStyles.borderBottomRightRadius).toBe('1px')
+    expect(boxStyles.borderBottomLeftRadius).toBe('20px')
   })
 })

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -1,5 +1,5 @@
-import { TextStyle, TextStyleCollection } from '@repay/cactus-theme'
-import styled, { FlattenSimpleInterpolation } from 'styled-components'
+import { TextStyleCollection } from '@repay/cactus-theme'
+import styled, { DefaultTheme, ThemedStyledProps } from 'styled-components'
 import {
   border,
   BorderProps,
@@ -20,7 +20,29 @@ import {
   TypographyProps,
 } from 'styled-system'
 
-import { textStyle } from '../helpers/theme'
+import { radius, textStyle } from '../helpers/theme'
+
+interface CustomBR {
+  square: string
+  intermediate: string
+  round: string
+}
+
+interface CustomBorderProps
+  extends Omit<
+    BorderProps,
+    | 'borderRadius'
+    | 'borderTopLeftRadius'
+    | 'borderTopRightRadius'
+    | 'borderBottomRightRadius'
+    | 'borderBottomLeftRadius'
+  > {
+  borderRadius?: BorderProps['borderRadius'] | CustomBR | 'themed'
+  borderTopLeftRadius?: BorderProps['borderTopLeftRadius'] | CustomBR
+  borderTopRightRadius?: BorderProps['borderTopRightRadius'] | CustomBR
+  borderBottomRightRadius?: BorderProps['borderBottomRightRadius'] | CustomBR
+  borderBottomLeftRadius?: BorderProps['borderBottomLeftRadius'] | CustomBR
+}
 
 export interface BoxProps
   extends PositionProps,
@@ -30,15 +52,53 @@ export interface BoxProps
     ColorStyleProps,
     DisplayProps,
     TypographyProps,
-    BorderProps {
+    CustomBorderProps {
   textStyle?: keyof TextStyleCollection
+}
+
+const isInstanceOfCustomBR = (borderProp: any): borderProp is CustomBR => {
+  return borderProp !== null && borderProp !== undefined && borderProp.hasOwnProperty('square')
+}
+
+const decideBorderRadius = (props: ThemedStyledProps<BoxProps, DefaultTheme>) => {
+  const {
+    borderRadius,
+    borderTopLeftRadius,
+    borderTopRightRadius,
+    borderBottomRightRadius,
+    borderBottomLeftRadius,
+  } = props
+
+  if (borderRadius && borderRadius === 'themed') {
+    return `border-radius: ${radius(props)};`
+  } else if (isInstanceOfCustomBR(borderRadius)) {
+    return `border-radius: ${borderRadius[props.theme.shape]};`
+  }
+
+  let borderRadiusStyles = ''
+
+  if (isInstanceOfCustomBR(borderTopLeftRadius)) {
+    borderRadiusStyles += `border-top-left-radius: ${borderTopLeftRadius[props.theme.shape]};`
+  }
+  if (isInstanceOfCustomBR(borderTopRightRadius)) {
+    borderRadiusStyles += `border-top-right-radius: ${borderTopRightRadius[props.theme.shape]};`
+  }
+  if (isInstanceOfCustomBR(borderBottomRightRadius)) {
+    borderRadiusStyles += `border-bottom-right-radius: ${
+      borderBottomRightRadius[props.theme.shape]
+    };`
+  }
+  if (isInstanceOfCustomBR(borderBottomLeftRadius)) {
+    borderRadiusStyles += `border-bottom-left-radius: ${borderBottomLeftRadius[props.theme.shape]};`
+  }
+  return borderRadiusStyles
 }
 
 export const Box = styled('div')<BoxProps>`
   box-sizing: border-box;
   ${compose(position, display, layout, space, colorStyle, color, typography, border)}
-  ${(p): FlattenSimpleInterpolation | TextStyle | undefined =>
-    p.textStyle && textStyle(p.theme, p.textStyle)}
+  ${(p) => p.textStyle && textStyle(p.theme, p.textStyle)}
+  ${decideBorderRadius}
 `
 
 export default Box


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-340

### Testing
1. Open the basic usage Box story
2. Set `borderRadius` to "themed" using the knobs.
3. Change the theme shape and make sure the shape of the box changes with it.
4. Open the "Custom Border Radius Definitions" Box story. This story allows you to set custom objects for each of the border radius props.
5. Edit the values in the `borderRadius` object and make sure they're used and that they change with the theme.
6. Remove the object from `borderRadius` (replace the text in there with an empty object `{}`)
7. Set a custom border radius object for any/all of the individual border radii props and make sure those are working as well.