### PR TITLE
CACTUS-345 :: Dropdown Widths

### DIFF
--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -140,7 +140,7 @@ function MenuButtonBase(props: MenuButtonProps): React.ReactElement {
 
           return {
             minWidth: targetRect.width,
-            maxWidth: Math.max(targetRect.width, Math.min(targetRect.width * 2, 300)),
+            maxWidth: Math.max(targetRect.width, Math.min(targetRect.width * 2, 400)),
             left: targetRect.left + scrollX,
             ...getTopPosition(targetRect, popoverRect),
           }

--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -140,7 +140,7 @@ function MenuButtonBase(props: MenuButtonProps): React.ReactElement {
 
           return {
             minWidth: targetRect.width,
-            maxWidth: Math.max(targetRect.width, Math.min(targetRect.width * 1.5, 300)),
+            maxWidth: Math.max(targetRect.width, Math.min(targetRect.width * 2, 300)),
             left: targetRect.left + scrollX,
             ...getTopPosition(targetRect, popoverRect),
           }

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -504,7 +504,8 @@ function positionList(
   const style: React.CSSProperties = {
     top: scrollY + triggerRect.top + triggerRect.height + OFFSET + 'px',
     left: scrollX + triggerRect.left + 'px',
-    width: triggerRect.width + 'px',
+    minWidth: triggerRect.width,
+    maxWidth: Math.max(triggerRect.width, Math.min(triggerRect.width * 2, 300)),
   }
   if (listRect === undefined) {
     return style

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -505,7 +505,7 @@ function positionList(
     top: scrollY + triggerRect.top + triggerRect.height + OFFSET + 'px',
     left: scrollX + triggerRect.left + 'px',
     minWidth: triggerRect.width,
-    maxWidth: Math.max(triggerRect.width, Math.min(triggerRect.width * 2, 300)),
+    maxWidth: Math.max(triggerRect.width, Math.min(triggerRect.width * 2, 400)),
   }
   if (listRect === undefined) {
     return style

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -209,7 +209,7 @@ const SplitButtonBase = (props: SplitButtonProps): React.ReactElement => {
                 position={(
                   targetRect,
                   popoverRect
-                ): { width?: number; left?: number; top?: string } => {
+                ): { minWidth?: number; maxWidth?: number; left?: number; top?: string } => {
                   if (!targetRect || !popoverRect || !mainActionRef.current) {
                     return {}
                   }
@@ -219,7 +219,8 @@ const SplitButtonBase = (props: SplitButtonProps): React.ReactElement => {
                   const scrollX = getScrollX()
 
                   return {
-                    width: splitButtonWidth,
+                    minWidth: splitButtonWidth,
+                    maxWidth: Math.max(splitButtonWidth, Math.min(splitButtonWidth * 2, 300)),
                     left: targetRect.left - mainActionButtonWidth + scrollX - 6,
                     ...getTopPosition(targetRect, popoverRect),
                   }

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -220,7 +220,7 @@ const SplitButtonBase = (props: SplitButtonProps): React.ReactElement => {
 
                   return {
                     minWidth: splitButtonWidth,
-                    maxWidth: Math.max(splitButtonWidth, Math.min(splitButtonWidth * 2, 300)),
+                    maxWidth: Math.max(splitButtonWidth, Math.min(splitButtonWidth * 2, 400)),
                     left: targetRect.left - mainActionButtonWidth + scrollX - 6,
                     ...getTopPosition(targetRect, popoverRect),
                   }


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-345

I bumped up the percentage the `MenuButton` uses so that the dropdown could be at most 2x as large as the `MenuButton`, and I used that value for the `SplitButton` & `Select` as well.

Should we consider setting the maximum width the `Select`'s dropdown can grow past its trigger to something larger than 300px? I think 300px is probably fine for the other two, but for the `Select`, I think it'd be much more common to see them with width greater than 150px (the way it's written, if 150px < Select width < 300px, then the dropdown will grow past the select, but only up to 300px max). Maybe we could set the hard cap somewhere in the 400 - 500 pixel range for the `Select`?

### Testing
1. Open the `MenuButton` storybook
2. Set the button's text to something small, 1-3 characters or so. Make sure the dropdown is growing past the button.
3. Open the `SplitButton` storybook
4. Set the main action text to something small, 1-3 characters or so. Make sure the dropdown is growing past the component's width.
5. Open the `Select` "Long option labels" storybook
6. Open the dropdown and make sure its width is longer than that of the Select