### PR TITLE
CACTUS-352 :: DataGrid Scroll Bug

### DIFF
--- a/modules/cactus-web/cactus-addon/constants.js
+++ b/modules/cactus-web/cactus-addon/constants.js
@@ -3,3 +3,4 @@ export const PROP_NAME = 'cactus'
 export const THEME_CHANGE = `${NAME}/themeChange`
 export const BACKGROUND_CHANGE = `${NAME}/backgroundChange`
 export const DECORATOR_LISTENING = `${NAME}/decoratorListening`
+export const BORDER_BOX_CHANGE = `${NAME}/borderBoxChange`

--- a/modules/cactus-web/cactus-addon/index.tsx
+++ b/modules/cactus-web/cactus-addon/index.tsx
@@ -4,7 +4,14 @@ import * as React from 'react'
 import styled, { CSSObject } from 'styled-components'
 
 import { StyleProvider } from '../src/StyleProvider/StyleProvider'
-import { BACKGROUND_CHANGE, DECORATOR_LISTENING, NAME, PROP_NAME, THEME_CHANGE } from './constants'
+import {
+  BACKGROUND_CHANGE,
+  BORDER_BOX_CHANGE,
+  DECORATOR_LISTENING,
+  NAME,
+  PROP_NAME,
+  THEME_CHANGE,
+} from './constants'
 
 type AlignmentTypes = 'center' | 'left' | 'right' | 'bottom' | 'top'
 
