### PR TITLE
CACTUS-338 :: Formik Example

### DIFF
--- a/docs/Components/API Documentation.md
+++ b/docs/Components/API Documentation.md
@@ -39,6 +39,15 @@ Inverse props are a _work in progress_ and should not be used in production curr
 
 Most of the time, a theme will make use of a lighter base color, and components placed on that background will be easily visible, however, if the base color is dark, it will be necessary to use the inverse colors for a component so that it is easy to see. The inverse components flip the colors used in their standard counterpart which will provide more contrast, making them easier to see.
 
+## Form Helper Tools
+
+If you are using `@repay/cactus-web` form elements to build a form and you'd like to implement a third-party form management tool, we recommend that you use [Formik](https://formik.org/).
+
+Formik exports a [Field](https://formik.org/docs/api/field) component which can easily be used to wrap our components, and their API helps handle things like form state
+management as well as field validation.
+
+To see an example showcasing how `Formik` and `@repay/cactus-web` form elements can be used together, check out the [UI Config](../../examples/mock-ebpp/src/containers/ui-config.tsx) container in our Mock EBPP app. Take note of the `FormikField` component and how it uses `Field` to wrap each of our components, as well as how we can use `Formik` to accomplish field validation.
+
 ## Next Steps
 
 You can find individual component documentation in the side navigation.

--- a/examples/mock-ebpp/package.json
+++ b/examples/mock-ebpp/package.json
@@ -35,6 +35,7 @@
     "@repay/cactus-icons": "^1.0.0",
     "@repay/cactus-theme": "^1.0.0",
     "@repay/cactus-web": "^2.0.0",
+    "formik": "^2.1.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",

--- a/examples/mock-ebpp/src/containers/ui-config.tsx
+++ b/examples/mock-ebpp/src/containers/ui-config.tsx
@@ -13,10 +13,39 @@ import {
   TextInputField,
   ToggleField,
 } from '@repay/cactus-web'
-import React, { useState } from 'react'
+import { ErrorMessage, Field, FieldProps, Form, Formik, FormikHelpers } from 'formik'
+import React from 'react'
 import { Helmet } from 'react-helmet'
 
 import { post } from '../api'
+
+type FormikFieldProps = Omit<
+  React.ComponentProps<typeof Field>,
+  'innerRef' | 'type' | 'render' | 'component'
+>
+
+const FormikField: React.FunctionComponent<FormikFieldProps> = ({
+  as: WrappedComponent,
+  name,
+  validate,
+  value: passedValue,
+  ...rest
+}) => (
+  <Field name={name} validate={validate}>
+    {({ field: { name, value }, form: { setFieldValue, setFieldTouched } }: FieldProps<any>) => {
+      const valueToUse = passedValue === undefined || passedValue === null ? value : passedValue
+      return (
+        <WrappedComponent
+          {...rest}
+          name={name}
+          value={valueToUse}
+          onChange={(_: string, val: any) => setFieldValue(name, val)}
+          onBlur={() => setFieldTouched(name, true)}
+        />
+      )
+    }}
+  </Field>
+)
 
 interface FileObject {
   fileName: string
@@ -25,115 +54,88 @@ interface FileObject {
   errorMsg?: string
 }
 
-interface State {
-  formData: {
-    displayName: string
-    merchantName: string
-    termsAndConditions: string
-    welcomeContent: string
-    footerContent: string
-    notificationEmail: string
-    allLocations: string[]
-    mpLocation: string
-    cardBrands: string[]
-    allowCustomerLogin: boolean
-    useCactusStyles: boolean
-    selectColor: string
-    fileInput: FileObject[] | undefined
-    establishedDate: string
-  }
-
-  status: {
-    error: boolean | undefined
-    message: string
-  }
+interface FormData {
+  displayName: string
+  merchantName: string
+  termsAndConditions: string
+  welcomeContent: string
+  footerContent: string
+  notificationEmail: string
+  allLocations: string[]
+  mpLocation: string
+  cardBrands: string[]
+  allowCustomerLogin: boolean
+  useCactusStyles: boolean
+  selectColor: string
+  fileInput: FileObject[] | undefined
+  establishedDate: string
 }
 
-const getInitialState = (): State => ({
-  formData: {
-    displayName: '',
-    merchantName: '',
-    termsAndConditions: '',
-    welcomeContent: '',
-    footerContent: '',
-    notificationEmail: '',
-    allLocations: [],
-    mpLocation: '',
-    cardBrands: [],
-    allowCustomerLogin: false,
-    useCactusStyles: false,
-    selectColor: '',
-    fileInput: undefined,
-    establishedDate: '2019-10-16',
-  },
-  status: {
-    error: undefined,
-    message: '',
-  },
-})
+type FormErrors = { [K in keyof FormData]?: string }
 
-const formatKey = (key: string): string => {
-  const words = key.replace('_', ' ').split(' ')
-  const newWords: string[] = []
-
-  words.forEach((word): void => {
-    newWords.push(word.charAt(0).toUpperCase() + word.slice(1))
-  })
-  return newWords.join(' ')
+const initialValues: FormData = {
+  displayName: '',
+  merchantName: '',
+  termsAndConditions: '',
+  welcomeContent: '',
+  footerContent: '',
+  notificationEmail: '',
+  allLocations: [],
+  mpLocation: '',
+  cardBrands: [],
+  allowCustomerLogin: false,
+  useCactusStyles: false,
+  selectColor: '',
+  fileInput: undefined,
+  establishedDate: '2019-10-16',
 }
 
-//eslint-disable-next-line @typescript-eslint/no-unused-vars
-const UIConfig = (props: RouteComponentProps): React.ReactElement => {
-  const [state, setState] = useState<State>(getInitialState())
-
-  const handleChange = (name: string, value: any): void => {
-    setState(
-      (state): State => ({
-        formData: { ...state.formData, [name]: value },
-        status: { ...state.status },
-      })
-    )
-  }
-
-  const validate = (formData: typeof state.formData): void => {
-    let errorFound = false
-    Object.keys(formData).forEach((key): void => {
-      //@ts-ignore
-      const value = formData[key]
-
-      if (value === '' || (Array.isArray(value) && value.length === 0)) {
-        errorFound = true
-        setState(
-          (state): State => ({
-            formData: { ...state.formData },
-            status: { error: true, message: `${formatKey(key)} is empty.` },
-          })
-        )
-        return
-      }
-    })
-
-    if (errorFound === false) {
-      setState(
-        (state): State => ({
-          formData: { ...state.formData },
-          status: { error: false, message: `Form successfully submitted` },
-        })
-      )
-    }
-  }
-
-  const handleSubmit = (event: React.SyntheticEvent): void => {
-    event.preventDefault()
-    validate(state.formData)
-    post(state.formData)
+const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
+  const onSubmit = (values: FormData, { setSubmitting }: FormikHelpers<FormData>) => {
+    post(values)
     console.log((window as any).apiData)
+    setSubmitting(false)
   }
 
-  const handleReset = (): void => {
-    console.log(state.formData.fileInput)
-    setState({ ...getInitialState() })
-    console.log(state.formData.fileInput)
+  const validate = (values: FormData): FormErrors => {
+    const errors: FormErrors = {}
+    if (!values.displayName) {
+      errors.displayName = 'Must provide display name'
+    }
+    if (!values.merchantName) {
+      errors.merchantName = 'Must provide merchant name'
+    }
+    if (!values.termsAndConditions) {
+      errors.termsAndConditions = 'Must provide terms & conditions'
+    }
+    if (!values.welcomeContent) {
+      errors.welcomeContent = 'Must provide welcome content'
+    }
+    if (!values.footerContent) {
+      errors.footerContent = 'Must provide footer content'
+    }
+    if (!values.notificationEmail) {
+      errors.notificationEmail = 'Must select a notification email'
+    }
+    if (!values.allLocations || !values.allLocations.length) {
+      errors.allLocations = 'Must select at least one location'
+    }
+    if (!values.mpLocation) {
+      errors.mpLocation = 'Must select most popular location'
+    }
+    if (!values.cardBrands || !values.cardBrands.length) {
+      errors.cardBrands = 'Must select supported card brands'
+    }
+    if (!values.selectColor) {
+      errors.selectColor = 'Must choose a color'
+    }
+    if (!values.fileInput) {
+      errors.fileInput = 'Must choose a logo'
+    }
+    if (!values.establishedDate) {
+      errors.establishedDate = 'Must set established date'
+    }
+    return errors
   }
 
   const emails = ['vvyverman@repay.com', 'dhuber@repay.com']
@@ -152,172 +154,174 @@ const UIConfig = (props: RouteComponentProps): React.ReactElement => {
           </Text>
         </Flex>
 
-        <Flex borderColor="base" borderWidth="2px" borderStyle="solid" width="90%">
-          {state.status.error === true ? (
-            <Alert status="error">{state.status.message}</Alert>
-          ) : state.status.error === false ? (
-            <Alert status="success"> {state.status.message} </Alert>
-          ) : null}
+        <Formik initialValues={initialValues} onSubmit={onSubmit} validate={validate}>
+          {({ errors, touched }) => (
+            <Flex borderColor="base" borderWidth="2px" borderStyle="solid" width="90%">
+              <ErrorMessage name="fileInput">
+                {(msg: string) => <Alert status="error">{msg}</Alert>}
+              </ErrorMessage>
+              <ErrorMessage name="selectColor">
+                {(msg: string) => <Alert status="error">{msg}</Alert>}
+              </ErrorMessage>
+              <Flex width="100%">
+                <Form style={{ width: '100%', padding: '16px' }}>
+                  <FormikField
+                    as={TextInputField}
+                    name="displayName"
+                    label="Display Name"
+                    tooltip="Enter your merchant display name"
+                    error={touched.displayName && errors.displayName}
+                  />
 
-          <Flex width="100%">
-            <form onSubmit={handleSubmit} style={{ width: '100%', padding: '16px' }}>
-              <TextInputField
-                onChange={handleChange}
-                name="displayName"
-                label="Display Name"
-                value={state.formData.displayName}
-                tooltip="Enter your merchant display name"
-              />
+                  <FormikField
+                    as={TextInputField}
+                    name="merchantName"
+                    label="Merchant Name"
+                    tooltip="Enter your merchant name"
+                    error={touched.merchantName && errors.merchantName}
+                  />
+                  <FormikField
+                    as={TextAreaField}
+                    name="termsAndConditions"
+                    label="Terms and Conditions"
+                    tooltip="Enter the terms and conditions for your customers"
+                    error={touched.termsAndConditions && errors.termsAndConditions}
+                  />
 
-              <TextInputField
-                onChange={handleChange}
-                name="merchantName"
-                label="Merchant Name"
-                value={state.formData.merchantName}
-                tooltip="Enter your merchant name"
-              />
-              <TextAreaField
-                onChange={handleChange}
-                name="termsAndConditions"
-                label="Terms and Conditions"
-                value={state.formData.termsAndConditions}
-                tooltip="Enter the terms and conditions for your customers"
-              />
+                  <FormikField
+                    as={TextAreaField}
+                    name="welcomeContent"
+                    label="Welcome Content"
+                    tooltip="Enter content to be displayed on login"
+                    error={touched.welcomeContent && errors.welcomeContent}
+                  />
+                  <FormikField
+                    as={TextAreaField}
+                    name="footerContent"
+                    label="Footer Content"
+                    my={4}
+                    tooltip="Enter content to be displayed in the footer"
+                    error={touched.footerContent && errors.footerContent}
+                  />
+                  <FormikField
+                    as={SelectField}
+                    options={emails}
+                    label="Notification Email"
+                    name="notificationEmail"
+                    my={4}
+                    tooltip="Select an email to receive notifications"
+                    error={touched.notificationEmail && errors.notificationEmail}
+                  />
+                  <FormikField
+                    as={SelectField}
+                    options={cities}
+                    multiple={true}
+                    label="All Locations"
+                    name="allLocations"
+                    tooltip="Select all store locations"
+                    error={touched.allLocations && errors.allLocations}
+                  />
+                  <FormikField
+                    as={SelectField}
+                    options={cities}
+                    comboBox={true}
+                    label="Most Popular Location"
+                    name="mpLocation"
+                    tooltip="Select your most popular location"
+                    error={touched.mpLocation && errors.mpLocation}
+                  />
+                  <FormikField
+                    as={SelectField}
+                    options={cardBrands}
+                    multiple={true}
+                    comboBox={true}
+                    label="Card Brands"
+                    name="cardBrands"
+                    tooltip="Select or create your supported card brands"
+                    error={touched.cardBrands && errors.cardBrands}
+                  />
 
-              <TextAreaField
-                onChange={handleChange}
-                name="welcomeContent"
-                label="Welcome Content"
-                value={state.formData.welcomeContent}
-                tooltip="Enter content to be displayed on login"
-              />
-              <TextAreaField
-                onChange={handleChange}
-                name="footerContent"
-                label="Footer Content"
-                my={4}
-                value={state.formData.footerContent}
-                tooltip="Enter content to be displayed in the footer"
-              />
-              <SelectField
-                options={emails}
-                label="Notification Email"
-                name="notificationEmail"
-                my={4}
-                onChange={handleChange}
-                value={state.formData.notificationEmail}
-                tooltip="Select an email to recieve notifications "
-              />
-              <SelectField
-                options={cities}
-                multiple={true}
-                label="All Locations"
-                name="allLocations"
-                onChange={handleChange}
-                value={state.formData.allLocations}
-                tooltip="Select all store locations"
-              />
-              <SelectField
-                options={cities}
-                comboBox={true}
-                label="Most Popular Location"
-                name="mpLocation"
-                onChange={handleChange}
-                value={state.formData.mpLocation}
-                tooltip="Select your most popular location"
-              />
-              <SelectField
-                options={cardBrands}
-                multiple={true}
-                comboBox={true}
-                label="Card Brands"
-                name="cardBrands"
-                onChange={handleChange}
-                value={state.formData.cardBrands}
-                tooltip="Select or create your supported card brands"
-              />
+                  <Flex width="50%">
+                    <FormikField
+                      as={FileInputField}
+                      my={4}
+                      label="Upload Logo"
+                      name="fileInput"
+                      tooltip="Upload files"
+                      accept={['.jpg', '.png']}
+                      labels={{
+                        delete: 'delete file',
+                        loading: 'loading',
+                        loaded: 'successful',
+                      }}
+                      prompt="Drag files here or"
+                      buttonText="Select Files..."
+                      validate={(val?: any) => (!val ? 'Must upload a logo' : undefined)}
+                    />
+                  </Flex>
 
-              <Flex width="50%">
-                <FileInputField
-                  my={4}
-                  label="Upload Logo"
-                  name="fileInput"
-                  tooltip="Upload files"
-                  accept={['.jpg', '.png']}
-                  labels={{
-                    delete: 'delete file',
-                    loading: 'loading',
-                    loaded: 'successful',
-                  }}
-                  prompt="Drag files here or"
-                  buttonText="Select Files..."
-                  onChange={handleChange}
-                  value={state.formData.fileInput}
-                />
+                  <Flex flexDirection="column" my={3}>
+                    <h3 style={{ margin: '5px 0' }}>Select Color</h3>
+                    <FormikField
+                      as={RadioButtonField}
+                      name="selectColor"
+                      value="yellow"
+                      label="Yellow"
+                      validate={(val?: string) => (!val ? 'Must select a color' : undefined)}
+                    />
+                    <FormikField
+                      as={RadioButtonField}
+                      name="selectColor"
+                      value="pink"
+                      label="Pink"
+                      validate={(val?: string) => (!val ? 'Must select a color' : undefined)}
+                    />
+                    <FormikField
+                      as={RadioButtonField}
+                      name="selectColor"
+                      value="blue"
+                      label="Blue"
+                      validate={(val?: string) => (!val ? 'Must select a color' : undefined)}
+                    />
+                  </Flex>
+
+                  <FormikField
+                    as={ToggleField}
+                    name="allowCustomerLogin"
+                    label="Allow Customer Login"
+                    my={4}
+                  />
+
+                  <FormikField
+                    as={CheckBoxField}
+                    name="useCactusStyles"
+                    label="Use Cactus Styles"
+                    my={4}
+                  />
+
+                  <FormikField
+                    as={DateInputField}
+                    label="Established Date"
+                    name="establishedDate"
+                    id="established-date"
+                    tooltip="The date which the company was established"
+                    format="YYYY-MM-dd"
+                    error={touched.establishedDate && errors.establishedDate}
+                  />
+
+                  <Flex width="100%" justifyContent="center">
+                    <Button type="reset" variant="standard" my={3} mr={3}>
+                      Reset
+                    </Button>
+                    <Button type="submit" variant="action" my={3} ml={3}>
+                      Submit
+                    </Button>
+                  </Flex>
+                </Form>
               </Flex>
-
-              <Flex flexDirection="column" my={3}>
-                <h3 style={{ margin: '5px 0' }}>Select Color</h3>
-                <RadioButtonField
-                  name="selectColor"
-                  value="yellow"
-                  label="Yellow"
-                  onChange={handleChange}
-                  checked={state.formData.selectColor === 'yellow'}
-                />
-                <RadioButtonField
-                  name="selectColor"
-                  value="pink"
-                  label="Pink"
-                  onChange={handleChange}
-                  checked={state.formData.selectColor === 'pink'}
-                />
-                <RadioButtonField
-                  name="selectColor"
-                  value="blue"
-                  label="Blue"
-                  onChange={handleChange}
-                  checked={state.formData.selectColor === 'blue'}
-                />
-              </Flex>
-
-              <ToggleField
-                name="allowCustomerLogin"
-                label="Allow Customer Login"
-                onChange={handleChange}
-                value={state.formData.allowCustomerLogin}
-                my={4}
-              />
-
-              <CheckBoxField
-                name="useCactusStyles"
-                label="Use Cactus Styles"
-                my={4}
-                checked={state.formData.useCactusStyles}
-                onChange={handleChange}
-              />
-
-              <DateInputField
-                label="Established Date"
-                name="establishedDate"
-                id="established-date"
-                tooltip="The date which the company was established"
-                format="YYYY-MM-dd"
-                value={state.formData.establishedDate}
-                onChange={handleChange}
-              />
-
-              <Flex width="100%" justifyContent="center">
-                <Button variant="standard" my={3} mr={3} onClick={handleReset}>
-                  Reset
-                </Button>
-                <Button type="submit" variant="action" my={3} ml={3}>
-                  Submit
-                </Button>
-              </Flex>
-            </form>
-          </Flex>
-        </Flex>
+            </Flex>
+          )}
+        </Formik>
       </Flex>
     </div>
   )

--- a/examples/mock-ebpp/tests/helpers/actions.ts
+++ b/examples/mock-ebpp/tests/helpers/actions.ts
@@ -1,14 +1,14 @@
 import { queryByLabelText, queryByText, within } from '@testing-library/testcafe'
 import { ClientFunction, Selector } from 'testcafe'
 
-const getDropdown = Selector((): Element | null => {
+const getDropdown = Selector(() => {
   if (document.activeElement && document.activeElement.getAttribute('role') === 'listbox') {
     return document.activeElement
   }
   return null
 })
 
-const getCombo = Selector((): Element | null => {
+const getCombo = Selector(() => {
   if (document.activeElement && document.activeElement.getAttribute('role') === 'search') {
     return document.activeElement
   }
@@ -81,7 +81,7 @@ const focusAccordionHeaderByText = ClientFunction((text: string): void => {
     ?.focus()
 })
 
-const getActiveElement = Selector((): Element | null => document.activeElement)
+const getActiveElement = Selector(() => document.activeElement)
 
 export default (
   t: TestController

--- a/yarn.lock
+++ b/yarn.lock
@@ -9831,6 +9831,11 @@ deep-object-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 deepmerge@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.1.1.tgz#ee0866e4019fe62c1276b9062d4c4803d9aea14c"
@@ -11918,6 +11923,20 @@ format@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formik@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.1.5.tgz#de5bbbe35543fa6d049fe96b8ee329d6cd6892b8"
+  integrity sha512-bWpo3PiqVDYslvrRjTq0Isrm0mFXHiO33D8MS6t6dWcqSFGeYF52nlpCM2xwOJ6tRVRznDkL+zz/iHPL4LDuvQ==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.14"
+    lodash-es "^4.17.14"
+    react-fast-compare "^2.0.1"
+    scheduler "^0.18.0"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -15836,6 +15855,11 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
+lodash-es@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -19566,7 +19590,7 @@ react-error-overlay@^6.0.3:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.3.tgz#c378c4b0a21e88b2e159a3e62b2f531fd63bf60d"
   integrity sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw==
 
-react-fast-compare@2.0.4:
+react-fast-compare@2.0.4, react-fast-compare@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
@@ -22975,6 +22999,11 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tinycolor2@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-338

Like I mentioned in our meeting, I wanted to configure the form validation to use the `error` prop on our form elements. As I did this I found a couple of components that don't expose that prop:
  - `RadioButtonField` - I think it would probably make the most sense to include `error`/`warning`/`success` props on the _group_ that Glen has been working on rather than individual radio button fields.
  - `FileInputField` - This component provides ways for developers to render error messages when a file fails to upload, but not for things like when a user doesn't upload a file at all. I think we should add that feature and just display a status message below the box.

Let me know what you guys think about those suggestions.

### Testing
This should really only affect the `mock-ebpp` example app, so I'd just run `yarn w mock-ebpp start` and play around with the UI Config form; make sure you can fill it out & submit, make sure errors are showing up, etc.