### PR TITLE
CACTUS-348 :: DataGrid Column Width

### DIFF
--- a/modules/cactus-web/src/DataGrid/DataGrid.mdx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.mdx
@@ -35,6 +35,7 @@ The `DataGrid` is a wrapper for `Table` that allows you to easily define table c
 The `DataGrid` component has two sub-components to help define your grid structure:
   - `DataGrid.DataColumn` - Receives an `id` prop and renders data from the `data` prop when the key matches `id`. Requires no children.
   - `DataGrid.Column` - Receives a child render function which will be to render anything in this column's cells.
+Any extra props passed to `Column` or `DataColumn` will be passed on to `Table.Cell` internally.
 
 ### Try It Out
 

--- a/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
@@ -219,7 +219,7 @@ const DataGridContainer = (): ReactElement => {
               }
         }
       >
-        <DataGrid.DataColumn id="name" title="Name" align="right" />
+        <DataGrid.DataColumn id="name" title="Name" />
         <DataGrid.DataColumn id="created" title="Created" sortable={true} />
         <DataGrid.DataColumn
           id="active"

--- a/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
@@ -221,8 +221,14 @@ const DataGridContainer = (): ReactElement => {
       >
         <DataGrid.DataColumn id="name" title="Name" />
         <DataGrid.DataColumn id="created" title="Created" sortable={true} />
-        <DataGrid.DataColumn id="active" title="Active" as={BoolComponent} sortable={true} />
-        <DataGrid.Column>
+        <DataGrid.DataColumn
+          id="active"
+          title="Active"
+          as={BoolComponent}
+          sortable={true}
+          width={text('Active Column Width', '')}
+        />
+        <DataGrid.Column width={text('Action Column Width', '')}>
           {(rowData): ReactElement => (
             <SplitButton
               onSelectMainAction={(): void => {

--- a/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
@@ -219,7 +219,7 @@ const DataGridContainer = (): ReactElement => {
               }
         }
       >
-        <DataGrid.DataColumn id="name" title="Name" />
+        <DataGrid.DataColumn id="name" title="Name" align="right" />
         <DataGrid.DataColumn id="created" title="Created" sortable={true} />
         <DataGrid.DataColumn
           id="active"

--- a/modules/cactus-web/src/DataGrid/DataGrid.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.tsx
@@ -3,7 +3,7 @@ import { ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { createContext, ReactElement, useContext, useEffect, useMemo, useState } from 'react'
 import styled, { DefaultTheme, StyledComponent, ThemedStyledProps } from 'styled-components'
-import { margin, MarginProps, WidthProps } from 'styled-system'
+import { margin, MarginProps } from 'styled-system'
 
 import { keyPressAsClick } from '../helpers/a11y'
 import { border, fontSize } from '../helpers/theme'
@@ -12,7 +12,7 @@ import MenuButton from '../MenuButton/MenuButton'
 import Pagination from '../Pagination/Pagination'
 import PrevNext from '../PrevNext/PrevNext'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
-import Table from '../Table/Table'
+import Table, { TableCellProps } from '../Table/Table'
 
 interface DataGridContextType {
   addDataColumn: (dataColumn: DataColumnProps) => void
@@ -102,14 +102,14 @@ interface PageSizeSelectProps {
   className?: string
 }
 
-interface DataColumnProps extends WidthProps {
+interface DataColumnProps extends Omit<TableCellProps, 'as' | 'title'> {
   id: string
   title: React.ReactChild
   sortable?: boolean
   as?: React.ComponentType<any>
 }
 
-interface ColumnProps extends WidthProps {
+interface ColumnProps extends Omit<TableCellProps, 'as' | 'title'> {
   children: ColumnFn
   title?: React.ReactChild
 }

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -40,7 +40,7 @@ interface TableHeaderProps
   variant?: TableVariant
 }
 
-interface TableCellProps
+export interface TableCellProps
   extends React.DetailedHTMLProps<
     React.TdHTMLAttributes<HTMLTableDataCellElement> &
       React.ThHTMLAttributes<HTMLTableHeaderCellElement>,

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext } from 'react'
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import { width, WidthProps } from 'styled-system'
 
-import { border, boxShadow, textStyle } from '../helpers/theme'
+import { border, boxShadow, media, textStyle } from '../helpers/theme'
 import variant from '../helpers/variant'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
 
@@ -236,7 +236,7 @@ const ContentBox = styled.div`
   }
 `
 
-const StyledCell = styled(({ width, variant, ...rest }) => <td {...rest} />)(
+const StyledCell = styled.td(
   variant({
     table: css<TableCellProps>`
       text-align: ${(p): string => p.align || 'left'};
@@ -244,15 +244,16 @@ const StyledCell = styled(({ width, variant, ...rest }) => <td {...rest} />)(
 
       ${(p) =>
         p.width
-          ? `${width}`
-          : p.theme.mediaQueries &&
-            `min-width: calc(160px * 0.7125);
-            ${p.theme.mediaQueries.large} {
-        min-width: calc(160px * 0.875);
-      }
-      ${p.theme.mediaQueries.extraLarge} {
-        min-width: 160px;
-      }`}
+          ? width
+          : css`
+              min-width: calc(160px * 0.7125);
+              ${media(p.theme, 'large')} {
+                min-width: calc(160px * 0.875);
+              }
+              ${media(p.theme, 'extraLarge')} {
+                min-width: 160px;
+              }
+            `}
     `,
     card: css`
       && {

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -2,7 +2,7 @@ import { ColorStyle, Shape, TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { createContext, useContext } from 'react'
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
-import { width } from 'styled-system'
+import { width, WidthProps } from 'styled-system'
 
 import { border, boxShadow, textStyle } from '../helpers/theme'
 import variant from '../helpers/variant'
@@ -41,11 +41,15 @@ interface TableHeaderProps
 }
 
 export interface TableCellProps
-  extends React.DetailedHTMLProps<
-    React.TdHTMLAttributes<HTMLTableDataCellElement> &
-      React.ThHTMLAttributes<HTMLTableHeaderCellElement>,
-    HTMLTableDataCellElement & HTMLTableHeaderCellElement
-  > {
+  extends WidthProps,
+    Omit<
+      React.DetailedHTMLProps<
+        React.TdHTMLAttributes<HTMLTableDataCellElement> &
+          React.ThHTMLAttributes<HTMLTableHeaderCellElement>,
+        HTMLTableDataCellElement & HTMLTableHeaderCellElement
+      >,
+      'width'
+    > {
   variant?: TableVariant
   align?: CellAlignment
   as?: CellType
@@ -232,7 +236,7 @@ const ContentBox = styled.div`
   }
 `
 
-const StyledCell = styled.td(
+const StyledCell = styled(({ width, variant, ...rest }) => <td {...rest} />)(
   variant({
     table: css<TableCellProps>`
       text-align: ${(p): string => p.align || 'left'};

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -2,6 +2,7 @@ import { ColorStyle, Shape, TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { createContext, useContext } from 'react'
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
+import { width } from 'styled-system'
 
 import { border, boxShadow, textStyle } from '../helpers/theme'
 import variant from '../helpers/variant'
@@ -236,19 +237,18 @@ const StyledCell = styled.td(
     table: css<TableCellProps>`
       text-align: ${(p): string => p.align || 'left'};
       padding: 16px;
-      min-width: calc(160px * 0.7125);
 
-      ${(p): string | undefined =>
-        p.theme.mediaQueries &&
-        `${p.theme.mediaQueries.large} {
-      min-width: calc(160px * 0.875);
-    }`}
-
-      ${(p): string | undefined =>
-        p.theme.mediaQueries &&
-        `${p.theme.mediaQueries.extraLarge} {
-      min-width: 160px;
-    }`}
+      ${(p) =>
+        p.width
+          ? `${width}`
+          : p.theme.mediaQueries &&
+            `min-width: calc(160px * 0.7125);
+            ${p.theme.mediaQueries.large} {
+        min-width: calc(160px * 0.875);
+      }
+      ${p.theme.mediaQueries.extraLarge} {
+        min-width: 160px;
+      }`}
     `,
     card: css`
       && {


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-348

To do this, I basically just took any extra props passed to `Column` or `DataColumn` and passed those to `Table.Cell`. Then, in `Table.Cell` I adjusted the CSS a bit so that we only set a `min-width` when `width` isn't passed. If it is passed, we just call the `width` function from Styled System.

The way I did this essentially gives developers the freedom to pass any extra props they want onto the table cells via the column props. Are you guys ok with that? It seemed like the right call to me.

### Testing
1. Open the DataGrid Basic Usage story.
2. Set width values using the two new knobs: "Active Column Width" and "Action Column Width".
3. Make sure that the values you set are setting the column widths appropriately.