### PR TITLE
refactor(cactus-web): add overflow props to Box component

### DIFF
--- a/modules/cactus-web/src/Box/Box.story.tsx
+++ b/modules/cactus-web/src/Box/Box.story.tsx
@@ -1,7 +1,13 @@
 import cactusTheme, { TextStyleCollection } from '@repay/cactus-theme'
 import { object, select, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
-import { PositionProperty, ZIndexProperty } from 'csstype'
+import {
+  OverflowProperty,
+  OverflowXProperty,
+  OverflowYProperty,
+  PositionProperty,
+  ZIndexProperty,
+} from 'csstype'
 import React from 'react'
 
 import Box from './Box'
@@ -66,6 +72,9 @@ storiesOf('Box', module)
         borderStyle={text('borderStyle', 'solid')}
         textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
         zIndex={text('zIndex', '') as ZIndexProperty}
+        overflow={text('overflow', '') as OverflowProperty}
+        overflowX={text('overflowX', '') as OverflowXProperty}
+        overflowY={text('overflowY', '') as OverflowYProperty}
       >
         {text('children', 'Example Content')}
       </Box>

--- a/modules/cactus-web/src/Box/Box.test.tsx
+++ b/modules/cactus-web/src/Box/Box.test.tsx
@@ -38,6 +38,7 @@ describe('component: Box', (): void => {
           borderStyle="solid"
           zIndex={100}
           textStyle="h1"
+          overflow="scroll"
         >
           Content
         </Box>

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -12,6 +12,8 @@ import {
   DisplayProps,
   layout,
   LayoutProps,
+  overflow,
+  OverflowProps,
   position,
   PositionProps,
   space,
@@ -52,7 +54,8 @@ export interface BoxProps
     ColorStyleProps,
     DisplayProps,
     TypographyProps,
-    CustomBorderProps {
+    CustomBorderProps,
+    OverflowProps {
   textStyle?: keyof TextStyleCollection
 }
 
@@ -96,7 +99,7 @@ const decideBorderRadius = (props: ThemedStyledProps<BoxProps, DefaultTheme>) =>
 
 export const Box = styled('div')<BoxProps>`
   box-sizing: border-box;
-  ${compose(position, display, layout, space, colorStyle, color, typography, border)}
+  ${compose(position, display, layout, space, colorStyle, color, typography, border, overflow)}
   ${(p) => p.textStyle && textStyle(p.theme, p.textStyle)}
   ${decideBorderRadius}
 `

--- a/modules/cactus-web/src/Box/__snapshots__/Box.test.tsx.snap
+++ b/modules/cactus-web/src/Box/__snapshots__/Box.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`component: Box should accept built-in props 1`] = `
   border-radius: 20px;
   border-style: solid;
   z-index: 100;
+  overflow: scroll;
   font-size: 31.1px;
   line-height: 1.5;
 }
@@ -37,6 +38,7 @@ exports[`component: Box should accept built-in props 1`] = `
     color="white"
     display="block"
     height="120px"
+    overflow="scroll"
     width="120px"
   >
     Content


### PR DESCRIPTION
Test:

- In Storybook, add content to the box that would overflow it's content

- Set the overflow, overflowX or overflowY prop to anything you want, and make sure it works as expected

[CACTUS-360]

[CACTUS-360]: https://repayonline.atlassian.net/browse/CACTUS-360