@@ -13,6 +20,7 @@ interface StyledContainerBaseProps {
   className?: string
   align?: AlignmentTypes
   overrides?: CSSObject
+  borderBox?: boolean
 }
 
 const StyledContainerBase: React.FC<StyledContainerBaseProps> = ({
@@ -38,9 +46,7 @@ const StyledContainer = styled(StyledContainerBase)`
   ${(p): CSSObject => alignmentMap[p.align]};
   ${(p): CSSObject => p.overrides}
 
-  * {
-    box-sizing: border-box;
-  }
+  ${(p): string => p.borderBox && '* { box-sizing: border-box; }'}
 `
 
 StyledContainer.defaultProps = {
@@ -57,6 +63,7 @@ const ProvideCactusTheme: React.FC<ProvideCactusThemeProps> = ({
 }): React.ReactElement => {
   const [theme, setTheme] = React.useState(cactusTheme)
   const [inverse, setInverse] = React.useState(false)
+  const [borderBox, setBorderBox] = React.useState(false)
 
   React.useEffect((): (() => void) => {
     const updateTheme = (params: any): void => {
@@ -67,19 +74,25 @@ const ProvideCactusTheme: React.FC<ProvideCactusThemeProps> = ({
       setInverse(inverse)
     }
 
+    const updateBorderBox = ({ borderBox }: any): void => {
+      setBorderBox(borderBox)
+    }
+
     channel.on(THEME_CHANGE, updateTheme)
     channel.on(BACKGROUND_CHANGE, updateBackground)
+    channel.on(BORDER_BOX_CHANGE, updateBorderBox)
 
     channel.emit(DECORATOR_LISTENING)
     return (): void => {
       channel.removeListener(THEME_CHANGE, updateTheme)
       channel.removeListener(BACKGROUND_CHANGE, updateBackground)
+      channel.removeListener(BORDER_BOX_CHANGE, updateBorderBox)
     }
   }, [channel])
 
   return (
     <StyleProvider theme={theme} global>
-      <StyledContainer {...props} inverse={inverse} />
+      <StyledContainer {...props} inverse={inverse} borderBox={borderBox} />
     </StyleProvider>
   )
 }

--- a/modules/cactus-web/cactus-addon/index.tsx
+++ b/modules/cactus-web/cactus-addon/index.tsx
@@ -37,6 +37,10 @@ const StyledContainer = styled(StyledContainerBase)`
   ${(p): ColorStyle => (p.inverse ? p.theme.colorStyles.base : p.theme.colorStyles.standard)};
   ${(p): CSSObject => alignmentMap[p.align]};
   ${(p): CSSObject => p.overrides}
+
+  * {
+    box-sizing: border-box;
+  }
 `
 
 StyledContainer.defaultProps = {

--- a/modules/cactus-web/cactus-addon/register.jsx
+++ b/modules/cactus-web/cactus-addon/register.jsx
@@ -4,7 +4,13 @@ import { Form } from '@storybook/components'
 import { styled } from '@storybook/theming'
 import * as React from 'react'
 
-import { BACKGROUND_CHANGE, DECORATOR_LISTENING, NAME, THEME_CHANGE } from './constants'
+import {
+  BACKGROUND_CHANGE,
+  BORDER_BOX_CHANGE,
+  DECORATOR_LISTENING,
+  NAME,
+  THEME_CHANGE,
+} from './constants'
 
 const ScrollArea = styled('div')({ height: '100%', width: '100%', overflowY: 'auto' })
 
@@ -28,6 +34,7 @@ class Panel extends React.Component {
       boxShadows: true,
     },
     backgroundInverse: false,
+    borderBox: false,
   }
 
   componentDidMount() {
@@ -41,6 +48,12 @@ class Panel extends React.Component {
   emitBackgroundChange = () => {
     this.props.channel.emit(BACKGROUND_CHANGE, {
       inverse: this.state.backgroundInverse,
+    })
+  }
+
+  emitBorderBoxChange = () => {
+    this.props.channel.emit(BORDER_BOX_CHANGE, {
+      borderBox: this.state.borderBox,
     })
   }
 
@@ -66,6 +79,10 @@ class Panel extends React.Component {
 
   handleBackgroundChange = (name, value) => {
     this.setState(() => ({ [name]: value }), this.emitBackgroundChange)
+  }
+
+  handleBorderBoxChange = (name, value) => {
+    this.setState(() => ({ [name]: value }), this.emitBorderBoxChange)
   }
 
   handleThemeChange = (name, value) => {
@@ -239,6 +256,22 @@ class Panel extends React.Component {
               checked={this.state.backgroundInverse}
             />
             <label htmlFor="background-inverse">Inverse</label>
+          </Form.Field>
+
+          <SectionTitle>Border-Box Everything</SectionTitle>
+          <Form.Field>
+            <input
+              id="border-box"
+              type="checkbox"
+              name="borderBox"
+              onChange={({ currentTarget }) =>
+                this.handleBorderBoxChange(currentTarget.name, currentTarget.checked)
+              }
+              checked={this.state.borderBox}
+            />
+            <label htmlFor="border-box">
+              Force Storybook to render everything with box-sixing: border-box
+            </label>
           </Form.Field>
         </Form>
       </ScrollArea>

--- a/modules/cactus-web/src/DataGrid/__snapshots__/DataGrid.test.tsx.snap
+++ b/modules/cactus-web/src/DataGrid/__snapshots__/DataGrid.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`component: DataGrid snapshot 1`] = `
   appearance: none;
   padding: 2px 8px;
   display: block;
+  box-sizing: content-box;
   border-left: 1px solid hsl(200,29%,90%);
 }
 

--- a/modules/cactus-web/src/Pagination/Pagination.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.tsx
@@ -302,6 +302,7 @@ const PageItem = styled.li`
   appearance: none;
   padding: 2px 8px;
   display: block;
+  box-sizing: content-box;
 
   &,
   :link {

--- a/modules/cactus-web/src/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/modules/cactus-web/src/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`component: Pagination 11 pages, first page selected 1`] = `
   appearance: none;
   padding: 2px 8px;
   display: block;
+  box-sizing: content-box;
   border-left: 1px solid hsl(200,29%,90%);
 }
 


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-352

Pretty quick one here. The bug came up because the Channels team uses a CSS framework that applies `border-box` styles to all of their elements. For this reason, ~I left the `* { box-sizing: border-box }` style in the storybook CSS~ I added a field to the theme addon in storybook so that we can toggle the border-box styles easily at any time. That way, we can hopefully try to prevent similar issues from cropping up later on.

### Testing
1. Bring up the DataGrid storybook and open the "Cactus Theme" addon tab. At the bottom, check the box to set all elements to `box-sizing: border-box`
2. Make sure there's no vertical scrollbar on the table itself. The pagination component should not be cut off.
2. If you want to test that the fix is _really_ working, you can remove the `box-sizing: content-box` style from the `li`s in the pagination component and you should see the problem pop back up.