### PR TITLE
CACTUS-356 :: FileInputField Validation Props

### DIFF
--- a/examples/mock-ebpp/src/containers/ui-config.tsx
+++ b/examples/mock-ebpp/src/containers/ui-config.tsx
@@ -1,6 +1,5 @@
 import { RouteComponentProps } from '@reach/router'
 import {
-  Alert,
   Button,
   CheckBoxField,
   DateInputField,
@@ -13,7 +12,7 @@ import {
   TextInputField,
   ToggleField,
 } from '@repay/cactus-web'
-import { ErrorMessage, Field, FieldProps, Form, Formik, FormikHelpers } from 'formik'
+import { Field, FieldProps, Form, Formik, FormikHelpers } from 'formik'
 import React from 'react'
 import { Helmet } from 'react-helmet'
 
@@ -157,9 +156,6 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
         <Formik initialValues={initialValues} onSubmit={onSubmit} validate={validate}>
           {({ errors, touched }) => (
             <Flex borderColor="base" borderWidth="2px" borderStyle="solid" width="90%">
-              <ErrorMessage name="fileInput">
-                {(msg: string) => <Alert status="error">{msg}</Alert>}
-              </ErrorMessage>
               <Flex width="100%">
                 <Form style={{ width: '100%', padding: '16px' }}>
                   <FormikField
@@ -254,6 +250,7 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
                       prompt="Drag files here or"
                       buttonText="Select Files..."
                       validate={(val?: any) => (!val ? 'Must upload a logo' : undefined)}
+                      error={touched.fileInput && errors.fileInput}
                     />
                   </Flex>
 

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.story.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.story.tsx
@@ -17,6 +17,7 @@ storiesOf('AccessibleField', module).add(
         warning={text('warning (will show field warning)', '')}
         success={text('success (will show field success)', '')}
         tooltip={text('tooltip?', 'Will only show a tooltip when text is provided.')}
+        autoTooltip={boolean('autoTooltip', true)}
       >
         <input style={{ minWidth: '300px' }} />
       </AccessibleField>

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -32,6 +32,7 @@ export interface FieldProps {
   error?: React.ReactNode
   warning?: React.ReactNode
   success?: React.ReactNode
+  autoTooltip?: boolean
 }
 
 interface AccessibleFieldProps extends FieldProps, MarginProps, WidthProps {
@@ -96,6 +97,7 @@ function AccessibleFieldBase(props: AccessibleFieldProps): React.ReactElement {
     statusMessage,
     disabled,
   } = accessibility
+  const { autoTooltip = true } = props
 
   const ref = React.useRef<HTMLDivElement | null>(null)
   const [forceTooltipVisible, setTooltipVisible] = React.useState<boolean>(false)
@@ -111,10 +113,14 @@ function AccessibleFieldBase(props: AccessibleFieldProps): React.ReactElement {
   }, [maxWidth, setMaxWidth])
 
   const handleFieldFocus = () => {
-    setTooltipVisible(true)
+    if (autoTooltip) {
+      setTooltipVisible(true)
+    }
   }
   const handleFieldBlur = () => {
-    setTooltipVisible(false)
+    if (autoTooltip) {
+      setTooltipVisible(false)
+    }
   }
 
   return (
@@ -192,6 +198,7 @@ AccessibleField.propTypes = {
   error: PropTypes.node,
   tooltip: PropTypes.node,
   disabled: PropTypes.bool,
+  autoTooltip: PropTypes.bool,
 }
 
 export default AccessibleField

--- a/modules/cactus-web/src/DateInputField/DateInputField.story.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.story.tsx
@@ -31,6 +31,7 @@ storiesOf('DateInputField', module)
         error={text('error?', '')}
         success={text('success?', '')}
         warning={text('warning?', '')}
+        autoTooltip={boolean('autoTooltip', true)}
       />
     )
   )

--- a/modules/cactus-web/src/DateInputField/DateInputField.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.tsx
@@ -32,6 +32,7 @@ function DateInputFieldBase(props: DateInputFieldProps): React.ReactElement {
     error,
     width,
     disabled,
+    autoTooltip,
     ...rest
   } = omitMargins(props) as Omit<DateInputFieldProps, keyof MarginProps>
 
@@ -47,6 +48,7 @@ function DateInputFieldBase(props: DateInputFieldProps): React.ReactElement {
       error={error}
       warning={warning}
       success={success}
+      autoTooltip={autoTooltip}
     >
       {({ fieldId, status, labelId, ariaDescribedBy, disabled }): React.ReactElement => (
         <DateInput

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -145,7 +145,8 @@ const fileStatus = (props: FileBoxProps) =>
 const FileBoxBase = React.forwardRef<HTMLDivElement, FileBoxProps>(
   (props, ref): React.ReactElement => {
     const { fileName, className, status, errorMsg, onDelete, labels, disabled } = props
-    const onClick = (): void => {
+    const onClick = (e: React.MouseEvent<HTMLButtonElement>): void => {
+      e.currentTarget.blur()
       onDelete(fileName)
     }
 

--- a/modules/cactus-web/src/FileInputField/FileInputField.story.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.story.tsx
@@ -22,6 +22,10 @@ storiesOf('FileInputField', module).add(
       }}
       prompt={text('prompt', 'Drag files here or')}
       buttonText={text('buttonText', 'Select Files...')}
+      success={text('success', '')}
+      warning={text('warning', '')}
+      error={text('error', '')}
+      autoTooltip={boolean('autoTooltip', false)}
     />
   )
 )

--- a/modules/cactus-web/src/FileInputField/FileInputField.test.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.test.tsx
@@ -96,7 +96,50 @@ describe('component: FileInputField', (): void => {
     expect(container).toMatchSnapshot()
   })
 
-  /** TODO: Add integration tests to theme-components example using puppeteer. We can't put them here because
-   * @types/puppeteer brings in @types/node and sets everything else on fire
-   * */
+  test('should render field validation messages', () => {
+    const { getByText, rerender } = render(
+      <StyleProvider>
+        <FileInputField
+          name="dabears"
+          id="free-fallin"
+          label="Bickin Back"
+          accept={['.txt']}
+          success="Mirror mirror on the wall"
+        />
+      </StyleProvider>
+    )
+
+    const successMsg = getByText('Mirror mirror on the wall')
+    expect(successMsg).toBeInTheDocument()
+
+    rerender(
+      <StyleProvider>
+        <FileInputField
+          name="dabears"
+          id="free-fallin"
+          label="Bickin Back"
+          accept={['.txt']}
+          warning="Who's the boolest of them all?"
+        />
+      </StyleProvider>
+    )
+
+    const warningMsg = getByText("Who's the boolest of them all?")
+    expect(warningMsg).toBeInTheDocument()
+
+    rerender(
+      <StyleProvider>
+        <FileInputField
+          name="dabears"
+          id="free-fallin"
+          label="Bickin Back"
+          accept={['.txt']}
+          error="My boy's the boolest of them all"
+        />
+      </StyleProvider>
+    )
+
+    const errorMsg = getByText("My boy's the boolest of them all")
+    expect(errorMsg).toBeInTheDocument()
+  })
 })

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -6,15 +6,12 @@ import { margin, MarginProps } from 'styled-system'
 import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import FileInput, { FileInputProps, FileObject } from '../FileInput/FileInput'
 import { omitMargins } from '../helpers/omit'
-import Label, { LabelProps } from '../Label/Label'
+import Label from '../Label/Label'
 import Tooltip from '../Tooltip/Tooltip'
 import { Omit } from '../types'
 
 interface FileInputFieldProps extends FileInputProps, MarginProps, FieldProps {
   className?: string
-  label: React.ReactNode
-  labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
-  tooltip?: React.ReactNode
 }
 
 const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -1,17 +1,16 @@
 import PropTypes from 'prop-types'
-import React, { useRef } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import FieldWrapper from '../FieldWrapper/FieldWrapper'
+import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import FileInput, { FileInputProps, FileObject } from '../FileInput/FileInput'
 import { omitMargins } from '../helpers/omit'
-import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import Tooltip from '../Tooltip/Tooltip'
 import { Omit } from '../types'
 
-interface FileInputFieldProps extends FileInputProps, MarginProps {
+interface FileInputFieldProps extends FileInputProps, MarginProps, FieldProps {
   className?: string
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
@@ -19,28 +18,48 @@ interface FileInputFieldProps extends FileInputProps, MarginProps {
 }
 
 const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
-  const { className, disabled, label, labelProps, id, tooltip, ...fileInputProps } = omitMargins(
-    props
-  ) as Omit<FileInputFieldProps, keyof MarginProps>
-  const inputId = useId(id, 'file-input')
-  const tipId = tooltip ? `${inputId}-tip` : ''
-  const containerRef = useRef<HTMLDivElement | null>(null)
-
-  let tooltipWidth = undefined
-  if (containerRef.current && tooltip) {
-    tooltipWidth = `${containerRef.current.getBoundingClientRect().width - 32}px`
-  }
+  const {
+    className,
+    disabled,
+    label,
+    labelProps,
+    id,
+    tooltip,
+    name,
+    success,
+    warning,
+    error,
+    width,
+    autoTooltip = false,
+    ...rest
+  } = omitMargins(props) as Omit<FileInputFieldProps, keyof MarginProps>
 
   return (
-    <FieldWrapper className={className} ref={containerRef}>
-      <Label {...labelProps} htmlFor={inputId}>
-        {label}
-      </Label>
-      {tooltip && (
-        <Tooltip id={tipId} label={tooltip} maxWidth={tooltipWidth} disabled={disabled} />
+    <AccessibleField
+      disabled={disabled}
+      className={className}
+      id={id}
+      name={name}
+      label={label}
+      labelProps={labelProps}
+      tooltip={tooltip}
+      success={success}
+      warning={warning}
+      error={error}
+      width={width}
+      autoTooltip={autoTooltip}
+    >
+      {({ fieldId, labelId, name, ariaDescribedBy, disabled }) => (
+        <FileInput
+          {...rest}
+          id={fieldId}
+          name={name}
+          disabled={disabled}
+          aria-labelledby={labelId}
+          aria-describedby={ariaDescribedBy}
+        />
       )}
-      <FileInput id={inputId} aria-describedby={tipId} disabled={disabled} {...fileInputProps} />
-    </FieldWrapper>
+    </AccessibleField>
   )
 }
 

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -5,21 +5,60 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   margin-top: 16px;
 }
 
-.c11 {
+.c5 {
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(200,10%,20%);
+}
+
+.c12 {
   font-size: 40px;
   vertical-align: middle;
 }
 
-.c14 {
+.c15 {
   font-size: 16px;
   vertical-align: middle;
 }
 
-.c6 {
+.c7 {
   vertical-align: middle;
 }
 
-.c13 {
+.c8 {
+  outline: none;
+  color: hsl(0,0%,70%);
+}
+
+.c8:hover {
+  color: hsl(0,0%,70%);
+}
+
+.c2 {
+  position: relative;
+}
+
+.c2 .c4 {
+  display: block;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 28px;
+  color: hsl(0,0%,70%);
+}
+
+.c2 .c6 {
+  position: absolute;
+  right: 8px;
+  top: 2px;
+  font-size: 16px;
+}
+
+.c2 .sc-qYSYK {
+  margin-top: 4px;
+}
+
+.c14 {
   font-size: 18px;
   line-height: 1.5;
   position: relative;
@@ -35,7 +74,7 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   cursor: not-allowed;
 }
 
-.c13:focus::after {
+.c14:focus::after {
   content: '';
   display: block;
   box-sizing: border-box;
@@ -48,36 +87,36 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   border-radius: 20px;
 }
 
-.c13::-moz-focus-inner {
+.c14::-moz-focus-inner {
   border: 0;
 }
 
-.c13 svg {
+.c14 svg {
   display: inline-block;
   margin-top: -4px;
   margin-right: 4px;
 }
 
-.c9 {
+.c10 {
   width: 300px;
   height: 100px;
 }
 
-.c9 .c10 {
+.c10 .c11 {
   position: absolute;
   top: 30%;
   left: 15%;
   color: hsl(0,0%,70%);
 }
 
-.c9 span {
+.c10 span {
   position: absolute;
   top: 20%;
   left: 37%;
   color: hsl(0,0%,70%);
 }
 
-.c8 {
+.c9 {
   box-sizing: border-box;
   border-radius: 8px;
   border: none;
@@ -100,13 +139,13 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   background-color: hsl(0,0%,90%);
 }
 
-.c8.empty .c12 {
+.c9.empty .c13 {
   position: absolute;
   left: 35%;
   bottom: 15%;
 }
 
-.c8.notEmpty {
+.c9.notEmpty {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -114,36 +153,20 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   padding: 0 8px;
 }
 
-.c8.notEmpty .c12 {
+.c9.notEmpty .c13 {
   position: relative;
   margin: 16px 0 16px 0;
 }
 
-.c8 input {
+.c9 input {
   display: none;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(200,10%,20%);
-}
-
-.c7 {
-  outline: none;
-  color: hsl(0,0%,70%);
-}
-
-.c7:hover {
-  color: hsl(0,0%,70%);
-}
-
-.c2 {
+.c3 {
   position: relative;
 }
 
-.c2 .c3 {
+.c3 .c4 {
   display: block;
   position: relative;
   bottom: 4px;
@@ -151,7 +174,7 @@ exports[`component: FileInputField should render a disabled file input field 1`]
   color: hsl(0,0%,70%);
 }
 
-.c2 .c5 {
+.c3 .c6 {
   position: absolute;
   top: -2px;
   right: 8px;
@@ -160,14 +183,14 @@ exports[`component: FileInputField should render a disabled file input field 1`]
 }
 
 @media screen and (min-width:1024px) {
-  .c13 {
+  .c5 {
     font-size: 18px;
     line-height: 1.5;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c4 {
+  .c14 {
     font-size: 18px;
     line-height: 1.5;
   }
@@ -175,20 +198,21 @@ exports[`component: FileInputField should render a disabled file input field 1`]
 
 <div>
   <div
-    class="c0 c1 c2"
+    class="c0 c1 c2 c3"
   >
     <label
-      class="c3 c4"
+      class="c4 c5"
       for="consistent"
+      id="consistent-label"
     >
       Just Boolin
     </label>
     <span
-      class="c5 "
+      class="c6 "
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6 c7"
+        class="c7 c8"
         disabled=""
         fill="currentcolor"
         height="1em"
@@ -201,7 +225,8 @@ exports[`component: FileInputField should render a disabled file input field 1`]
       </svg>
     </span>
     <div
-      class="c8 empty"
+      aria-labelledby="consistent-label"
+      class="c9 empty"
     >
       <input
         accept=".txt"
@@ -210,10 +235,10 @@ exports[`component: FileInputField should render a disabled file input field 1`]
         type="file"
       />
       <div
-        class="c9"
+        class="c10"
       >
         <svg
-          class="c10 c11"
+          class="c11 c12"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"
@@ -228,14 +253,14 @@ exports[`component: FileInputField should render a disabled file input field 1`]
         </span>
       </div>
       <button
-        aria-describedby="consistent-tip"
-        class="c12 c13"
+        aria-describedby="consistent-tip consistent-status"
+        class="c13 c14"
         disabled=""
         id="consistent"
         type="button"
       >
         <svg
-          class="c14"
+          class="c15"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"
@@ -257,29 +282,85 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   margin-top: 16px;
 }
 
-.c24 {
+.c5 {
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(200,10%,20%);
+}
+
+.c25 {
   font-size: 16px;
   vertical-align: middle;
 }
 
-.c18 {
+.c19 {
   vertical-align: middle;
 }
 
-.c14 {
+.c15 {
   font-size: 24px;
   vertical-align: middle;
 }
 
+.c22 {
+  vertical-align: middle;
+}
+
+.c7 {
+  vertical-align: middle;
+}
+
 .c21 {
-  vertical-align: middle;
+  padding: 2px 4px;
+  position: relative;
+  box-sizing: border-box;
+  overflow-wrap: break-word;
+  display: inline-block;
+  font-size: 15px;
+  line-height: 1.6;
+  background-color: hsla(353,84%,44%,0.3);
 }
 
-.c6 {
-  vertical-align: middle;
+.c21 .c14,
+.c21 .sc-fzoCCn,
+.c21 .sc-paXsP {
+  margin-right: 4px;
+  vertical-align: -2px;
 }
 
-.c12 {
+.c8 {
+  outline: none;
+  color: hsl(200,10%,20%);
+}
+
+.c8:hover {
+  color: hsl(200,96%,35%);
+}
+
+.c2 {
+  position: relative;
+}
+
+.c2 .c4 {
+  display: block;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 28px;
+}
+
+.c2 .c6 {
+  position: absolute;
+  right: 8px;
+  top: 2px;
+  font-size: 16px;
+}
+
+.c2 .c20 {
+  margin-top: 4px;
+}
+
+.c13 {
   box-sizing: border-box;
   width: 40px;
   height: 40px;
@@ -300,11 +381,11 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   background-color: hsla(353,84%,44%,0.3);
 }
 
-.c12 .c13 {
+.c13 .c14 {
   padding-bottom: 4px;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -327,37 +408,19 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   font-size: 24px;
 }
 
-.c16::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus {
+.c17:focus {
   background-color: hsla(200,96%,35%,0.3);
 }
 
-.c16:hover {
+.c17:hover {
   color: hsl(200,96%,35%);
 }
 
-.c20 {
-  padding: 2px 4px;
-  position: relative;
-  box-sizing: border-box;
-  overflow-wrap: break-word;
-  display: inline-block;
-  font-size: 15px;
-  line-height: 1.6;
-  background-color: hsla(353,84%,44%,0.3);
-}
-
-.c20 .c13,
-.c20 .sc-fzqOul,
-.c20 .sc-oTbqq {
-  margin-right: 4px;
-  vertical-align: -2px;
-}
-
-.c23 {
+.c24 {
   font-size: 18px;
   line-height: 1.5;
   position: relative;
@@ -372,12 +435,12 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   color: hsl(200,96%,35%);
 }
 
-.c23:hover {
+.c24:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c23:focus::after {
+.c24:focus::after {
   content: '';
   display: block;
   box-sizing: border-box;
@@ -390,17 +453,17 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   border-radius: 20px;
 }
 
-.c23::-moz-focus-inner {
+.c24::-moz-focus-inner {
   border: 0;
 }
 
-.c23 svg {
+.c24 svg {
   display: inline-block;
   margin-top: -4px;
   margin-right: 4px;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   width: 100%;
   min-height: 36px;
@@ -424,52 +487,52 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   background-color: hsla(353,84%,44%,0.3);
 }
 
-.c10 span {
+.c11 span {
   margin-left: 8px;
   margin-right: 8px;
   font-size: 18px;
   line-height: 1.5;
 }
 
-.c10 .c11 {
+.c11 .c12 {
   height: 24px;
   width: 24px;
 }
 
-.c10 .c11 .c13 {
+.c11 .c12 .c14 {
   height: 16px;
   width: 16px;
 }
 
-.c10 .c11 .sc-oTbqq {
+.c11 .c12 .sc-paXsP {
   height: 18px;
   width: 18px;
 }
 
-.c10 .sc-pBolk {
+.c11 .sc-pjstK {
   height: 12px;
   width: 12px;
 }
 
-.c10 .c15 {
+.c11 .c16 {
   margin-left: auto;
 }
 
-.c10 .c17 {
+.c11 .c18 {
   height: 12px;
   width: 12px;
 }
 
-.c9 {
+.c10 {
   width: 100%;
 }
 
-.c9 .c19 {
+.c10 .c20 {
   position: relative;
   margin-top: 4px;
 }
 
-.c8 {
+.c9 {
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
@@ -491,13 +554,13 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   align-items: center;
 }
 
-.c8.empty .c22 {
+.c9.empty .c23 {
   position: absolute;
   left: 35%;
   bottom: 15%;
 }
 
-.c8.notEmpty {
+.c9.notEmpty {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -505,43 +568,27 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   padding: 0 8px;
 }
 
-.c8.notEmpty .c22 {
+.c9.notEmpty .c23 {
   position: relative;
   margin: 16px 0 16px 0;
 }
 
-.c8 input {
+.c9 input {
   display: none;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(200,10%,20%);
-}
-
-.c7 {
-  outline: none;
-  color: hsl(200,10%,20%);
-}
-
-.c7:hover {
-  color: hsl(200,96%,35%);
-}
-
-.c2 {
+.c3 {
   position: relative;
 }
 
-.c2 .c3 {
+.c3 .c4 {
   display: block;
   position: relative;
   bottom: 4px;
   padding-left: 16px;
 }
 
-.c2 .c5 {
+.c3 .c6 {
   position: absolute;
   top: -2px;
   right: 8px;
@@ -549,28 +596,28 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 }
 
 @media screen and (min-width:1024px) {
-  .c20 {
+  .c5 {
+    font-size: 18px;
+    line-height: 1.5;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c21 {
     font-size: 15px;
     line-height: 1.6;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c23 {
+  .c24 {
     font-size: 18px;
     line-height: 1.5;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c10 span {
-    font-size: 18px;
-    line-height: 1.5;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c4 {
+  .c11 span {
     font-size: 18px;
     line-height: 1.5;
   }
@@ -578,20 +625,21 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 
 <div>
   <div
-    class="c0 c1 c2"
+    class="c0 c1 c2 c3"
   >
     <label
-      class="c3 c4"
+      class="c4 c5"
       for="consistent"
+      id="consistent-label"
     >
       Just Boolin
     </label>
     <span
-      class="c5 "
+      class="c6 "
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6 c7"
+        class="c7 c8"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -610,7 +658,8 @@ exports[`component: FileInputField should render a file with an error 1`] = `
       upload something
     </span>
     <div
-      class="c8 notEmpty"
+      aria-labelledby="consistent-label"
+      class="c9 notEmpty"
     >
       <input
         accept=".txt"
@@ -618,19 +667,19 @@ exports[`component: FileInputField should render a file with an error 1`] = `
         type="file"
       />
       <div
-        class="c9"
+        class="c10"
       >
         <div
           aria-disabled="false"
           aria-label="boolest.txt, Get it together, man"
-          class="c10"
+          class="c11"
           tabindex="0"
         >
           <div
-            class="c11 c12"
+            class="c12 c13"
           >
             <svg
-              class="c13 c14"
+              class="c14 c15"
               fill="currentcolor"
               height="1em"
               viewBox="0 0 24 24"
@@ -646,12 +695,12 @@ exports[`component: FileInputField should render a file with an error 1`] = `
           </span>
           <button
             aria-label="Delete File"
-            class="c15 c16"
+            class="c16 c17"
             type="button"
             variant="standard"
           >
             <svg
-              class="c17 c18"
+              class="c18 c19"
               fill="currentcolor"
               height="1em"
               viewBox="0 0 24 24"
@@ -664,12 +713,12 @@ exports[`component: FileInputField should render a file with an error 1`] = `
           </button>
         </div>
         <div
-          class="c19 c20"
+          class="c20 c21"
           role="alert"
         >
           <svg
             aria-hidden="true"
-            class="c13 c21"
+            class="c14 c22"
             fill="currentcolor"
             height="1em"
             viewBox="0 0 24 24"
@@ -685,13 +734,13 @@ exports[`component: FileInputField should render a file with an error 1`] = `
         </div>
       </div>
       <button
-        aria-describedby="consistent-tip"
-        class="c22 c23"
+        aria-describedby="consistent-tip consistent-status"
+        class="c23 c24"
         id="consistent"
         type="button"
       >
         <svg
-          class="c24"
+          class="c25"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"
@@ -713,25 +762,63 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   margin-top: 16px;
 }
 
-.c21 {
+.c5 {
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(200,10%,20%);
+}
+
+.c22 {
   font-size: 16px;
   vertical-align: middle;
 }
 
-.c18 {
+.c19 {
   vertical-align: middle;
 }
 
-.c6 {
+.c7 {
   vertical-align: middle;
 }
 
-.c14 {
+.c15 {
   font-size: 24px;
   vertical-align: middle;
 }
 
-.c12 {
+.c8 {
+  outline: none;
+  color: hsl(200,10%,20%);
+}
+
+.c8:hover {
+  color: hsl(200,96%,35%);
+}
+
+.c2 {
+  position: relative;
+}
+
+.c2 .c4 {
+  display: block;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 28px;
+}
+
+.c2 .c6 {
+  position: absolute;
+  right: 8px;
+  top: 2px;
+  font-size: 16px;
+}
+
+.c2 .sc-qYSYK {
+  margin-top: 4px;
+}
+
+.c13 {
   box-sizing: border-box;
   width: 40px;
   height: 40px;
@@ -752,11 +839,11 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c12 .sc-fzoCCn {
+.c13 .sc-fzoPby {
   padding-bottom: 4px;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -779,19 +866,19 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   font-size: 24px;
 }
 
-.c16::-moz-focus-inner {
+.c17::-moz-focus-inner {
   border: 0;
 }
 
-.c16:focus {
+.c17:focus {
   background-color: hsla(200,96%,35%,0.3);
 }
 
-.c16:hover {
+.c17:hover {
   color: hsl(200,96%,35%);
 }
 
-.c20 {
+.c21 {
   font-size: 18px;
   line-height: 1.5;
   position: relative;
@@ -806,12 +893,12 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   color: hsl(200,96%,35%);
 }
 
-.c20:hover {
+.c21:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c20:focus::after {
+.c21:focus::after {
   content: '';
   display: block;
   box-sizing: border-box;
@@ -824,17 +911,17 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   border-radius: 20px;
 }
 
-.c20::-moz-focus-inner {
+.c21::-moz-focus-inner {
   border: 0;
 }
 
-.c20 svg {
+.c21 svg {
   display: inline-block;
   margin-top: -4px;
   margin-right: 4px;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   width: 100%;
   min-height: 36px;
@@ -858,52 +945,52 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c10 span {
+.c11 span {
   margin-left: 8px;
   margin-right: 8px;
   font-size: 18px;
   line-height: 1.5;
 }
 
-.c10 .c11 {
+.c11 .c12 {
   height: 24px;
   width: 24px;
 }
 
-.c10 .c11 .sc-fzoCCn {
+.c11 .c12 .sc-fzoPby {
   height: 16px;
   width: 16px;
 }
 
-.c10 .c11 .c13 {
+.c11 .c12 .c14 {
   height: 18px;
   width: 18px;
 }
 
-.c10 .sc-pBolk {
+.c11 .sc-pjstK {
   height: 12px;
   width: 12px;
 }
 
-.c10 .c15 {
+.c11 .c16 {
   margin-left: auto;
 }
 
-.c10 .c17 {
+.c11 .c18 {
   height: 12px;
   width: 12px;
 }
 
-.c9 {
+.c10 {
   width: 100%;
 }
 
-.c9 .sc-pJkiN {
+.c10 .sc-qYSYK {
   position: relative;
   margin-top: 4px;
 }
 
-.c8 {
+.c9 {
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
@@ -925,13 +1012,13 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   align-items: center;
 }
 
-.c8.empty .c19 {
+.c9.empty .c20 {
   position: absolute;
   left: 35%;
   bottom: 15%;
 }
 
-.c8.notEmpty {
+.c9.notEmpty {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -939,43 +1026,27 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   padding: 0 8px;
 }
 
-.c8.notEmpty .c19 {
+.c9.notEmpty .c20 {
   position: relative;
   margin: 16px 0 16px 0;
 }
 
-.c8 input {
+.c9 input {
   display: none;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(200,10%,20%);
-}
-
-.c7 {
-  outline: none;
-  color: hsl(200,10%,20%);
-}
-
-.c7:hover {
-  color: hsl(200,96%,35%);
-}
-
-.c2 {
+.c3 {
   position: relative;
 }
 
-.c2 .c3 {
+.c3 .c4 {
   display: block;
   position: relative;
   bottom: 4px;
   padding-left: 16px;
 }
 
-.c2 .c5 {
+.c3 .c6 {
   position: absolute;
   top: -2px;
   right: 8px;
@@ -983,21 +1054,21 @@ exports[`component: FileInputField should render a loaded file 1`] = `
 }
 
 @media screen and (min-width:1024px) {
-  .c20 {
+  .c5 {
     font-size: 18px;
     line-height: 1.5;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c10 span {
+  .c21 {
     font-size: 18px;
     line-height: 1.5;
   }
 }
 
 @media screen and (min-width:1024px) {
-  .c4 {
+  .c11 span {
     font-size: 18px;
     line-height: 1.5;
   }
@@ -1005,20 +1076,21 @@ exports[`component: FileInputField should render a loaded file 1`] = `
 
 <div>
   <div
-    class="c0 c1 c2"
+    class="c0 c1 c2 c3"
   >
     <label
-      class="c3 c4"
+      class="c4 c5"
       for="consistent"
+      id="consistent-label"
     >
       Just Boolin
     </label>
     <span
-      class="c5 "
+      class="c6 "
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6 c7"
+        class="c7 c8"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -1037,7 +1109,8 @@ exports[`component: FileInputField should render a loaded file 1`] = `
       upload something
     </span>
     <div
-      class="c8 notEmpty"
+      aria-labelledby="consistent-label"
+      class="c9 notEmpty"
     >
       <input
         accept=".txt"
@@ -1045,19 +1118,19 @@ exports[`component: FileInputField should render a loaded file 1`] = `
         type="file"
       />
       <div
-        class="c9"
+        class="c10"
       >
         <div
           aria-disabled="false"
           aria-label="boolest.txt, Successful"
-          class="c10"
+          class="c11"
           tabindex="0"
         >
           <div
-            class="c11 c12"
+            class="c12 c13"
           >
             <svg
-              class="c13 c14"
+              class="c14 c15"
               fill="currentcolor"
               height="1em"
               viewBox="0 0 24 24"
@@ -1073,12 +1146,12 @@ exports[`component: FileInputField should render a loaded file 1`] = `
           </span>
           <button
             aria-label="Delete File"
-            class="c15 c16"
+            class="c16 c17"
             type="button"
             variant="standard"
           >
             <svg
-              class="c17 c18"
+              class="c18 c19"
               fill="currentcolor"
               height="1em"
               viewBox="0 0 24 24"
@@ -1092,13 +1165,13 @@ exports[`component: FileInputField should render a loaded file 1`] = `
         </div>
       </div>
       <button
-        aria-describedby="consistent-tip"
-        class="c19 c20"
+        aria-describedby="consistent-tip consistent-status"
+        class="c20 c21"
         id="consistent"
         type="button"
       >
         <svg
-          class="c21"
+          class="c22"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"
@@ -1120,20 +1193,403 @@ exports[`component: FileInputField should render a loading file 1`] = `
   margin-top: 16px;
 }
 
+.c5 {
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(200,10%,20%);
+}
+
+.c16 {
+  font-size: 16px;
+  vertical-align: middle;
+}
+
+.c7 {
+  vertical-align: middle;
+}
+
+.c8 {
+  outline: none;
+  color: hsl(200,10%,20%);
+}
+
+.c8:hover {
+  color: hsl(200,96%,35%);
+}
+
+.c2 {
+  position: relative;
+}
+
+.c2 .c4 {
+  display: block;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 28px;
+}
+
+.c2 .c6 {
+  position: absolute;
+  right: 8px;
+  top: 2px;
+  font-size: 16px;
+}
+
+.c2 .sc-qYSYK {
+  margin-top: 4px;
+}
+
+.c13 {
+  vertical-align: middle;
+  font-size: 40px;
+  -webkit-animation: bKPVWD 0.75s linear infinite;
+  animation: bKPVWD 0.75s linear infinite;
+}
+
+.c15 {
+  font-size: 18px;
+  line-height: 1.5;
+  position: relative;
+  border: none;
+  padding: 4px;
+  outline: none;
+  background-color: transparent;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: pointer;
+  box-sizing: border-box;
+  color: hsl(200,96%,35%);
+}
+
+.c15:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c15:focus::after {
+  content: '';
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  top: 0px;
+  left: 0px;
+  border: 1px solid hsl(200,96%,35%);
+  border-radius: 20px;
+}
+
+.c15::-moz-focus-inner {
+  border: 0;
+}
+
+.c15 svg {
+  display: inline-block;
+  margin-top: -4px;
+  margin-right: 4px;
+}
+
+.c11 {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 36px;
+  margin-top: 8px;
+  padding: 0 8px 0 8px;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: hsl(200,10%,20%);
+  background-color: hsl(200,29%,90%);
+}
+
+.c11 span {
+  margin-left: 8px;
+  margin-right: 8px;
+  font-size: 18px;
+  line-height: 1.5;
+}
+
+.c11 .sc-oTBUA {
+  height: 24px;
+  width: 24px;
+}
+
+.c11 .sc-oTBUA .sc-fzoPby {
+  height: 16px;
+  width: 16px;
+}
+
+.c11 .sc-oTBUA .sc-paXsP {
+  height: 18px;
+  width: 18px;
+}
+
+.c11 .c12 {
+  height: 12px;
+  width: 12px;
+}
+
+.c11 .sc-pbxSd {
+  margin-left: auto;
+}
+
+.c11 .sc-fzoWqW {
+  height: 12px;
+  width: 12px;
+}
+
+.c10 {
+  width: 100%;
+}
+
+.c10 .sc-qYSYK {
+  position: relative;
+  margin-top: 4px;
+}
+
+.c9 {
+  box-sizing: border-box;
+  border-radius: 8px;
+  border: 2px dotted;
+  border-color: hsl(200,10%,20%);
+  min-width: 300px;
+  min-height: 100px;
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9.empty .c14 {
+  position: absolute;
+  left: 35%;
+  bottom: 15%;
+}
+
+.c9.notEmpty {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-color: hsl(200,96%,35%);
+  padding: 0 8px;
+}
+
+.c9.notEmpty .c14 {
+  position: relative;
+  margin: 16px 0 16px 0;
+}
+
+.c9 input {
+  display: none;
+}
+
+.c3 {
+  position: relative;
+}
+
+.c3 .c4 {
+  display: block;
+  position: relative;
+  bottom: 4px;
+  padding-left: 16px;
+}
+
+.c3 .c6 {
+  position: absolute;
+  top: -2px;
+  right: 8px;
+  font-size: 16px;
+}
+
+@media screen and (min-width:1024px) {
+  .c5 {
+    font-size: 18px;
+    line-height: 1.5;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c15 {
+    font-size: 18px;
+    line-height: 1.5;
+  }
+}
+
+@media screen and (min-width:1024px) {
+  .c11 span {
+    font-size: 18px;
+    line-height: 1.5;
+  }
+}
+
+<div>
+  <div
+    class="c0 c1 c2 c3"
+  >
+    <label
+      class="c4 c5"
+      for="consistent"
+      id="consistent-label"
+    >
+      Just Boolin
+    </label>
+    <span
+      class="c6 "
+      data-reach-tooltip-trigger=""
+    >
+      <svg
+        class="c7 c8"
+        fill="currentcolor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M22,12 C22,6.47714622 17.5223159,2 12,2 C6.47523326,2 2,6.47577095 2,12 C2,17.524229 6.47523326,22 12,22 C17.5223159,22 22,17.5228538 22,12 Z M24,12 C24,18.6274771 18.6268316,24 12,24 C5.37060996,24 0,18.6287448 0,12 C0,5.37125524 5.37060996,0 12,0 C18.6268316,0 24,5.37252293 24,12 Z M11.057,15.6442233 L11.057,12.5 L9.27493729,12.5 C8.72265254,12.5 8.27493729,12.0522847 8.27493729,11.5 C8.27493729,10.9477153 8.72265254,10.5 9.27493729,10.5 L12.057,10.5 C12.6092847,10.5 13.057,10.9477153 13.057,11.5 L13.057,15.6442233 L15.0505322,15.6442233 C15.602817,15.6442233 16.0505322,16.0919386 16.0505322,16.6442233 C16.0505322,17.1965081 15.602817,17.6442233 15.0505322,17.6442233 L9,17.6442233 C8.44771525,17.6442233 8,17.1965081 8,16.6442233 C8,16.0919386 8.44771525,15.6442233 9,15.6442233 L11.057,15.6442233 Z M11.5,9 C10.6715729,9 10,8.32842712 10,7.5 C10,6.67157288 10.6715729,6 11.5,6 C12.3284271,6 13,6.67157288 13,7.5 C13,8.32842712 12.3284271,9 11.5,9 Z"
+        />
+      </svg>
+    </span>
+    <span
+      id="consistent-tip"
+      role="tooltip"
+      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
+    >
+      upload something
+    </span>
+    <div
+      aria-labelledby="consistent-label"
+      class="c9 notEmpty"
+    >
+      <input
+        accept=".txt"
+        name="bears"
+        type="file"
+      />
+      <div
+        class="c10"
+      >
+        <div
+          aria-disabled="false"
+          aria-label="boolest.txt, Loading"
+          class="c11"
+          tabindex="0"
+        >
+          <span>
+            boolest.txt
+          </span>
+          <svg
+            class="sc-pJurq c12 c13"
+            fill="currentcolor"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+          >
+            <path
+              d="M12,0 C5.372583,0 0,5.372583 0,12 C0,18.627417 5.372583,24 12,24 C18.627417,24 24,18.627417 24,12 C24,11.4477153 23.5522847,11 23,11 C22.4477153,11 22,11.4477153 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 C12.5522847,2 13,1.55228475 13,1 C13,0.44771525 12.5522847,0 12,0 Z"
+              transform="rotate(-177 12 12)"
+            />
+          </svg>
+        </div>
+      </div>
+      <button
+        aria-describedby="consistent-tip consistent-status"
+        class="c14 c15"
+        id="consistent"
+        type="button"
+      >
+        <svg
+          class="c16"
+          fill="currentcolor"
+          height="1em"
+          viewBox="0 0 24 24"
+          width="1em"
+        >
+          <path
+            d="M3,9 L3,2 C3,1.44771525 3.44771525,1 4,1 L8.86956522,1 C9.13300396,1 9.38580138,1.10395302 9.57303415,1.28927399 L10.6720803,2.37709802 L20,2.37709802 C20.5522847,2.37709802 21,2.82481327 21,3.37709802 L21,9 L22,9 C22.6077887,9 23.0750324,9.5377097 22.9902149,10.1395511 L21.2857687,22.2338171 C21.2162209,22.7273084 20.7939217,23.094266 20.2955538,23.094266 L3.92354726,23.094266 C3.43189906,23.094266 3.01318427,22.7368835 2.9359601,22.251338 L1.01241285,10.157072 C0.915823617,9.5497691 1.38506399,9 2,9 L3,9 Z M4,11 L3.17161508,11 L4.7770699,21.094266 L19.4266021,21.094266 L20.8491881,11 L20,11 L4,11 Z M19,9 L19,4.37709802 L10.2608696,4.37709802 C9.99743082,4.37709802 9.7446334,4.27314501 9.55740063,4.08782403 L8.45835446,3 L5,3 L5,9 L19,9 Z"
+          />
+        </svg>
+        Select Files...
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`component: FileInputField should render file input field 1`] = `
+.c1 + .c0 {
+  margin-top: 16px;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(200,10%,20%);
+}
+
+.c12 {
+  font-size: 40px;
+  vertical-align: middle;
+}
+
 .c15 {
   font-size: 16px;
   vertical-align: middle;
 }
 
-.c6 {
+.c7 {
   vertical-align: middle;
 }
 
-.c12 {
-  vertical-align: middle;
-  font-size: 40px;
-  -webkit-animation: bKPVWD 0.75s linear infinite;
-  animation: bKPVWD 0.75s linear infinite;
+.c8 {
+  outline: none;
+  color: hsl(200,10%,20%);
+}
+
+.c8:hover {
+  color: hsl(200,96%,35%);
+}
+
+.c2 {
+  position: relative;
+}
+
+.c2 .c4 {
+  display: block;
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 28px;
+}
+
+.c2 .c6 {
+  position: absolute;
+  right: 8px;
+  top: 2px;
+  font-size: 16px;
+}
+
+.c2 .sc-qYSYK {
+  margin-top: 4px;
 }
 
 .c14 {
@@ -1180,74 +1636,25 @@ exports[`component: FileInputField should render a loading file 1`] = `
 }
 
 .c10 {
-  box-sizing: border-box;
-  width: 100%;
-  min-height: 36px;
-  margin-top: 8px;
-  padding: 0 8px 0 8px;
-  border-radius: 4px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: hsl(200,10%,20%);
-  background-color: hsl(200,29%,90%);
-}
-
-.c10 span {
-  margin-left: 8px;
-  margin-right: 8px;
-  font-size: 18px;
-  line-height: 1.5;
-}
-
-.c10 .sc-qQxXP {
-  height: 24px;
-  width: 24px;
-}
-
-.c10 .sc-qQxXP .sc-fzoCCn {
-  height: 16px;
-  width: 16px;
-}
-
-.c10 .sc-qQxXP .sc-oTbqq {
-  height: 18px;
-  width: 18px;
+  width: 300px;
+  height: 100px;
 }
 
 .c10 .c11 {
-  height: 12px;
-  width: 12px;
+  position: absolute;
+  top: 30%;
+  left: 15%;
+  color: hsl(200,96%,35%);
 }
 
-.c10 .sc-qYSYK {
-  margin-left: auto;
-}
-
-.c10 .sc-fzoMdx {
-  height: 12px;
-  width: 12px;
+.c10 span {
+  position: absolute;
+  top: 20%;
+  left: 37%;
+  color: hsl(200,18%,45%);
 }
 
 .c9 {
-  width: 100%;
-}
-
-.c9 .sc-pJkiN {
-  position: relative;
-  margin-top: 4px;
-}
-
-.c8 {
   box-sizing: border-box;
   border-radius: 8px;
   border: 2px dotted;
@@ -1269,13 +1676,13 @@ exports[`component: FileInputField should render a loading file 1`] = `
   align-items: center;
 }
 
-.c8.empty .c13 {
+.c9.empty .c13 {
   position: absolute;
   left: 35%;
   bottom: 15%;
 }
 
-.c8.notEmpty {
+.c9.notEmpty {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
@@ -1283,47 +1690,38 @@ exports[`component: FileInputField should render a loading file 1`] = `
   padding: 0 8px;
 }
 
-.c8.notEmpty .c13 {
+.c9.notEmpty .c13 {
   position: relative;
   margin: 16px 0 16px 0;
 }
 
-.c8 input {
+.c9 input {
   display: none;
 }
 
-.c4 {
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(200,10%,20%);
-}
-
-.c7 {
-  outline: none;
-  color: hsl(200,10%,20%);
-}
-
-.c7:hover {
-  color: hsl(200,96%,35%);
-}
-
-.c2 {
+.c3 {
   position: relative;
 }
 
-.c2 .c3 {
+.c3 .c4 {
   display: block;
   position: relative;
   bottom: 4px;
   padding-left: 16px;
 }
 
-.c2 .c5 {
+.c3 .c6 {
   position: absolute;
   top: -2px;
   right: 8px;
   font-size: 16px;
+}
+
+@media screen and (min-width:1024px) {
+  .c5 {
+    font-size: 18px;
+    line-height: 1.5;
+  }
 }
 
 @media screen and (min-width:1024px) {
@@ -1333,36 +1731,23 @@ exports[`component: FileInputField should render a loading file 1`] = `
   }
 }
 
-@media screen and (min-width:1024px) {
-  .c10 span {
-    font-size: 18px;
-    line-height: 1.5;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c4 {
-    font-size: 18px;
-    line-height: 1.5;
-  }
-}
-
 <div>
   <div
-    class="c0 c1 c2"
+    class="c0 c1 c2 c3"
   >
     <label
-      class="c3 c4"
+      class="c4 c5"
       for="consistent"
+      id="consistent-label"
     >
       Just Boolin
     </label>
     <span
-      class="c5 "
+      class="c6 "
       data-reach-tooltip-trigger=""
     >
       <svg
-        class="c6 c7"
+        class="c7 c8"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -1381,7 +1766,8 @@ exports[`component: FileInputField should render a loading file 1`] = `
       upload something
     </span>
     <div
-      class="c8 notEmpty"
+      aria-labelledby="consistent-label"
+      class="c9 empty"
     >
       <input
         accept=".txt"
@@ -1389,275 +1775,10 @@ exports[`component: FileInputField should render a loading file 1`] = `
         type="file"
       />
       <div
-        class="c9"
-      >
-        <div
-          aria-disabled="false"
-          aria-label="boolest.txt, Loading"
-          class="c10"
-          tabindex="0"
-        >
-          <span>
-            boolest.txt
-          </span>
-          <svg
-            class="sc-pAZqv c11 c12"
-            fill="currentcolor"
-            height="1em"
-            viewBox="0 0 24 24"
-            width="1em"
-          >
-            <path
-              d="M12,0 C5.372583,0 0,5.372583 0,12 C0,18.627417 5.372583,24 12,24 C18.627417,24 24,18.627417 24,12 C24,11.4477153 23.5522847,11 23,11 C22.4477153,11 22,11.4477153 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 C12.5522847,2 13,1.55228475 13,1 C13,0.44771525 12.5522847,0 12,0 Z"
-              transform="rotate(-177 12 12)"
-            />
-          </svg>
-        </div>
-      </div>
-      <button
-        aria-describedby="consistent-tip"
-        class="c13 c14"
-        id="consistent"
-        type="button"
+        class="c10"
       >
         <svg
-          class="c15"
-          fill="currentcolor"
-          height="1em"
-          viewBox="0 0 24 24"
-          width="1em"
-        >
-          <path
-            d="M3,9 L3,2 C3,1.44771525 3.44771525,1 4,1 L8.86956522,1 C9.13300396,1 9.38580138,1.10395302 9.57303415,1.28927399 L10.6720803,2.37709802 L20,2.37709802 C20.5522847,2.37709802 21,2.82481327 21,3.37709802 L21,9 L22,9 C22.6077887,9 23.0750324,9.5377097 22.9902149,10.1395511 L21.2857687,22.2338171 C21.2162209,22.7273084 20.7939217,23.094266 20.2955538,23.094266 L3.92354726,23.094266 C3.43189906,23.094266 3.01318427,22.7368835 2.9359601,22.251338 L1.01241285,10.157072 C0.915823617,9.5497691 1.38506399,9 2,9 L3,9 Z M4,11 L3.17161508,11 L4.7770699,21.094266 L19.4266021,21.094266 L20.8491881,11 L20,11 L4,11 Z M19,9 L19,4.37709802 L10.2608696,4.37709802 C9.99743082,4.37709802 9.7446334,4.27314501 9.55740063,4.08782403 L8.45835446,3 L5,3 L5,9 L19,9 Z"
-          />
-        </svg>
-        Select Files...
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`component: FileInputField should render file input field 1`] = `
-.c1 + .c0 {
-  margin-top: 16px;
-}
-
-.c11 {
-  font-size: 40px;
-  vertical-align: middle;
-}
-
-.c14 {
-  font-size: 16px;
-  vertical-align: middle;
-}
-
-.c6 {
-  vertical-align: middle;
-}
-
-.c13 {
-  font-size: 18px;
-  line-height: 1.5;
-  position: relative;
-  border: none;
-  padding: 4px;
-  outline: none;
-  background-color: transparent;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  cursor: pointer;
-  box-sizing: border-box;
-  color: hsl(200,96%,35%);
-}
-
-.c13:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c13:focus::after {
-  content: '';
-  display: block;
-  box-sizing: border-box;
-  position: absolute;
-  height: 100%;
-  width: 100%;
-  top: 0px;
-  left: 0px;
-  border: 1px solid hsl(200,96%,35%);
-  border-radius: 20px;
-}
-
-.c13::-moz-focus-inner {
-  border: 0;
-}
-
-.c13 svg {
-  display: inline-block;
-  margin-top: -4px;
-  margin-right: 4px;
-}
-
-.c9 {
-  width: 300px;
-  height: 100px;
-}
-
-.c9 .c10 {
-  position: absolute;
-  top: 30%;
-  left: 15%;
-  color: hsl(200,96%,35%);
-}
-
-.c9 span {
-  position: absolute;
-  top: 20%;
-  left: 37%;
-  color: hsl(200,18%,45%);
-}
-
-.c8 {
-  box-sizing: border-box;
-  border-radius: 8px;
-  border: 2px dotted;
-  border-color: hsl(200,10%,20%);
-  min-width: 300px;
-  min-height: 100px;
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8.empty .c12 {
-  position: absolute;
-  left: 35%;
-  bottom: 15%;
-}
-
-.c8.notEmpty {
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  border-color: hsl(200,96%,35%);
-  padding: 0 8px;
-}
-
-.c8.notEmpty .c12 {
-  position: relative;
-  margin: 16px 0 16px 0;
-}
-
-.c8 input {
-  display: none;
-}
-
-.c4 {
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(200,10%,20%);
-}
-
-.c7 {
-  outline: none;
-  color: hsl(200,10%,20%);
-}
-
-.c7:hover {
-  color: hsl(200,96%,35%);
-}
-
-.c2 {
-  position: relative;
-}
-
-.c2 .c3 {
-  display: block;
-  position: relative;
-  bottom: 4px;
-  padding-left: 16px;
-}
-
-.c2 .c5 {
-  position: absolute;
-  top: -2px;
-  right: 8px;
-  font-size: 16px;
-}
-
-@media screen and (min-width:1024px) {
-  .c13 {
-    font-size: 18px;
-    line-height: 1.5;
-  }
-}
-
-@media screen and (min-width:1024px) {
-  .c4 {
-    font-size: 18px;
-    line-height: 1.5;
-  }
-}
-
-<div>
-  <div
-    class="c0 c1 c2"
-  >
-    <label
-      class="c3 c4"
-      for="consistent"
-    >
-      Just Boolin
-    </label>
-    <span
-      class="c5 "
-      data-reach-tooltip-trigger=""
-    >
-      <svg
-        class="c6 c7"
-        fill="currentcolor"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-      >
-        <path
-          d="M22,12 C22,6.47714622 17.5223159,2 12,2 C6.47523326,2 2,6.47577095 2,12 C2,17.524229 6.47523326,22 12,22 C17.5223159,22 22,17.5228538 22,12 Z M24,12 C24,18.6274771 18.6268316,24 12,24 C5.37060996,24 0,18.6287448 0,12 C0,5.37125524 5.37060996,0 12,0 C18.6268316,0 24,5.37252293 24,12 Z M11.057,15.6442233 L11.057,12.5 L9.27493729,12.5 C8.72265254,12.5 8.27493729,12.0522847 8.27493729,11.5 C8.27493729,10.9477153 8.72265254,10.5 9.27493729,10.5 L12.057,10.5 C12.6092847,10.5 13.057,10.9477153 13.057,11.5 L13.057,15.6442233 L15.0505322,15.6442233 C15.602817,15.6442233 16.0505322,16.0919386 16.0505322,16.6442233 C16.0505322,17.1965081 15.602817,17.6442233 15.0505322,17.6442233 L9,17.6442233 C8.44771525,17.6442233 8,17.1965081 8,16.6442233 C8,16.0919386 8.44771525,15.6442233 9,15.6442233 L11.057,15.6442233 Z M11.5,9 C10.6715729,9 10,8.32842712 10,7.5 C10,6.67157288 10.6715729,6 11.5,6 C12.3284271,6 13,6.67157288 13,7.5 C13,8.32842712 12.3284271,9 11.5,9 Z"
-        />
-      </svg>
-    </span>
-    <span
-      id="consistent-tip"
-      role="tooltip"
-      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap; word-wrap: normal;"
-    >
-      upload something
-    </span>
-    <div
-      class="c8 empty"
-    >
-      <input
-        accept=".txt"
-        name="bears"
-        type="file"
-      />
-      <div
-        class="c9"
-      >
-        <svg
-          class="c10 c11"
+          class="c11 c12"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"
@@ -1672,13 +1793,13 @@ exports[`component: FileInputField should render file input field 1`] = `
         </span>
       </div>
       <button
-        aria-describedby="consistent-tip"
-        class="c12 c13"
+        aria-describedby="consistent-tip consistent-status"
+        class="c13 c14"
         id="consistent"
         type="button"
       >
         <svg
-          class="c14"
+          class="c15"
           fill="currentcolor"
           height="1em"
           viewBox="0 0 24 24"

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
@@ -22,6 +22,7 @@ radioGroupStories.add(
       error={text('error', '')}
       success={text('success', '')}
       warning={text('warning', '')}
+      autoTooltip={boolean('autoTooltip', true)}
     >
       <RadioGroup.Button label="That's right" value="right" />
       <RadioGroup.Button disabled label="That's wrong" value="left" />

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
@@ -56,6 +56,7 @@ export const RadioGroup = React.forwardRef<HTMLFieldSetElement, RadioGroupProps>
       onChange,
       onFocus,
       onBlur,
+      autoTooltip = true,
       ...props
     },
     ref
@@ -143,7 +144,12 @@ export const RadioGroup = React.forwardRef<HTMLFieldSetElement, RadioGroupProps>
           {children}
         </Box>
         {tooltip && (
-          <Tooltip id={tooltipId} label={tooltip} disabled={disabled} forceVisible={showTooltip} />
+          <Tooltip
+            id={tooltipId}
+            label={tooltip}
+            disabled={disabled}
+            forceVisible={autoTooltip ? showTooltip : false}
+          />
         )}
         {status && (
           <div>

--- a/modules/cactus-web/src/SelectField/SelectField.story.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.story.tsx
@@ -19,6 +19,7 @@ storiesOf('SelectField', module)
         success={text('success', '')}
         warning={text('warning', '')}
         error={text('error', '')}
+        autoTooltip={boolean('autoTooltip', true)}
       />
     ),
     { knobs: { escapeHTML: false } }

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -33,6 +33,7 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
     error,
     width,
     disabled,
+    autoTooltip,
     ...rest
   } = omitMargins(props) as Omit<SelectFieldProps, keyof MarginProps>
 
@@ -49,6 +50,7 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
       warning={warning}
       error={error}
       width={width}
+      autoTooltip={autoTooltip}
     >
       {({ fieldId, labelId, name, ariaDescribedBy, status, disabled }): React.ReactElement => (
         <Select

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.story.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.story.tsx
@@ -21,6 +21,7 @@ storiesOf('TextAreaField', module)
         error={text('error', '')}
         tooltip={text('tooltip', 'Some tooltip text')}
         resize={boolean('resize', false)}
+        autoTooltip={boolean('autoTooltip', true)}
         {...eventLoggers}
       />
     )

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -33,6 +33,7 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
     name,
     id,
     disabled,
+    autoTooltip,
     ...textAreaProps
   } = omitMargins(props) as Omit<TextAreaFieldProps, keyof MarginProps>
 
@@ -66,6 +67,7 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
       warning={warning}
       error={error}
       tooltip={tooltip}
+      autoTooltip={autoTooltip}
     >
       {({ fieldId, status, ariaDescribedBy, disabled }): React.ReactElement => (
         <TextArea

--- a/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
@@ -37,6 +37,7 @@ textInputFieldStories
         error={text('error', '')}
         tooltip={text('tooltip', 'Enter some text')}
         name="input-1"
+        autoTooltip={boolean('autoTooltip', true)}
         {...eventLoggers}
       />
     ),

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -33,6 +33,7 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
     onFocus,
     onBlur,
     disabled,
+    autoTooltip,
     ...inputProps
   } = omitMargins(props) as Omit<TextInputFieldProps, keyof MarginProps>
 
@@ -66,6 +67,7 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
       warning={warning}
       error={error}
       tooltip={tooltip}
+      autoTooltip={autoTooltip}
     >
       {({ fieldId, status, ariaDescribedBy, disabled }): React.ReactElement => (
         <TextInput


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-356

Implemented that `autoTooltip` prop and exposed it on all relevant components, like we talked about in Slack.

### Testing
1. Open the `FileInputField` storybook
2. Pass some text in for `success`, `warning`, and `error` and make sure the corresponding status messages are shown.
3. Test out the `autoTooltip` prop on `AccessibleField`, `RadioGroup`, `SelectField`, `TextInputField`, and `TextAreaField`.