### PR TITLE
fix(cactus-web): ignore width on card view of table and Datagrid

### DIFF
--- a/modules/cactus-web/src/Table/Table.test.tsx
+++ b/modules/cactus-web/src/Table/Table.test.tsx
@@ -104,4 +104,30 @@ describe('component: Table', (): void => {
 
     expect(container).toMatchSnapshot()
   })
+  test('ignores width on card', (): void => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <Table variant="card">
+          <Table.Header>
+            <Table.Cell>Header Cell</Table.Cell>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell width="230px" data-testid="cell">
+                Data cell
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Data cell</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Data cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </StyleProvider>
+    )
+    const singleCell = getByTestId('cell')
+    expect(singleCell).toHaveStyle('width: 288px')
+  })
 })

--- a/modules/cactus-web/src/Table/Table.test.tsx
+++ b/modules/cactus-web/src/Table/Table.test.tsx
@@ -128,6 +128,6 @@ describe('component: Table', (): void => {
       </StyleProvider>
     )
     const singleCell = getByTestId('cell')
-    expect(singleCell).toHaveStyle('width: 288px')
+    expect(singleCell).toHaveStyle('width: 272px')
   })
 })

--- a/modules/cactus-web/src/Table/Table.test.tsx
+++ b/modules/cactus-web/src/Table/Table.test.tsx
@@ -128,6 +128,6 @@ describe('component: Table', (): void => {
       </StyleProvider>
     )
     const singleCell = getByTestId('cell')
-    expect(singleCell).toHaveStyle('width: 272px')
+    expect(singleCell).toHaveStyle('width: 240px')
   })
 })

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -258,7 +258,7 @@ const StyledCell = styled.td(
     card: css`
       && {
         display: flex;
-        max-width: 100%;
+        width: 288px;
         flex-flow: row wrap;
         justify-content: space-between;
         padding: 8px 16px;

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -256,7 +256,7 @@ const StyledCell = styled.td(
     card: css`
       && {
         display: flex;
-        width: 272px;
+        width: 240px;
         flex-flow: row wrap;
         justify-content: space-between;
         padding: 8px 16px;

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -228,11 +228,9 @@ const HeaderBox = styled.div.attrs({ 'aria-hidden': 'true' })`
 const ContentBox = styled.div`
   flex-grow: 1;
   text-align: right;
-  max-width: 100%;
   &:only-child,
   ${HeaderBox}:empty + & {
     text-align: center;
-    width: 100%;
   }
 `
 
@@ -258,7 +256,7 @@ const StyledCell = styled.td(
     card: css`
       && {
         display: flex;
-        width: 288px;
+        width: 272px;
         flex-flow: row wrap;
         justify-content: space-between;
         padding: 8px 16px;

--- a/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
+++ b/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`component: Table card carousel 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  max-width: 100%;
+  width: 288px;
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;

--- a/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
+++ b/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`component: Table card carousel 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 272px;
+  width: 240px;
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;

--- a/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
+++ b/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
@@ -29,13 +29,11 @@ exports[`component: Table card carousel 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   text-align: right;
-  max-width: 100%;
 }
 
 .c7:only-child,
 .c5:empty + .c7 {
   text-align: center;
-  width: 100%;
 }
 
 .c3 {
@@ -49,7 +47,7 @@ exports[`component: Table card carousel 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  width: 288px;
+  width: 272px;
   -webkit-flex-flow: row wrap;
   -ms-flex-flow: row wrap;
   flex-flow: row wrap;


### PR DESCRIPTION
Check that the width prop is ignored in card view in both DataGrid and Table

[CACTUS-374]


[CACTUS-374]: https://repayonline.atlassian.net/browse/CACTUS-374