### PR TITLE
CACTUS-378 ActionBar.Item key fix

### DIFF
--- a/modules/cactus-web/src/ActionBar/ActionBar.mdx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.mdx
@@ -23,6 +23,7 @@ const MySite = () => (
   <Layout>
     <ActionBar>
       <ActionBar.Item
+        id="ab-print"
         icon={<ActionsPrint/>}
         onClick={printThisPage}
         aria-label="Print this page"
@@ -48,7 +49,7 @@ import { ActionBar } from '@repay/cactus-web'
 const MyPage = () => (
   <>
     <ActionBar.Item
-      key="page-action"
+      id="page-action"
       icon={<ActionsKey/>}
       orderHint="high"
       onClick={doSomethingPageSpecific}
@@ -58,7 +59,7 @@ const MyPage = () => (
 )
 ```
 
-- You must provide either a _key_ or an _id_ prop to uniquely identify the action on the ActionBar (`id` takes precedence over `key`); if neither is present, an error will be thrown.
+- You must provide either an _id_ prop to uniquely identify the action on the ActionBar; if it is not present, an error will be thrown. (We would use _key_ as well, but React doesn't forward it with the props.)
 - The _orderHint_ indicates where, relative to other ActionBar items, the item should appear.
   - Possible values are 'top', 'high', 'center' (default), 'low', and 'bottom'.
   - Items with the same hint are rendered in the order they're added, according to how React renders the entire document tree.
@@ -114,7 +115,7 @@ Because ActionBar items typically only have an icon and no text, it may not be o
 
 ### ActionBar.Item
 
-<PropsTable of={ActionBar} staticProp="ActionBarItem" includeProps={['icon', 'orderHint', 'key', 'id']} />
+<PropsTable of={ActionBar} staticProp="ActionBarItem" />
 
 ### ActionBar.Button
 

--- a/modules/cactus-web/src/ActionBar/ActionBar.mdx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.mdx
@@ -59,7 +59,7 @@ const MyPage = () => (
 )
 ```
 
-- You must provide either an _id_ prop to uniquely identify the action on the ActionBar; if it is not present, an error will be thrown. (We would use _key_ as well, but React doesn't forward it with the props.)
+- You must provide an _id_ prop to uniquely identify the action on the ActionBar; if it is not present, an error will be thrown. (We would use _key_ as well, but React doesn't forward it with the props.)
 - The _orderHint_ indicates where, relative to other ActionBar items, the item should appear.
   - Possible values are 'top', 'high', 'center' (default), 'low', and 'bottom'.
   - Items with the same hint are rendered in the order they're added, according to how React renders the entire document tree.

--- a/modules/cactus-web/src/ActionBar/ActionBar.story.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.story.tsx
@@ -42,7 +42,7 @@ const SimpleRouter = () => {
   return (
     <Flex alignItems="center" justifyContent="center" flexDirection="column">
       <ActionBar.Item
-        key="refresh"
+        id="refresh"
         icon={<ActionsRefresh />}
         orderHint="high"
         onClick={() => setCount((c) => c + 1)}

--- a/modules/cactus-web/src/ActionBar/ActionBar.test.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.test.tsx
@@ -12,7 +12,7 @@ describe('component: ActionBar', () => {
       <StyleProvider>
         <ActionBar>
           <ActionBar.Item id="one" icon={<ActionsGear />} />
-          <ActionBar.Item key="two" icon={<ActionsKey />} />
+          <ActionBar.Item id="two" icon={<ActionsKey />} />
         </ActionBar>
       </StyleProvider>
     )
@@ -29,7 +29,7 @@ describe('component: ActionBar', () => {
           <div aria-label="Content">
             <ActionBar.Item id="bottom" icon={<ActionsKey />} orderHint="bottom" />
             <ActionBar.Item id="normal" icon={<ActionsKey />} />
-            <ActionBar.Item key="top" aria-label="top" icon={<ActionsKey />} orderHint="top" />
+            <ActionBar.Item id="top" aria-label="top" icon={<ActionsKey />} orderHint="top" />
           </div>
         </ActionProvider>
       </StyleProvider>

--- a/modules/cactus-web/src/ActionBar/ActionBar.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.tsx
@@ -5,6 +5,8 @@ import { Sidebar } from '../Layout/Sidebar'
 import { OrderHint, OrderHintKey, useAction, useActionBarItems } from './ActionProvider'
 
 interface ItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Required when used within an ActionProvider */
+  id?: string
   icon: React.ReactElement
   orderHint?: OrderHint
 }
@@ -16,9 +18,7 @@ export const ActionBarItem = React.forwardRef<HTMLButtonElement, ItemProps>(
         {icon}
       </ActionBar.Button>
     )
-    // Undocumented React internals: make sure a test will fail if this changes.
-    const key = (child as any)._owner?.key
-    return useAction(child, orderHint, props.id || key)
+    return useAction(child, orderHint, props.id)
   }
 )
 

--- a/modules/cactus-web/src/ActionBar/__snapshots__/ActionBar.test.tsx.snap
+++ b/modules/cactus-web/src/ActionBar/__snapshots__/ActionBar.test.tsx.snap
@@ -148,6 +148,7 @@ exports[`component: ActionBar typechecks 1`] = `
     </button>
     <button
       class="c1 c2"
+      id="two"
       role="button"
     >
       <svg

--- a/modules/cactus-web/src/Layout/Layout.story.tsx
+++ b/modules/cactus-web/src/Layout/Layout.story.tsx
@@ -56,7 +56,7 @@ storiesOf('Layout', module).add(
         {hasActions && (
           <ActionBar>
             <ActionBar.Item
-              key="whattime"
+              id="whattime"
               icon={<DescriptiveClock />}
               onClick={() => alert(`It is now ${new Date()}.`)}
             />


### PR DESCRIPTION
Note that I didn't actually make id required, since it could still be used in the absence of ActionProvider.