### PR TITLE
Decouple Sidebar from Layout

### DIFF
--- a/modules/cactus-web/src/ActionBar/ActionBar.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-import { Sidebar } from '../Layout/Layout'
+import { Sidebar } from '../Layout/Sidebar'
 import { OrderHint, OrderHintKey, useAction, useActionBarItems } from './ActionProvider'
 
 interface ItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {

--- a/modules/cactus-web/src/ActionBar/__snapshots__/ActionBar.test.tsx.snap
+++ b/modules/cactus-web/src/ActionBar/__snapshots__/ActionBar.test.tsx.snap
@@ -56,11 +56,11 @@ exports[`component: ActionBar typechecks 1`] = `
   color: hsl(200,96%,35%);
 }
 
-.c2.c2.c2:focus {
+.c2.c2.c2.c2:focus {
   box-shadow: inset 0px 0px 0px 1px hsl(200,96%,35%);
 }
 
-.c2.c2.c2[aria-expanded='true'] {
+.c2.c2.c2.c2[aria-expanded='true'] {
   background-color: hsl(200,96%,35%);
   color: hsl(0,0%,100%);
   box-shadow: none;
@@ -74,29 +74,60 @@ exports[`component: ActionBar typechecks 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 0px;
-  height: auto;
-  box-shadow: inset -1px 0px 0px 0px hsl(200,29%,90%);
 }
 
 .c0:empty {
   display: none;
 }
 
