### PR TITLE
CACTUS-355 :: Tooltip Fix

### DIFF
--- a/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
@@ -39,7 +39,8 @@ textInputFieldStories
         name="input-1"
         {...eventLoggers}
       />
-    )
+    ),
+    { cactus: { overrides: { height: '110vh', width: '110vw' } } }
   )
   .add(
     'Fixed Width Container',

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -4,7 +4,7 @@ import VisuallyHidden from '@reach/visually-hidden'
 import { NotificationInfo } from '@repay/cactus-icons'
 import { ColorStyle, Shape } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import React, { cloneElement } from 'react'
+import React, { cloneElement, useRef } from 'react'
 import styled, { css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
@@ -106,7 +106,8 @@ const StyledInfo = styled(({ forceVisible, ...props }) => <NotificationInfo {...
 
 const TooltipBase = (props: TooltipProps): React.ReactElement => {
   const { className, disabled, label, ariaLabel, id, maxWidth, position, forceVisible } = props
-  const [trigger, tooltip] = useTooltip()
+  const triggerRef = useRef<HTMLSpanElement | null>(null)
+  const [trigger, tooltip] = useTooltip({ ref: triggerRef })
 
   return (
     <>
@@ -123,7 +124,12 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
             isVisible={forceVisible || tooltip.isVisible}
             label={label}
             ariaLabel={ariaLabel}
-            position={position || cactusPosition}
+            position={
+              position ||
+              ((_, tooltipRect) => {
+                return cactusPosition(triggerRef.current?.getBoundingClientRect(), tooltipRect)
+              })
+            }
             style={{ maxWidth }}
           />
           <VisuallyHidden role="tooltip" id={id}>


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-355

This was happening because `reach/tooltip` doesn't get the client rect for the trigger unless the mouse hovers over the tooltip icon. This wouldn't be a problem if the icon were always in the same place, but when the page is big enough to scroll, then the icon moves. My solution was to manage the ref on the trigger myself and call `getBoundingClientRect()` to pass that into our `cactusPosition` function.

### Testing
1. Clean & rebuild `cactus-web` with `yarn web cleanup && yarn web build`
2. Run the mock-ebpp example app with `yarn w mock-ebpp start`
3. Open the UI Config form and make sure the tooltip comes up in the right spot when you trigger it by focusing on fields, even after you scroll on the page.