-.c0 .c1 {
+.c0.cactus-layout-floatLeft,
+.c0.cactus-layout-fixedLeft {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-shadow: inset -1px 0px 0px 0px hsl(200,29%,90%);
+}
+
+.c0.cactus-layout-floatLeft .c1,
+.c0.cactus-layout-fixedLeft .c1 {
   box-shadow: inset 0px -1px 0px 0px hsl(200,29%,90%);
 }
 
-.c0 .c1:hover {
+.c0.cactus-layout-floatLeft .c1:hover,
+.c0.cactus-layout-fixedLeft .c1:hover {
   box-shadow: inset 0px -1px 0px 0px hsl(200,96%,35%);
+}
+
+.c0.cactus-layout-fixedBottom {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-shadow: inset 0px 1px 0px 0px hsl(200,29%,90%);
+}
+
+.c0.cactus-layout-fixedBottom .c1 {
+  box-shadow: inset -1px 0px 0px 0px hsl(200,29%,90%);
+}
+
+.c0.cactus-layout-fixedBottom .c1:hover {
+  box-shadow: inset -1px 0px 0px 0px hsl(200,96%,35%);
+}
+
+.c0.cactus-layout-fixedBottom .c1[aria-expanded='true']::after {
+  content: '';
+  z-index: 99;
+  background-color: rgba(0,0,0,0.5);
+  position: fixed;
+  top: 0;
+  bottom: 60px;
+  left: 0;
+  right: 0;
+  cursor: default;
 }
 
 <div>
   <div
-    class="c0"
+    class="c0 cactus-layout-floatLeft"
   >
     <button
       class="c1 c2"

--- a/modules/cactus-web/src/Footer/Footer.tsx
+++ b/modules/cactus-web/src/Footer/Footer.tsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types'
 import React, { createContext, useContext, useEffect, useState } from 'react'
-import styled, { DefaultTheme, StyledComponent } from 'styled-components'
+import styled from 'styled-components'
 
 import { useSizeRef } from '../helpers/rect'
-import { boxShadow, media } from '../helpers/theme'
+import { boxShadow } from '../helpers/theme'
 import useId from '../helpers/useId'
 import { useLayout } from '../Layout/Layout'
 import Link from '../Link/Link'
@@ -39,7 +39,7 @@ const LogoAndContentSection = styled('div')`
   align-items: center;
   padding: 16px 24px 16px 24px;
 
-  ${(p) => media(p.theme, 'small')} {
+  .cactus-layout-fixedBottom & {
     flex-direction: row;
     justify-content: flex-start;
   }
@@ -48,7 +48,7 @@ const LogoAndContentSection = styled('div')`
 const LogoWrapper = styled('div')`
   margin-bottom: 16px;
 
-  ${(p) => media(p.theme, 'small')} {
+  .cactus-layout-fixedBottom & {
     margin-right: 16px;
     margin-bottom: 0px;
   }
@@ -66,15 +66,11 @@ const Img = styled('img')`
 const LinksColsContainer = styled('div')`
   max-width: 100%;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: stretch;
   justify-content: center;
   padding: 16px 24px 16px 24px;
   background-color: ${(p) => p.theme.colors.white};
-
-  ${(p) => media(p.theme, 'small')} {
-    flex-direction: row;
-  }
 `
 
 const LinkCol = styled('div')<LinkColProps>`
@@ -89,7 +85,7 @@ const LinkCol = styled('div')<LinkColProps>`
     max-width: 100%;
   }
 
-  ${(p) => media(p.theme, 'small')} {
+  .cactus-layout-fixedBottom & {
     max-width: calc(100% / ${(p) => p.maxCols});
   }
 
@@ -125,7 +121,9 @@ const divideLinks = (links: LinkType[], maxCols: number): LinkType[][] => {
   return divided
 }
 
-const FooterBase = (props: FooterProps) => {
+type FooterType = React.FC<FooterProps> & { Link: React.FC<LinkProps> }
+
+export const Footer: FooterType = (props) => {
   const { logo, className, children } = props
   const [links, setLinks] = useState(new Map<string, LinkType>())
   const screenSize = useContext(ScreenSizeContext)
@@ -143,10 +141,13 @@ const FooterBase = (props: FooterProps) => {
   )
   const sizeRef = useSizeRef<HTMLDivElement>(heightCallback)
   const position = screenSize.size === 'tiny' ? 'flow' : 'fixedBottom'
-  useLayout('footer', { position, offset: footerHeight })
+  let { cssClass } = useLayout('footer', { position, offset: footerHeight })
+  if (className) {
+    cssClass = `${className} ${cssClass}`
+  }
 
   return (
-    <div ref={sizeRef} className={className}>
+    <StyledFooter ref={sizeRef} className={cssClass}>
       <LogoAndContentSection>
         {logo && (
           <LogoWrapper>
@@ -173,7 +174,7 @@ const FooterBase = (props: FooterProps) => {
           ))}
         </LinksColsContainer>
       )}
-    </div>
+    </StyledFooter>
   )
 }
 
@@ -182,7 +183,7 @@ interface LinkProps {
   to: string
 }
 
-export const FooterLink = (props: LinkProps): React.ReactNode => {
+export const FooterLink: React.FC<LinkProps> = (props) => {
   const { children, to } = props
   const { addLink } = useContext(FooterContext)
   const key = useId()
@@ -192,22 +193,19 @@ export const FooterLink = (props: LinkProps): React.ReactNode => {
   return <React.Fragment />
 }
 
-export const Footer = styled(FooterBase)`
+const StyledFooter = styled.footer.attrs({ role: 'contentinfo' as string })`
   display: flex;
   flex-direction: column;
   justify-content: center;
   width: 100%;
   background-color: ${(p) => p.theme.colors.lightContrast};
   ${(p) => boxShadow(p.theme, 1)};
-  ${(p) => media(p.theme, 'small')} {
-    position: fixed;
-    left: 0;
-    bottom: 0;
+  &.cactus-layout-fixedBottom {
+    height: auto;
   }
 `
 
-const DefaultFooter = Footer as any
-DefaultFooter.Link = FooterLink
+Footer.Link = FooterLink
 
 Footer.propTypes = {
   logo: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
@@ -218,8 +216,4 @@ FooterLink.propTypes = {
   children: PropTypes.node.isRequired,
 }
 
-type FooterType = StyledComponent<typeof FooterBase, DefaultTheme, FooterProps> & {
-  Link: React.ComponentType<LinkProps>
-}
-
-export default DefaultFooter as FooterType
+export default Footer

--- a/modules/cactus-web/src/Footer/__snapshots__/Footer.test.tsx.snap
+++ b/modules/cactus-web/src/Footer/__snapshots__/Footer.test.tsx.snap
@@ -42,8 +42,23 @@ exports[`component: Footer snapshot 1`] = `
   padding: 16px 24px 16px 24px;
 }
 
+.cactus-layout-fixedBottom .c1 {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
 .c2 {
   margin-bottom: 16px;
+}
+
+.cactus-layout-fixedBottom .c2 {
+  margin-right: 16px;
+  margin-bottom: 0px;
 }
 
 .c4 {
@@ -61,9 +76,9 @@ exports[`component: Footer snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -104,6 +119,10 @@ exports[`component: Footer snapshot 1`] = `
   max-width: 100%;
 }
 
+.cactus-layout-fixedBottom .c6 {
+  max-width: calc(100% / 2);
+}
+
 .c6:last-of-type {
   border-right: none;
 }
@@ -125,50 +144,14 @@ exports[`component: Footer snapshot 1`] = `
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-@media screen and (min-width:768px) {
-  .c1 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c2 {
-    margin-right: 16px;
-    margin-bottom: 0px;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c5 {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c6 {
-    max-width: calc(100% / 2);
-  }
-}
-
-@media screen and (min-width:768px) {
-  .c0 {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-  }
+.c0.cactus-layout-fixedBottom {
+  height: auto;
 }
 
 <div>
-  <div
-    class="c0"
+  <footer
+    class="c0 cactus-layout-fixedBottom"
+    role="contentinfo"
   >
     <div
       class="c1"
@@ -212,6 +195,6 @@ exports[`component: Footer snapshot 1`] = `
         </a>
       </div>
     </div>
-  </div>
+  </footer>
 </div>
 `;

--- a/modules/cactus-web/src/Layout/Sidebar.tsx
+++ b/modules/cactus-web/src/Layout/Sidebar.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { Direction, insetBorder, Props as ThemeProps } from '../helpers/theme'
+import { ScreenSizeContext, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
+import { Position, Role, useLayout } from './Layout'
+
+const WIDTH = 60
+
+interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {
+  layoutRole: Role
+}
+
+type SidebarType = React.FC<SidebarProps> & { Button: ReturnType<typeof styled.button> }
+
+export const Sidebar: SidebarType = ({ layoutRole, className, ...props }) => {
+  const size = React.useContext(ScreenSizeContext)
+  let position: Position = 'floatLeft'
+  if (size < SIZES.small) {
+    position = 'fixedBottom'
+  } else if (size < SIZES.large) {
+    position = 'fixedLeft'
+  }
+  const { cssClass } = useLayout(layoutRole, { position, offset: WIDTH })
+  className = className ? `${className} ${cssClass}` : cssClass
+  return <SidebarDiv {...props} className={className} />
+}
+
+Sidebar.Button = styled.button.attrs({ role: 'button' })`
+  cursor: pointer;
+  border: none;
+  outline: none;
+  background-color: transparent;
+  text-decoration: none;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  box-sizing: border-box;
+
+  &:active,
+  &:focus {
+    outline: none;
+  }
+
+  &::-moz-focus-inner {
+    border: none;
+  }
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${WIDTH}px;
+  height: ${WIDTH}px;
+  padding: 8px;
+
+  img,
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  :hover {
+    color: ${(p) => p.theme.colors.callToAction};
+  }
+
+  &&&&:focus {
+    ${(p) => insetBorder(p.theme, 'callToAction')};
+  }
+
+  &&&&[aria-expanded='true'] {
+    ${(p) => p.theme.colorStyles.callToAction};
+    box-shadow: none;
+  }
+`
+
+const borders = ({ theme }: ThemeProps, border: Direction, buttonBorder: Direction) => `
+  ${insetBorder(theme, 'lightContrast', border)};
+  ${Sidebar.Button} {
+    ${insetBorder(theme, 'lightContrast', buttonBorder)};
+    :hover {
+      ${insetBorder(theme, 'callToAction', buttonBorder)};
+    }
+  }
+`
+
+const SidebarDiv = styled.div`
+  ${(p) => p.theme.colorStyles.standard};
+  box-sizing: border-box;
+  display: flex;
+  :empty {
+    display: none;
+  }
+
+  &.cactus-layout-floatLeft,
+  &.cactus-layout-fixedLeft {
+    flex-direction: column;
+    ${(p) => borders(p, 'right', 'bottom')};
+  }
+
+  &.cactus-layout-fixedBottom {
+    flex-direction: row;
+    ${(p) => borders(p, 'top', 'right')};
+    ${Sidebar.Button}[aria-expanded='true']::after {
+      content: '';
+      z-index: 99;
+      background-color: rgba(0, 0, 0, 0.5);
+      position: fixed;
+      top: 0;
+      bottom: ${WIDTH}px;
+      left: 0;
+      right: 0;
+      cursor: default;
+    }
+  }
+`

--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -13,7 +13,8 @@ import { useAction } from '../ActionBar/ActionProvider'
 import { isActionKey, keyPressAsClick } from '../helpers/a11y'
 import { AsProps, GenericComponent } from '../helpers/asProps'
 import { border, borderSize, boxShadow, media, radius, textStyle } from '../helpers/theme'
-import { Sidebar as LayoutSidebar, useLayout } from '../Layout/Layout'
+import { useLayout } from '../Layout/Layout'
+import { Sidebar as LayoutSidebar } from '../Layout/Sidebar'
 import { ScreenSizeContext, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
 import {
   focusMenu,

--- a/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
+++ b/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
@@ -56,11 +56,11 @@ exports[`component: MenuBar sidebar 1`] = `
   color: hsl(200,96%,35%);
 }
 
-.c3.c3.c3:focus {
+.c3.c3.c3.c3:focus {
   box-shadow: inset 0px 0px 0px 1px hsl(200,96%,35%);
 }
 
-.c3.c3.c3[aria-expanded='true'] {
+.c3.c3.c3.c3[aria-expanded='true'] {
   background-color: hsl(200,96%,35%);
   color: hsl(0,0%,100%);
   box-shadow: none;
@@ -74,27 +74,55 @@ exports[`component: MenuBar sidebar 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 0px;
-  bottom: 0px;
-  box-shadow: inset -1px 0px 0px 0px hsl(200,29%,90%);
 }
 
 .c0:empty {
   display: none;
 }
 
-.c0 .c2 {
+.c0.cactus-layout-floatLeft,
+.c0.cactus-layout-fixedLeft {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-shadow: inset -1px 0px 0px 0px hsl(200,29%,90%);
+}
+
+.c0.cactus-layout-floatLeft .c2,
+.c0.cactus-layout-fixedLeft .c2 {
   box-shadow: inset 0px -1px 0px 0px hsl(200,29%,90%);
 }
 
-.c0 .c2:hover {
+.c0.cactus-layout-floatLeft .c2:hover,
+.c0.cactus-layout-fixedLeft .c2:hover {
   box-shadow: inset 0px -1px 0px 0px hsl(200,96%,35%);
+}
+
+.c0.cactus-layout-fixedBottom {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  box-shadow: inset 0px 1px 0px 0px hsl(200,29%,90%);
+}
+
+.c0.cactus-layout-fixedBottom .c2 {
+  box-shadow: inset -1px 0px 0px 0px hsl(200,29%,90%);
+}
+
+.c0.cactus-layout-fixedBottom .c2:hover {
+  box-shadow: inset -1px 0px 0px 0px hsl(200,96%,35%);
+}
+
+.c0.cactus-layout-fixedBottom .c2[aria-expanded='true']::after {
+  content: '';
+  z-index: 99;
+  background-color: rgba(0,0,0,0.5);
+  position: fixed;
+  top: 0;
+  bottom: 60px;
+  left: 0;
+  right: 0;
+  cursor: default;
 }
 
 .c8 {
@@ -252,7 +280,7 @@ exports[`component: MenuBar sidebar 1`] = `
 
 <div>
   <div
-    class="c0"
+    class="c0 cactus-layout-fixedLeft"
   >
     <nav
       aria-label="Menu of Main-ness"

--- a/modules/cactus-web/src/helpers/theme.ts
+++ b/modules/cactus-web/src/helpers/theme.ts
@@ -7,7 +7,7 @@ import {
 } from '@repay/cactus-theme'
 import { css, FlattenSimpleInterpolation } from 'styled-components'
 
-type Props = { theme: CactusTheme }
+export type Props = { theme: CactusTheme }
 
 export const borderSize = (props: Props): string => (props.theme.border === 'thick' ? '2px' : '1px')
 
@@ -16,7 +16,7 @@ export const border = (theme: CactusTheme, color: string): string => {
   return `${thickness} solid ${theme.colors[color as CactusColor] || color}`
 }
 
-type Direction = 'top' | 'bottom' | 'left' | 'right'
+export type Direction = 'top' | 'bottom' | 'left' | 'right'
 
 export const insetBorder = (theme: CactusTheme, color: string, direction?: Direction): string => {
   let hOffset = 0,


### PR DESCRIPTION
Though this is not directly related to the ActionBar.Panel (CACTUS-346), it's something I wanted to do in my previous ticket to make future work (including the Panel) easier; I'm putting it up in a separate PR so as not to clutter up the ActionBar tickets, but this is something like CACTUS-333.5 or CACTUS-346.-5.

In order to decouple Sidebar, I changed Layout from directly referencing the Sidebar `styled-components` class, to referencing a generic CSS class that could be assigned to any component. This will also make it easier to cascade styles down the tree based on the current layout position.

While I was at it, I did a little refactoring of the `Footer`:
- Changed exported component to the new paradigm (not directly exposing styled component).
- Changed element from `div` to `footer`.
- Replaced media queries with references to the new CSS classes, which are in turn controlled by the `ScreenSizeProvider`.