### PR TITLE
CACTUS-342 Events Part 1: The Easy Stuff

### DIFF
--- a/examples/mock-ebpp/src/containers/ui-config.tsx
+++ b/examples/mock-ebpp/src/containers/ui-config.tsx
@@ -158,7 +158,7 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
             <Flex borderColor="base" borderWidth="2px" borderStyle="solid" width="90%">
               <Flex width="100%">
                 <Form style={{ width: '100%', padding: '16px' }}>
-                  <FormikField
+                  <Field
                     as={TextInputField}
                     name="displayName"
                     label="Display Name"
@@ -166,14 +166,14 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
                     error={touched.displayName && errors.displayName}
                   />
 
-                  <FormikField
+                  <Field
                     as={TextInputField}
                     name="merchantName"
                     label="Merchant Name"
                     tooltip="Enter your merchant name"
                     error={touched.merchantName && errors.merchantName}
                   />
-                  <FormikField
+                  <Field
                     as={TextAreaField}
                     name="termsAndConditions"
                     label="Terms and Conditions"
@@ -181,14 +181,14 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
                     error={touched.termsAndConditions && errors.termsAndConditions}
                   />
 
-                  <FormikField
+                  <Field
                     as={TextAreaField}
                     name="welcomeContent"
                     label="Welcome Content"
                     tooltip="Enter content to be displayed on login"
                     error={touched.welcomeContent && errors.welcomeContent}
                   />
-                  <FormikField
+                  <Field
                     as={TextAreaField}
                     name="footerContent"
                     label="Footer Content"
@@ -254,7 +254,7 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
                     />
                   </Flex>
 
-                  <FormikField
+                  <Field
                     as={RadioGroup}
                     name="selectColor"
                     label="Select Color"
@@ -265,17 +265,19 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
                     <RadioGroup.Button value="yellow" label="Yellow" />
                     <RadioGroup.Button value="pink" label="Pink" />
                     <RadioGroup.Button value="blue" label="Blue" />
-                  </FormikField>
+                  </Field>
 
-                  <FormikField
+                  <Field
                     as={ToggleField}
+                    type="checkbox"
                     name="allowCustomerLogin"
                     label="Allow Customer Login"
                     my={4}
                   />
 
-                  <FormikField
+                  <Field
                     as={CheckBoxField}
+                    type="checkbox"
                     name="useCactusStyles"
                     label="Use Cactus Styles"
                     my={4}

--- a/examples/standard/src/App.tsx
+++ b/examples/standard/src/App.tsx
@@ -7,7 +7,7 @@ import React, { Component, ReactElement } from 'react'
 
 interface AppProps extends RouteComponentProps {
   onLangChange: (lang: string) => void
-  onChangeFeature: (name: string, enabled: boolean) => void
+  onChangeFeature: (event: React.ChangeEvent<HTMLInputElement>) => void
   lang: string
   include_carrot_snacks?: boolean
   children?: React.ReactNode
@@ -56,7 +56,7 @@ class App extends Component<AppProps> {
                   id="feature-include-carrots"
                   label={label || ''}
                   onChange={this.props.onChangeFeature}
-                  value={Boolean(this.props.include_carrot_snacks)}
+                  checked={Boolean(this.props.include_carrot_snacks)}
                 />
               )}
             </I18nResource>

--- a/examples/standard/src/index.tsx
+++ b/examples/standard/src/index.tsx
@@ -27,10 +27,10 @@ class RootWrapper extends Component<
 
   private handleLangChange = (lang: string): void => this.setState({ lang })
 
-  private handleChangeFeature = (name: string, enabled: boolean): void => {
+  private handleChangeFeature = ({ target }: React.ChangeEvent<HTMLInputElement>): void => {
     this.setState((s): { lang: string; features: FeatureFlagsObject } => ({
       ...s,
-      features: { ...s.features, [name]: enabled },
+      features: { ...s.features, [target.name]: target.checked },
     }))
   }
   public render(): React.ReactElement {

--- a/examples/theme-components/src/containers/Breadcrumb.tsx
+++ b/examples/theme-components/src/containers/Breadcrumb.tsx
@@ -48,7 +48,7 @@ const BreadcrumbExample: React.FC<RouteComponentProps & BreadProps> = (
           label="Add a new path"
           name="path"
           value={value}
-          onChange={(_, val): void => setValue(val)}
+          onChange={(e): void => setValue(e.target.value)}
         />
         <Button onClick={addPaths} mt="10px">
           Add

--- a/examples/theme-components/src/containers/FormExample.tsx
+++ b/examples/theme-components/src/containers/FormExample.tsx
@@ -61,7 +61,22 @@ const post = (data: { [k: string]: any }): void => {
 const FormExample: React.FC<RouteComponentProps> = (): ReactElement => {
   const [values, setValues] = React.useState<FieldsTypes>(getInitialValues)
 
+  const onCheckboxChange = React.useCallback(
+    ({ target }: React.ChangeEvent<HTMLInputElement>): void => {
+      setValues((s) => ({ ...s, data: { ...s.data, [target.name]: target.checked } }))
+    },
+    [setValues]
+  )
+
   const onChange = React.useCallback(
+    (e: React.SyntheticEvent): void => {
+      const { name, value } = e.target as HTMLInputElement
+      setValues((s) => ({ ...s, data: { ...s.data, [name]: value } }))
+    },
+    [setValues]
+  )
+
+  const onLegacyChange = React.useCallback(
     (name: string, value: any): void => {
       setValues(
         (s): FieldsTypes => ({
@@ -158,7 +173,7 @@ const FormExample: React.FC<RouteComponentProps> = (): ReactElement => {
             name="checkbox"
             label="CheckBox Field"
             checked={values.data.checkbox}
-            onChange={onChange}
+            onChange={onCheckboxChange}
           />
           <RadioGroup
             name="radiobuttonGroup"
@@ -177,7 +192,7 @@ const FormExample: React.FC<RouteComponentProps> = (): ReactElement => {
             name="selectBox"
             value={values.data.selectBox}
             options={selectOptions}
-            onChange={onChange}
+            onChange={onLegacyChange}
           />
           <TextAreaField
             name="textarea"
@@ -190,8 +205,8 @@ const FormExample: React.FC<RouteComponentProps> = (): ReactElement => {
             mt={4}
             label="Toggle Field"
             name="togglefield"
-            value={values.data.togglefield}
-            onChange={onChange}
+            checked={values.data.togglefield}
+            onChange={onCheckboxChange}
           />
           <Button mt={5} ml="25%" type="submit" variant="action">
             Submit

--- a/examples/theme-components/src/containers/IconButton.tsx
+++ b/examples/theme-components/src/containers/IconButton.tsx
@@ -38,6 +38,9 @@ const IconbuttonExample: React.FC<RouteComponentProps> = (): React.ReactElement 
     },
     [state]
   )
+  const onToggleChange = useCallback(({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState((s) => ({ ...s, [target.name]: target.checked }))
+  }, [])
   return (
     <div>
       <Link to="/">
@@ -66,14 +69,14 @@ const IconbuttonExample: React.FC<RouteComponentProps> = (): React.ReactElement 
         <ToggleField
           name="disabled"
           label="Disabled"
-          onChange={changeVariant}
-          value={state.disabled}
+          onChange={onToggleChange}
+          checked={state.disabled}
         />
         <ToggleField
           name="inverse"
           label="Inverse"
-          onChange={changeVariant}
-          value={state.inverse}
+          onChange={onToggleChange}
+          checked={state.inverse}
         />
       </Flex>
       <Grid justify="center" style={state.inverse ? containerStyle : {}}>

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.mdx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.mdx
@@ -35,10 +35,10 @@ import React, { useState } from 'react'
 import { Button, CheckBoxField } from '@repay/cactus-web'
 
 export default function Form() {
-  const [values, setValues] = useState({ checked: false })
+  const [values, setValues] = useState({ checkboxfield: false })
   const handleChange = useCallback(
-    (name, value) => {
-      setValues(state => setValues({ ...state, [name]: value }))
+    (e) => {
+      setValues(state => ({ ...state, [e.target.name]: e.target.checked }))
     },
     [setValues]
   )
@@ -57,7 +57,7 @@ export default function Form() {
         name="checkboxfield"
         label="Is Checked"
         onChange={handleChange}
-        value={values.checked}
+        value={values.checkboxfield}
       />
       <Button type="submit" variant="action">
         Submit

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, queryByAttribute, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import pick from 'lodash/pick'
 import * as React from 'react'
 
 import { StyleProvider } from '../StyleProvider/StyleProvider'
@@ -51,15 +52,17 @@ describe('component: CheckBoxField', (): void => {
   })
 
   test('should trigger onChange event', (): void => {
-    const onChange = jest.fn()
+    const box: any = {}
+    const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['name', 'checked'])))
     const { getByLabelText } = render(
       <StyleProvider>
-        <CheckBoxField label="Katastro" name="katastro" onChange={onChange} />
+        <CheckBoxField label="Katastro" name="katastro" defaultChecked onChange={onChange} />
       </StyleProvider>
     )
 
     fireEvent.click(getByLabelText('Katastro'))
-    expect(onChange).toHaveBeenCalledWith('katastro', true)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(box).toEqual({ name: 'katastro', checked: false })
   })
 
   test('should trigger onFocus event', (): void => {

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
@@ -5,38 +5,25 @@ import { margin, MarginProps } from 'styled-system'
 
 import CheckBox, { CheckBoxProps } from '../CheckBox/CheckBox'
 import FieldWrapper from '../FieldWrapper/FieldWrapper'
-import handleEvent from '../helpers/eventHandler'
 import { omitMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler, Omit } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
 export interface CheckBoxFieldProps
-  extends Omit<CheckBoxProps, 'id' | 'onChange' | 'onBlur' | 'onFocus' | 'disabled'>,
+  extends Omit<CheckBoxProps, 'id' | 'onChange' | 'disabled'>,
     MarginProps {
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
   name: string
   onChange?: FieldOnChangeHandler<boolean>
-  onFocus?: FieldOnFocusHandler
-  onBlur?: FieldOnBlurHandler
   disabled?: boolean
 }
 
 const CheckBoxFieldBase = React.forwardRef<HTMLInputElement, CheckBoxFieldProps>((props, ref) => {
   const componentProps = omitMargins(props) as Omit<CheckBoxFieldProps, keyof MarginProps>
-  const {
-    label,
-    labelProps,
-    id,
-    name,
-    onChange,
-    onBlur,
-    onFocus,
-    className,
-    ...checkboxProps
-  } = componentProps
+  const { label, labelProps, id, name, onChange, className, ...checkboxProps } = componentProps
   const checkboxId = useId(id, name)
 
   const handleChange = React.useCallback(
@@ -49,25 +36,9 @@ const CheckBoxFieldBase = React.forwardRef<HTMLInputElement, CheckBoxFieldProps>
     [name, onChange]
   )
 
-  const handleFocus = (): void => {
-    handleEvent(onFocus, name)
-  }
-
-  const handleBlur = (): void => {
-    handleEvent(onBlur, name)
-  }
-
   return (
     <FieldWrapper className={className}>
-      <CheckBox
-        {...checkboxProps}
-        ref={ref}
-        id={checkboxId}
-        name={name}
-        onChange={handleChange}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-      />
+      <CheckBox {...checkboxProps} ref={ref} id={checkboxId} name={name} onChange={handleChange} />
       <Label {...labelProps} htmlFor={checkboxId}>
         {label}
       </Label>
@@ -89,15 +60,12 @@ export const CheckBoxField = styled(CheckBoxFieldBase)`
   ${margin}
 `
 
-// @ts-ignore
 CheckBoxField.propTypes = {
   label: PropTypes.node.isRequired,
   labelProps: PropTypes.object,
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
   disabled: PropTypes.bool,
 }
 

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
@@ -8,37 +8,23 @@ import FieldWrapper from '../FieldWrapper/FieldWrapper'
 import { omitMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
-import { FieldOnChangeHandler } from '../types'
 
-export interface CheckBoxFieldProps
-  extends Omit<CheckBoxProps, 'id' | 'onChange' | 'disabled'>,
-    MarginProps {
+export interface CheckBoxFieldProps extends Omit<CheckBoxProps, 'id' | 'disabled'>, MarginProps {
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
   name: string
-  onChange?: FieldOnChangeHandler<boolean>
   disabled?: boolean
 }
 
 const CheckBoxFieldBase = React.forwardRef<HTMLInputElement, CheckBoxFieldProps>((props, ref) => {
   const componentProps = omitMargins(props) as Omit<CheckBoxFieldProps, keyof MarginProps>
-  const { label, labelProps, id, name, onChange, className, ...checkboxProps } = componentProps
+  const { label, labelProps, id, name, className, ...checkboxProps } = componentProps
   const checkboxId = useId(id, name)
-
-  const handleChange = React.useCallback(
-    (event: React.FormEvent<HTMLInputElement>): void => {
-      if (typeof onChange === 'function') {
-        const target = (event.target as unknown) as HTMLInputElement
-        onChange(name, target.checked)
-      }
-    },
-    [name, onChange]
-  )
 
   return (
     <FieldWrapper className={className}>
-      <CheckBox {...checkboxProps} ref={ref} id={checkboxId} name={name} onChange={handleChange} />
+      <CheckBox {...checkboxProps} ref={ref} id={checkboxId} name={name} />
       <Label {...labelProps} htmlFor={checkboxId}>
         {label}
       </Label>
@@ -65,7 +51,6 @@ CheckBoxField.propTypes = {
   labelProps: PropTypes.object,
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
   disabled: PropTypes.bool,
 }
 

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.mdx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.mdx
@@ -46,7 +46,6 @@ If you use an intermediate component, the component will have to accept the forw
   - Pass `checked` or `defaultChecked` to `CheckBoxGroup.Item`s.
 - Passing a `ref` to `CheckBoxGroup` will be set on the `fieldset` element.
 - `onChange`, `onFocus` and `onBlur` handlers are not forwarded to individual checkboxes. They are associated with the `fieldset` and rely on event delegation to capture changes.
-  - The `name` passed to `onFocus` and `onBlur` handlers will match with the `name` of the `CheckBoxGroup`, while the `name` passed to the `onChange` handler will be the name associated with an individual checkbox.
 
 ## Properties
 

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.story.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.story.tsx
@@ -15,7 +15,7 @@ checkBoxGroupStories.add(
       id="cbg"
       label={text('label', 'My Label')}
       disabled={boolean('disabled', false)}
-      onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
+      onChange={(e: any) => console.log(`'${e.target.name}' changed: ${e.target.checked}`)}
       onFocus={(e) => console.log(`'${e.target.name}' focused`)}
       onBlur={(e) => console.log(`'${e.target.name}' blurred`)}
       tooltip={text('tooltip', 'Check some boxes')}
@@ -45,7 +45,9 @@ checkBoxGroupStories.add(
           name="controller"
           label="Controller"
           checked={value}
-          onChange={(name, val) => setValue((value) => ({ ...value, [name]: val }))}
+          onChange={({ target }: any) =>
+            setValue((value) => ({ ...value, [target.name]: target.checked }))
+          }
         >
           <CheckBoxGroup.Item name="option-1" label="Option 1" />
           <CheckBoxGroup.Item name="option-2" label="Option 2" />

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.story.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.story.tsx
@@ -16,8 +16,8 @@ checkBoxGroupStories.add(
       label={text('label', 'My Label')}
       disabled={boolean('disabled', false)}
       onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
-      onFocus={(name) => console.log(`'${name}' focused`)}
-      onBlur={(name) => console.log(`'${name}' blurred`)}
+      onFocus={(e) => console.log(`'${e.target.name}' focused`)}
+      onBlur={(e) => console.log(`'${e.target.name}' blurred`)}
       tooltip={text('tooltip', 'Check some boxes')}
       autoTooltip={boolean('autoTooltip', true)}
       error={text('error', '')}

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.test.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.test.tsx
@@ -16,6 +16,7 @@ describe('component: CheckBoxGroup', (): void => {
           required
           checked={{ cb1: true }}
           tooltip="Check some boxes"
+          onChange={() => undefined}
         >
           <CheckBoxGroup.Item id="cb1" name="cb1" label="CB 1" />
           <CheckBoxGroup.Item id="cb2" name="cb2" label="CB 2" />
@@ -70,8 +71,10 @@ describe('component: CheckBoxGroup', (): void => {
   })
 
   test('should trigger events', () => {
-    const onChange = jest.fn()
-    const onChangeOne = jest.fn()
+    const changes: [string, boolean][] = []
+    const onChange = jest.fn((e) => changes.push([e.target.name, e.target.checked]))
+    const changeOne: [string, boolean][] = []
+    const onChangeOne = jest.fn((e) => changeOne.push([e.target.name, e.target.checked]))
     const focusNames: string[] = []
     const onFocus = jest.fn((e) => focusNames.push(e.target.name))
     const focusOne: string[] = []
@@ -124,11 +127,11 @@ describe('component: CheckBoxGroup', (): void => {
     expect(onBlur).toHaveBeenCalledTimes(2)
 
     userEvent.tab()
-    expect(onChange.mock.calls).toEqual([
+    expect(changes).toEqual([
       ['cb2', true],
       ['cb1', true],
     ])
-    expect(onChangeOne.mock.calls).toEqual([['cb2', true]])
+    expect(changeOne).toEqual([['cb2', true]])
     expect(focusNames).toEqual(['cb1', 'cb2', 'cb1', 'cb2'])
     expect(focusOne).toEqual(['cb1', 'cb1'])
     expect(blurNames).toEqual(['cb1', 'cb2', 'cb1'])

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.test.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.test.tsx
@@ -72,9 +72,12 @@ describe('component: CheckBoxGroup', (): void => {
   test('should trigger events', () => {
     const onChange = jest.fn()
     const onChangeOne = jest.fn()
-    const onFocus = jest.fn()
-    const onFocusOne = jest.fn()
-    const onBlur = jest.fn()
+    const focusNames: string[] = []
+    const onFocus = jest.fn((e) => focusNames.push(e.target.name))
+    const focusOne: string[] = []
+    const onFocusOne = jest.fn((e) => focusOne.push(e.target.name))
+    const blurNames: string[] = []
+    const onBlur = jest.fn((e) => blurNames.push(e.target.name))
     const { getByLabelText } = render(
       <StyleProvider>
         <CheckBoxGroup
@@ -109,16 +112,16 @@ describe('component: CheckBoxGroup', (): void => {
     userEvent.click(getByLabelText('CB 2'))
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChangeOne).toHaveBeenCalledTimes(1)
-    expect(onFocus).toHaveBeenCalledTimes(1)
+    expect(onFocus).toHaveBeenCalledTimes(2)
     expect(onFocusOne).toHaveBeenCalledTimes(1)
-    expect(onBlur).not.toHaveBeenCalled()
+    expect(onBlur).toHaveBeenCalledTimes(1)
 
     userEvent.click(getByLabelText('CB 1'))
     expect(onChange).toHaveBeenCalledTimes(2)
     expect(onChangeOne).toHaveBeenCalledTimes(1)
-    expect(onFocus).toHaveBeenCalledTimes(1)
+    expect(onFocus).toHaveBeenCalledTimes(3)
     expect(onFocusOne).toHaveBeenCalledTimes(2)
-    expect(onBlur).not.toHaveBeenCalled()
+    expect(onBlur).toHaveBeenCalledTimes(2)
 
     userEvent.tab()
     expect(onChange.mock.calls).toEqual([
@@ -126,8 +129,8 @@ describe('component: CheckBoxGroup', (): void => {
       ['cb1', true],
     ])
     expect(onChangeOne.mock.calls).toEqual([['cb2', true]])
-    expect(onFocus.mock.calls).toEqual([['checkboxes'], ['checkboxes']])
-    expect(onFocusOne.mock.calls).toEqual([['cb1'], ['cb1']])
-    expect(onBlur.mock.calls).toEqual([['checkboxes']])
+    expect(focusNames).toEqual(['cb1', 'cb2', 'cb1', 'cb2'])
+    expect(focusOne).toEqual(['cb1', 'cb1'])
+    expect(blurNames).toEqual(['cb1', 'cb2', 'cb1'])
   })
 })

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -6,26 +6,20 @@ import { FieldProps, useAccessibleField } from '../AccessibleField/AccessibleFie
 import Box from '../Box/Box'
 import CheckBoxField, { CheckBoxFieldProps } from '../CheckBoxField/CheckBoxField'
 import Fieldset from '../Fieldset/Fieldset'
-import handleEvent from '../helpers/eventHandler'
 import { cloneAll } from '../helpers/react'
 import Label from '../Label/Label'
 import StatusMessage from '../StatusMessage/StatusMessage'
 import Tooltip from '../Tooltip/Tooltip'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
 interface CheckBoxGroupProps
   extends MarginProps,
     WidthProps,
     Omit<FieldProps, 'labelProps'>,
-    Omit<
-      React.FieldsetHTMLAttributes<HTMLFieldSetElement>,
-      'name' | 'onChange' | 'onFocus' | 'onBlur' | 'defaultValue'
-    > {
+    Omit<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, 'name' | 'onChange' | 'defaultValue'> {
   checked?: { [K: string]: boolean }
   required?: boolean
   onChange?: FieldOnChangeHandler<boolean>
-  onFocus?: FieldOnFocusHandler
-  onBlur?: FieldOnBlurHandler
 }
 
 type CheckBoxGroupItemProps = Omit<CheckBoxFieldProps, 'required'>
@@ -93,22 +87,22 @@ export const CheckBoxGroup = React.forwardRef<HTMLFieldSetElement, CheckBoxGroup
 
     const handleFocus = React.useCallback(
       (event: React.FocusEvent<HTMLFieldSetElement>): void => {
+        onFocus?.(event)
         if (!event.currentTarget.contains(event.relatedTarget as Node)) {
-          handleEvent(onFocus, name)
           setTooltipVisible(() => true)
         }
       },
-      [name, onFocus]
+      [onFocus]
     )
 
     const handleBlur = React.useCallback(
       (e: React.FocusEvent<HTMLFieldSetElement>) => {
+        onBlur?.(e)
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-          handleEvent(onBlur, name)
           setTooltipVisible(() => false)
         }
       },
-      [onBlur, name, setTooltipVisible]
+      [onBlur, setTooltipVisible]
     )
 
     return (
@@ -162,8 +156,6 @@ CheckBoxGroup.propTypes = {
   warning: PropTypes.node,
   error: PropTypes.node,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
   checked: PropTypes.objectOf(PropTypes.bool.isRequired),
 }
 

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -31,6 +31,8 @@ type ForwardProps = {
   required?: boolean
 }
 
+const noop = () => undefined
+
 export const CheckBoxGroup = React.forwardRef<HTMLFieldSetElement, CheckBoxGroupProps>(
   (
     { label, children, tooltip, required, checked, onFocus, onBlur, autoTooltip = true, ...props },
@@ -62,7 +64,7 @@ export const CheckBoxGroup = React.forwardRef<HTMLFieldSetElement, CheckBoxGroup
       // This is to avert a PropTypes warning regarding missing onChange handler.
       const hasChecked = props.checked !== undefined || element.props.checked !== undefined
       if (hasChecked && hasOnChange && !element.props.onChange) {
-        props = { ...props, onChange: () => undefined }
+        props = { ...props, onChange: noop }
       }
       return React.cloneElement(element, props)
     }

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.mdx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.mdx
@@ -40,8 +40,10 @@ import { Button, RadioButtonField } from '@repay/cactus-web'
 export default function Form() {
   const [values, setValues] = useState({ radiobuttonfield: 'option_a' })
   const handleChange = useCallback(
-    (name, value) => {
-      setValues(state => setValues({ ...state, [name]: value }))
+    (e) => {
+      if (e.checked) {
+        setValues(state => ({ ...state, [e.target.name]: e.target.value }))
+      }
     },
     [setValues]
   )

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.mdx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.mdx
@@ -41,7 +41,7 @@ export default function Form() {
   const [values, setValues] = useState({ radiobuttonfield: 'option_a' })
   const handleChange = useCallback(
     (e) => {
-      if (e.checked) {
+      if (e.target.checked) {
         setValues(state => ({ ...state, [e.target.name]: e.target.value }))
       }
     },

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.test.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, queryByAttribute, render } from '@testing-library/react'
+import pick from 'lodash/pick'
 import * as React from 'react'
 
 import { StyleProvider } from '../StyleProvider/StyleProvider'
@@ -52,7 +53,8 @@ describe('component: RadioButtonField', (): void => {
   })
 
   test('should trigger onChange event', (): void => {
-    const onChange = jest.fn()
+    const box: any = {}
+    const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['name', 'value'])))
     const { getByLabelText } = render(
       <StyleProvider>
         <RadioButtonField id="Ackermann" name="rbf" label="Levi" onChange={onChange} />
@@ -60,7 +62,8 @@ describe('component: RadioButtonField', (): void => {
     )
 
     fireEvent.click(getByLabelText('Levi'))
-    expect(onChange).toHaveBeenCalledWith('rbf', 'on')
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(box).toEqual({ name: 'rbf', value: 'on' })
   })
 
   test('should trigger onFocus event', (): void => {

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
@@ -8,44 +8,24 @@ import { omitMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import RadioButton, { RadioButtonProps } from '../RadioButton/RadioButton'
-import { FieldOnChangeHandler } from '../types'
 
-export interface RadioButtonFieldProps
-  extends Omit<RadioButtonProps, 'id' | 'onChange'>,
-    MarginProps {
+export interface RadioButtonFieldProps extends Omit<RadioButtonProps, 'id'>, MarginProps {
   label: React.ReactNode
   name: string
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
-  onChange?: FieldOnChangeHandler<string>
 }
 
 const RadioButtonFieldBase = React.forwardRef<HTMLInputElement, RadioButtonFieldProps>(
   (props, ref) => {
-    const { label, labelProps, id, className, name, onChange, ...radioButtonProps } = omitMargins(
+    const { label, labelProps, id, className, name, ...radioButtonProps } = omitMargins(
       props
     ) as Omit<RadioButtonFieldProps, keyof MarginProps>
     const radioButtonId = useId(id, name)
 
-    const handleChange = React.useCallback(
-      (event: React.FormEvent<HTMLInputElement>): void => {
-        if (typeof onChange === 'function') {
-          const target = (event.target as unknown) as HTMLInputElement
-          onChange(name, target.value)
-        }
-      },
-      [name, onChange]
-    )
-
     return (
       <FieldWrapper className={className}>
-        <RadioButton
-          ref={ref}
-          id={radioButtonId}
-          name={name}
-          onChange={handleChange}
-          {...radioButtonProps}
-        />
+        <RadioButton ref={ref} id={radioButtonId} name={name} {...radioButtonProps} />
         <Label {...labelProps} htmlFor={radioButtonId}>
           {label}
         </Label>
@@ -73,7 +53,6 @@ RadioButtonField.propTypes = {
   name: PropTypes.string.isRequired,
   labelProps: PropTypes.object,
   id: PropTypes.string,
-  onChange: PropTypes.func,
 }
 
 RadioButtonField.defaultProps = {

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
@@ -4,38 +4,27 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import FieldWrapper from '../FieldWrapper/FieldWrapper'
-import handleEvent from '../helpers/eventHandler'
 import { omitMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import RadioButton, { RadioButtonProps } from '../RadioButton/RadioButton'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler, Omit } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
 export interface RadioButtonFieldProps
-  extends Omit<RadioButtonProps, 'id' | 'onChange' | 'onFocus' | 'onBlur'>,
+  extends Omit<RadioButtonProps, 'id' | 'onChange'>,
     MarginProps {
   label: React.ReactNode
   name: string
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
   onChange?: FieldOnChangeHandler<string>
-  onFocus?: FieldOnFocusHandler
-  onBlur?: FieldOnBlurHandler
 }
 
 const RadioButtonFieldBase = React.forwardRef<HTMLInputElement, RadioButtonFieldProps>(
   (props, ref) => {
-    const {
-      label,
-      labelProps,
-      id,
-      className,
-      name,
-      onChange,
-      onFocus,
-      onBlur,
-      ...radioButtonProps
-    } = omitMargins(props) as Omit<RadioButtonFieldProps, keyof MarginProps>
+    const { label, labelProps, id, className, name, onChange, ...radioButtonProps } = omitMargins(
+      props
+    ) as Omit<RadioButtonFieldProps, keyof MarginProps>
     const radioButtonId = useId(id, name)
 
     const handleChange = React.useCallback(
@@ -48,14 +37,6 @@ const RadioButtonFieldBase = React.forwardRef<HTMLInputElement, RadioButtonField
       [name, onChange]
     )
 
-    const handleFocus = (): void => {
-      handleEvent(onFocus, name)
-    }
-
-    const handleBlur = (): void => {
-      handleEvent(onBlur, name)
-    }
-
     return (
       <FieldWrapper className={className}>
         <RadioButton
@@ -63,8 +44,6 @@ const RadioButtonFieldBase = React.forwardRef<HTMLInputElement, RadioButtonField
           id={radioButtonId}
           name={name}
           onChange={handleChange}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           {...radioButtonProps}
         />
         <Label {...labelProps} htmlFor={radioButtonId}>
@@ -95,8 +74,6 @@ RadioButtonField.propTypes = {
   labelProps: PropTypes.object,
   id: PropTypes.string,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
 }
 
 RadioButtonField.defaultProps = {

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.mdx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.mdx
@@ -21,7 +21,7 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 ### Try it out
 
-export const code = `<RadioGroup name="radioCity" label="Here there be radios" value="option_b">
+export const code = `<RadioGroup name="radioCity" label="Here there be radios" defaultValue="option_b">
   <RadioGroup.Button label="Radio The First" value="option_a" />
   <RadioGroup.Button label="Radio The Second" value="option_b" />
   <RadioGroup.Button label="Radio The Third" value="option_c" />

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
@@ -15,7 +15,7 @@ radioGroupStories.add(
       name="you-are-group-one"
       label={text('label', 'A Label')}
       disabled={boolean('disabled', false)}
-      onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
+      onChange={(e: any) => console.log(`'${e.target.name}' changed: ${e.target.value}`)}
       onFocus={(e: any) => console.log(`'${e.target.value}' focused`)}
       onBlur={(e: any) => console.log(`'${e.target.value}' blurred`)}
       tooltip={text('tooltip', 'Here there be radio buttons')}
@@ -39,7 +39,7 @@ radioGroupStories.add('With Values', () => {
         name="youAreGroupTwo"
         label="Controller"
         value={value}
-        onChange={(name, value) => setValue(value)}
+        onChange={(e: any) => setValue(e.target.value)}
       >
         <RadioGroup.Button label="Empty" value="" />
         <RadioGroup.Button label={<sup>Strong</sup>} value="strong" />

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
@@ -16,8 +16,8 @@ radioGroupStories.add(
       label={text('label', 'A Label')}
       disabled={boolean('disabled', false)}
       onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
-      onFocus={(name) => console.log(`'${name}' focused`)}
-      onBlur={(name) => console.log(`'${name}' blurred`)}
+      onFocus={(e: any) => console.log(`'${e.target.value}' focused`)}
+      onBlur={(e: any) => console.log(`'${e.target.value}' blurred`)}
       tooltip={text('tooltip', 'Here there be radio buttons')}
       error={text('error', '')}
       success={text('success', '')}

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.test.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.test.tsx
@@ -17,6 +17,7 @@ describe('component: RadioGroup', (): void => {
           disabled={false}
           value="persephone"
           tooltip="Select your preferred realm"
+          onChange={() => undefined}
         >
           <RadioGroup.Button id="earth" label="Glebe" value="james" />
           <RadioGroup.Button id="life" label="Elysium" value="persephone" />
@@ -80,8 +81,10 @@ describe('component: RadioGroup', (): void => {
   })
 
   test('should trigger events', (): void => {
-    const onChange = jest.fn()
-    const onChangeOne = jest.fn()
+    const changes: [string, string][] = []
+    const onChange = jest.fn((e) => changes.push([e.target.name, e.target.value]))
+    const changeOne: [string, string][] = []
+    const onChangeOne = jest.fn((e) => changeOne.push([e.target.name, e.target.value]))
     const focusNames: string[] = []
     const onFocus = jest.fn((e) => focusNames.push(e.target.id))
     const focusOne: string[] = []
@@ -136,11 +139,11 @@ describe('component: RadioGroup', (): void => {
     expect(onBlur).toHaveBeenCalledTimes(2)
 
     userEvent.tab()
-    expect(onChange.mock.calls).toEqual([
+    expect(changes).toEqual([
       ['wizards', 'pyro'],
       ['wizards', 'persephone'],
     ])
-    expect(onChangeOne.mock.calls).toEqual([['wizards', 'pyro']])
+    expect(changeOne).toEqual([['wizards', 'pyro']])
     expect(focusNames).toEqual(['earth', 'fire', 'life'])
     expect(focusOne).toEqual(['earth'])
     expect(blurNames).toEqual(['earth', 'fire', 'life'])

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.test.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.test.tsx
@@ -82,9 +82,12 @@ describe('component: RadioGroup', (): void => {
   test('should trigger events', (): void => {
     const onChange = jest.fn()
     const onChangeOne = jest.fn()
-    const onFocus = jest.fn()
-    const onFocusOne = jest.fn()
-    const onBlur = jest.fn()
+    const focusNames: string[] = []
+    const onFocus = jest.fn((e) => focusNames.push(e.target.id))
+    const focusOne: string[] = []
+    const onFocusOne = jest.fn((e) => focusOne.push(e.target.id))
+    const blurNames: string[] = []
+    const onBlur = jest.fn((e) => blurNames.push(e.target.id))
     const { getByLabelText } = render(
       <StyleProvider>
         <RadioGroup
@@ -121,16 +124,16 @@ describe('component: RadioGroup', (): void => {
     userEvent.click(getByLabelText('Sorcha'))
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChangeOne).toHaveBeenCalledTimes(1)
-    expect(onFocus).toHaveBeenCalledTimes(1)
+    expect(onFocus).toHaveBeenCalledTimes(2)
     expect(onFocusOne).toHaveBeenCalledTimes(1)
-    expect(onBlur).not.toHaveBeenCalled()
+    expect(onBlur).toHaveBeenCalledTimes(1)
 
     userEvent.click(getByLabelText('Yogo'))
     expect(onChange).toHaveBeenCalledTimes(2)
     expect(onChangeOne).toHaveBeenCalledTimes(1)
-    expect(onFocus).toHaveBeenCalledTimes(1)
+    expect(onFocus).toHaveBeenCalledTimes(3)
     expect(onFocusOne).toHaveBeenCalledTimes(1)
-    expect(onBlur).not.toHaveBeenCalled()
+    expect(onBlur).toHaveBeenCalledTimes(2)
 
     userEvent.tab()
     expect(onChange.mock.calls).toEqual([
@@ -138,8 +141,8 @@ describe('component: RadioGroup', (): void => {
       ['wizards', 'persephone'],
     ])
     expect(onChangeOne.mock.calls).toEqual([['wizards', 'pyro']])
-    expect(onFocus.mock.calls).toEqual([['wizards']])
-    expect(onFocusOne.mock.calls).toEqual([['wizards']])
-    expect(onBlur.mock.calls).toEqual([['wizards']])
+    expect(focusNames).toEqual(['earth', 'fire', 'life'])
+    expect(focusOne).toEqual(['earth'])
+    expect(blurNames).toEqual(['earth', 'fire', 'life'])
   })
 })

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
@@ -5,28 +5,22 @@ import { MarginProps, WidthProps } from 'styled-system'
 import { FieldProps, useAccessibleField } from '../AccessibleField/AccessibleField'
 import Box from '../Box/Box'
 import Fieldset from '../Fieldset/Fieldset'
-import handleEvent from '../helpers/eventHandler'
 import { cloneAll } from '../helpers/react'
 import Label from '../Label/Label'
 import RadioButtonField, { RadioButtonFieldProps } from '../RadioButtonField/RadioButtonField'
 import StatusMessage from '../StatusMessage/StatusMessage'
 import Tooltip from '../Tooltip/Tooltip'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
 interface RadioGroupProps
   extends MarginProps,
     WidthProps,
     Omit<FieldProps, 'labelProps'>,
-    Omit<
-      React.FieldsetHTMLAttributes<HTMLFieldSetElement>,
-      'name' | 'onChange' | 'onFocus' | 'onBlur'
-    > {
+    Omit<React.FieldsetHTMLAttributes<HTMLFieldSetElement>, 'name' | 'onChange'> {
   value?: string | number
   defaultValue?: string | number
   required?: boolean
   onChange?: FieldOnChangeHandler<string>
-  onFocus?: FieldOnFocusHandler
-  onBlur?: FieldOnBlurHandler
 }
 
 // This allows omitting the required `name` prop, since it'll be injected by the RadioGroup.
@@ -105,21 +99,21 @@ export const RadioGroup = React.forwardRef<HTMLFieldSetElement, RadioGroupProps>
     )
     const handleFocus = React.useCallback(
       (e: React.FocusEvent<HTMLFieldSetElement>) => {
+        onFocus?.(e)
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-          handleEvent(onFocus, name)
           setTooltipVisible(() => true)
         }
       },
-      [onFocus, name, setTooltipVisible]
+      [onFocus, setTooltipVisible]
     )
     const handleBlur = React.useCallback(
       (e: React.FocusEvent<HTMLFieldSetElement>) => {
+        onBlur?.(e)
         if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-          handleEvent(onBlur, name)
           setTooltipVisible(() => false)
         }
       },
-      [onBlur, name, setTooltipVisible]
+      [onBlur, setTooltipVisible]
     )
 
     return (
@@ -173,8 +167,6 @@ RadioGroup.propTypes = {
   warning: PropTypes.node,
   error: PropTypes.node,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
   value: function (props: Record<string, any>): Error | null {
     if (props.value !== undefined) {
       const proptype = typeof props.value

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
@@ -34,6 +34,8 @@ type ForwardProps = {
   required?: boolean
 }
 
+const noop = () => undefined
+
 export const RadioGroup = React.forwardRef<HTMLFieldSetElement, RadioGroupProps>(
   (
     {
@@ -85,7 +87,7 @@ export const RadioGroup = React.forwardRef<HTMLFieldSetElement, RadioGroupProps>
       // This is to avert a PropTypes warning regarding missing onChange handler.
       const hasChecked = props.checked !== undefined || element.props.checked !== undefined
       if (hasChecked && hasOnChange && !element.props.onChange) {
-        props = { ...props, onChange: () => undefined }
+        props = { ...props, onChange: noop }
       }
       return React.cloneElement(element, props)
     }

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.mdx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.mdx
@@ -38,8 +38,8 @@ import { Button, TextAreaField } from '@repay/cactus-web'
 export default function Form() {
   const [values, setValues] = useState({ textArea: '' })
   const handleChange = useCallback(
-    (name, value) => {
-      setValues(state => setValues({ ...state, [name]: value }))
+    (e) => {
+      setValues(state => ({ ...state, [e.target.name]: e.target.value }))
     },
     [setValues]
   )

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -6,14 +6,11 @@ import { margin, MarginProps } from 'styled-system'
 import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import { omitMargins } from '../helpers/omit'
 import TextArea, { TextAreaProps } from '../TextArea/TextArea'
-import { FieldOnChangeHandler } from '../types'
 
 interface TextAreaFieldProps
   extends MarginProps,
     FieldProps,
-    Omit<TextAreaProps, 'name' | 'status' | 'onChange'> {
-  onChange?: FieldOnChangeHandler<string>
-}
+    Omit<TextAreaProps, 'name' | 'status'> {}
 
 const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
   const {
@@ -24,23 +21,12 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
     warning,
     error,
     tooltip,
-    onChange,
     name,
     id,
     disabled,
     autoTooltip,
     ...textAreaProps
   } = omitMargins(props) as Omit<TextAreaFieldProps, keyof MarginProps>
-
-  const handleChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
-      if (typeof onChange === 'function') {
-        const currentTarget = (event.currentTarget as unknown) as HTMLTextAreaElement
-        onChange(name, currentTarget.value)
-      }
-    },
-    [onChange, name]
-  )
 
   return (
     <AccessibleField
@@ -62,7 +48,6 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
           id={fieldId}
           width="100%"
           status={status}
-          onChange={handleChange}
           aria-describedby={ariaDescribedBy}
           name={name}
           {...textAreaProps}
@@ -87,7 +72,6 @@ TextAreaField.propTypes = {
   error: PropTypes.string,
   tooltip: PropTypes.string,
   value: PropTypes.string,
-  onChange: PropTypes.func,
 }
 
 TextAreaField.defaultProps = {

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -4,18 +4,15 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
-import handleEvent from '../helpers/eventHandler'
 import { omitMargins } from '../helpers/omit'
 import TextArea, { TextAreaProps } from '../TextArea/TextArea'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
 interface TextAreaFieldProps
   extends MarginProps,
     FieldProps,
-    Omit<TextAreaProps, 'name' | 'status' | 'onChange' | 'onFocus' | 'onBlur'> {
+    Omit<TextAreaProps, 'name' | 'status' | 'onChange'> {
   onChange?: FieldOnChangeHandler<string>
-  onFocus?: FieldOnFocusHandler
-  onBlur?: FieldOnBlurHandler
 }
 
 const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
@@ -28,8 +25,6 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
     error,
     tooltip,
     onChange,
-    onFocus,
-    onBlur,
     name,
     id,
     disabled,
@@ -46,14 +41,6 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
     },
     [onChange, name]
   )
-
-  const handleFocus = (): void => {
-    handleEvent(onFocus, name)
-  }
-
-  const handleBlur = (): void => {
-    handleEvent(onBlur, name)
-  }
 
   return (
     <AccessibleField
@@ -76,8 +63,6 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
           width="100%"
           status={status}
           onChange={handleChange}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           aria-describedby={ariaDescribedBy}
           name={name}
           {...textAreaProps}
@@ -103,8 +88,6 @@ TextAreaField.propTypes = {
   tooltip: PropTypes.string,
   value: PropTypes.string,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
 }
 
 TextAreaField.defaultProps = {

--- a/modules/cactus-web/src/TextInputField/TextInputField.mdx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.mdx
@@ -11,7 +11,7 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 # TextInputField
 
-The `TextInputField` is a combination of `TextInput`, `Label`, and some handy tools to make integrating this filed into a form easier.
+The `TextInputField` is a combination of `TextInput`, `Label`, and some handy tools to make integrating this field into a form easier.
 
 ### Try it out
 
@@ -38,8 +38,8 @@ import { Button, TextInputField } from '@repay/cactus-web'
 export default function Form() {
   const [values, setValues] = useState({ input: '' })
   const handleChange = useCallback(
-    (name, value) => {
-      setValues(state => setValues({ ...state, name: value }))
+    (e) => {
+      setValues(state => ({ ...state, [e.target.name]: e.target.value }))
     },
     [setValues]
   )

--- a/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
@@ -1,4 +1,3 @@
-import { actions } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React, { useState } from 'react'
@@ -6,7 +5,11 @@ import React, { useState } from 'react'
 import TextInputField from './TextInputField'
 
 const textInputFieldStories = storiesOf('TextInputField', module)
-const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
+const eventLoggers = {
+  onChange: (e: any) => console.log(`onChange '${e.target.name}': ${e.target.value}`),
+  onFocus: (e: any) => console.log('onFocus:', e.target.name),
+  onBlur: (e: any) => console.log('onBlur:', e.target.name),
+}
 
 const InputValidator = (): React.ReactElement => {
   const [input, setInput] = useState('')
@@ -18,7 +21,7 @@ const InputValidator = (): React.ReactElement => {
       name="input"
       label="Type Something"
       tooltip="You must type more than 5 characters"
-      onChange={(_, value): void => setInput(value)}
+      onChange={(e) => setInput(e.target.value)}
       success={success}
     />
   )

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -6,14 +6,11 @@ import { margin, MarginProps } from 'styled-system'
 import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import { omitMargins } from '../helpers/omit'
 import { TextInput, TextInputProps } from '../TextInput/TextInput'
-import { FieldOnChangeHandler } from '../types'
 
 interface TextInputFieldProps
   extends MarginProps,
     FieldProps,
-    Omit<TextInputProps, 'name' | 'status' | 'onChange'> {
-  onChange?: FieldOnChangeHandler<string>
-}
+    Omit<TextInputProps, 'name' | 'status'> {}
 
 const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
   const {
@@ -26,21 +23,10 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
     warning,
     error,
     tooltip,
-    onChange,
     disabled,
     autoTooltip,
     ...inputProps
   } = omitMargins(props) as Omit<TextInputFieldProps, keyof MarginProps>
-
-  const handleChange = React.useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>): void => {
-      if (typeof onChange === 'function') {
-        const currentTarget = (event.currentTarget as unknown) as HTMLInputElement
-        onChange(name, currentTarget.value)
-      }
-    },
-    [onChange, name]
-  )
 
   return (
     <AccessibleField
@@ -63,7 +49,6 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
           id={fieldId}
           width="100%"
           status={status}
-          onChange={handleChange}
           name={name}
           aria-describedby={ariaDescribedBy}
         />
@@ -86,7 +71,6 @@ TextInputField.propTypes = {
   warning: PropTypes.string,
   error: PropTypes.string,
   tooltip: PropTypes.string,
-  onChange: PropTypes.func,
 }
 
 TextInputField.defaultProps = {

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -4,18 +4,15 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
-import handleEvent from '../helpers/eventHandler'
 import { omitMargins } from '../helpers/omit'
 import { TextInput, TextInputProps } from '../TextInput/TextInput'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
 interface TextInputFieldProps
   extends MarginProps,
     FieldProps,
-    Omit<TextInputProps, 'name' | 'status' | 'onChange' | 'onFocus' | 'onBlur'> {
+    Omit<TextInputProps, 'name' | 'status' | 'onChange'> {
   onChange?: FieldOnChangeHandler<string>
-  onFocus?: FieldOnFocusHandler
-  onBlur?: FieldOnBlurHandler
 }
 
 const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
@@ -30,8 +27,6 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
     error,
     tooltip,
     onChange,
-    onFocus,
-    onBlur,
     disabled,
     autoTooltip,
     ...inputProps
@@ -46,14 +41,6 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
     },
     [onChange, name]
   )
-
-  const handleFocus = (): void => {
-    handleEvent(onFocus, name)
-  }
-
-  const handleBlur = (): void => {
-    handleEvent(onBlur, name)
-  }
 
   return (
     <AccessibleField
@@ -77,8 +64,6 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
           width="100%"
           status={status}
           onChange={handleChange}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           name={name}
           aria-describedby={ariaDescribedBy}
         />
@@ -102,8 +87,6 @@ TextInputField.propTypes = {
   error: PropTypes.string,
   tooltip: PropTypes.string,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
 }
 
 TextInputField.defaultProps = {

--- a/modules/cactus-web/src/Toggle/Toggle.mdx
+++ b/modules/cactus-web/src/Toggle/Toggle.mdx
@@ -7,21 +7,18 @@ import PropsTable from 'website-src/components/PropsTable'
 import { livePreviewStyle } from '../helpers/constants'
 import Toggle from './Toggle'
 import cactusTheme from '@repay/cactus-theme'
-import React, { useState } from 'react'
+import React from 'react'
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 # Toggle
 
-The `Toggle` component can be useful for boolean fields.
+The `Toggle` component can be useful for boolean fields. Props & behavior are basically the same as a checkbox.
 
 ### Try it out
 
-export const code = ` () => {
-  const [state, setState] = useState(true)
-  return <Toggle value={state} onClick={() => setState(!state)} />
-}`
+export const code = `<Toggle />`
 
-<LiveProvider code={code} scope={{ Toggle, useState }}>
+<LiveProvider code={code} scope={{ Toggle }}>
   <LiveEditor style={livePreviewStyle} />
   <LiveError />
   <LivePreview />
@@ -44,10 +41,10 @@ export const code = ` () => {
 import { Toggle } from '@repay/cactus-web'
 ...
 // Basic usage
-<Toggle value={false} />
+<Toggle defaultChecked={false} />
 
 // Disabled
-<Toggle value={true} disabled={true} />
+<Toggle disabled />
 ```
 
 ## Properties

--- a/modules/cactus-web/src/Toggle/Toggle.story.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.story.tsx
@@ -6,31 +6,21 @@ import Toggle from './Toggle'
 
 const toggleStories = storiesOf('Toggle', module)
 
-const initialState = { value: false }
-type State = Readonly<typeof initialState>
-
-class ToggleManager extends React.Component {
-  public readonly state: State = initialState
-  private handleToggle = (): void => {
-    this.setState({
-      value: !this.state.value,
-    })
-  }
-  public render(): React.ReactElement {
-    return (
-      <Toggle
-        value={this.state.value}
-        onClick={this.handleToggle}
-        disabled={boolean('disabled', false)}
-        {...this.props}
-      />
-    )
-  }
+const ToggleManager = (props: any) => {
+  const [checked, setChecked] = React.useState<boolean>(false)
+  const onChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      console.log(`onChange '${e.target.name}': ${e.target.checked}`)
+      setChecked(e.target.checked)
+    },
+    [setChecked]
+  )
+  return <Toggle {...props} checked={checked} onChange={onChange} />
 }
 
 toggleStories.add(
   'Basic Usage',
   (): React.ReactElement => {
-    return <ToggleManager />
+    return <ToggleManager disabled={boolean('Disabled', false)} />
   }
 )

--- a/modules/cactus-web/src/Toggle/Toggle.test.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.test.tsx
@@ -1,17 +1,20 @@
 import { generateTheme } from '@repay/cactus-theme'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import pick from 'lodash/pick'
 import * as React from 'react'
 
 import { StyleProvider } from '../StyleProvider/StyleProvider'
 import Toggle from './Toggle'
 
-afterEach(cleanup)
+// Use this to avoid PropTypes error regarding readonly field.
+const noop = () => undefined
 
 describe('component: Toggle', (): void => {
   test('should render a toggle', (): void => {
     const toggle = render(
       <StyleProvider>
-        <Toggle value={false} />
+        <Toggle checked={false} onChange={noop} />
       </StyleProvider>
     )
 
@@ -21,17 +24,17 @@ describe('component: Toggle', (): void => {
   test('should render a disabled toggle', (): void => {
     const toggle = render(
       <StyleProvider>
-        <Toggle value={false} disabled={true} />
+        <Toggle checked={false} disabled={true} />
       </StyleProvider>
     )
 
     expect(toggle.asFragment()).toMatchSnapshot()
   })
 
-  test('should initialize value to true', (): void => {
+  test('should initialize checked to true', (): void => {
     const toggle = render(
       <StyleProvider>
-        <Toggle value={true} />
+        <Toggle checked={true} onChange={noop} />
       </StyleProvider>
     )
 
@@ -41,35 +44,37 @@ describe('component: Toggle', (): void => {
   test('should support margin space props', (): void => {
     const toggle = render(
       <StyleProvider>
-        <Toggle value={false} marginBottom={4} />
+        <Toggle checked={false} marginBottom={4} onChange={noop} />
       </StyleProvider>
     )
 
     expect(toggle.asFragment()).toMatchSnapshot()
   })
 
-  test('should trigger onClick event', (): void => {
-    const onClick = jest.fn()
-    const { getByTestId } = render(
+  test('should trigger onChange event', (): void => {
+    const box: any = {}
+    const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['id', 'checked'])))
+    const { container } = render(
       <StyleProvider>
-        <Toggle value={false} onClick={onClick} data-testid="will-click" />
+        <Toggle checked={false} onChange={onChange} id="will-change" />
       </StyleProvider>
     )
 
-    fireEvent.click(getByTestId('will-click'))
-    expect(onClick).toHaveBeenCalled()
+    userEvent.click(container.querySelector('#will-change') as Element)
+    expect(onChange).toHaveBeenCalled()
+    expect(box).toEqual({ id: 'will-change', checked: true })
   })
 
-  test('should not trigger onClick event', (): void => {
-    const onClick = jest.fn()
+  test('should not trigger onChange event', (): void => {
+    const onChange = jest.fn()
     const { getByTestId } = render(
       <StyleProvider>
-        <Toggle value={false} onClick={onClick} disabled={true} data-testid="will-not-click" />
+        <Toggle disabled onChange={onChange} data-testid="will-not-change" />
       </StyleProvider>
     )
 
-    fireEvent.click(getByTestId('will-not-click'))
-    expect(onClick).not.toHaveBeenCalled()
+    userEvent.click(getByTestId('will-not-change'))
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   describe('with theme customization', (): void => {

--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -4,61 +4,96 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { omitMargins } from '../helpers/omit'
+import { extractMargins } from '../helpers/omit'
 import { boxShadow } from '../helpers/theme'
-import { Omit } from '../types'
 
-export interface ToggleProps
-  extends Omit<
-      React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-      'value' | 'ref'
-    >,
-    MarginProps {
-  value?: boolean
+export interface ToggleProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
+  checked?: boolean
   disabled?: boolean
 }
 
-const ToggleBase = (props: ToggleProps): React.ReactElement => {
-  const componentProps = omitMargins(props)
-  const { value, ...toggleProps } = componentProps
-  return (
-    <button type="button" role="switch" aria-checked={value} {...toggleProps}>
-      <StyledX aria-hidden="true" />
-      <StyledCheck aria-hidden="true" />
-    </button>
-  )
-}
+export const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
+  ({ className, ...props }, ref) => {
+    const marginProps = extractMargins(props)
+    return (
+      <Wrapper {...marginProps} className={className} role="none">
+        <Checkbox {...props} role="switch" aria-checked={props.checked} ref={ref} />
+        <Switch aria-hidden />
+        <StyledX aria-hidden />
+        <StyledCheck aria-hidden />
+      </Wrapper>
+    )
+  }
+)
+
+const Checkbox = styled.input.attrs({ type: 'checkbox' as string })`
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+  :disabled {
+    cursor: not-allowed;
+  }
+`
 
 const StyledX = styled(NavigationClose)`
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: ${(p): string => p.theme.colors.white};
+  opacity: 1;
+  transition: opacity 0.3s;
+  input:checked ~ & {
+    opacity: 0;
+  }
 `
 
 const StyledCheck = styled(StatusCheck)`
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: ${(p): string => p.theme.colors.white};
+  opacity: 0;
+  transition: opacity 0.3s;
+  input:checked ~ & {
+    opacity: 1;
+  }
 `
 
-export const Toggle = styled(ToggleBase)`
+const Wrapper = styled.div`
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
-  background-color: ${(p): string =>
-    p.disabled ? p.theme.colors.lightGray : p.theme.colors.error};
-  border: 1px solid ${(p): string => (p.disabled ? p.theme.colors.lightGray : p.theme.colors.error)};
-  cursor: ${(p): string => (p.disabled ? 'cursor' : 'pointer')};
+  ${margin}
+`
 
-  &:focus {
+const Switch = styled.div`
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
+  background-color: ${(p) => p.theme.colors.error};
+  cursor: pointer;
+  input:disabled ~ & {
+    background-color: ${(p) => p.theme.colors.lightGray};
+    cursor: cursor;
+    opacity: 0.5;
+  }
+
+  input:focus ~ & {
     ${(p): string => boxShadow(p.theme, 1)};
   }
 
@@ -67,56 +102,33 @@ export const Toggle = styled(ToggleBase)`
     height: 26px;
     border-radius: 50%;
     content: '';
-    top: -1px;
-    left: -1px;
+    top: 0;
+    left: 0;
     position: absolute;
-    transition: transform 0.3s;
+    transition: left 0.3s;
     background-color: ${(p): string => p.theme.colors.white};
     box-shadow: 0 0 3px ${(p): string => p.theme.colors.darkestContrast};
   }
 
-  &[aria-checked='true'] {
+  input:checked ~ & {
     background-color: ${(p): string => p.theme.colors.success};
-    border-color: ${(p): string => p.theme.colors.success};
 
     ::after {
-      transform: translateX(26px);
-    }
-
-    ${StyledX} {
-      opacity: 0;
-    }
-
-    ${StyledCheck} {
-      opacity: 1;
+      left: 26px;
     }
   }
-
-  ${StyledX} {
-    opacity: 1;
-    transition: opacity 0.3s;
-  }
-
-  ${StyledCheck} {
-    opacity: 0;
-    transition: opacity 0.3s;
-  }
-
-  &[disabled] {
-    opacity: 0.5;
-  }
-
-  ${margin}
 `
 
-// @ts-ignore
 Toggle.propTypes = {
-  value: PropTypes.bool,
+  checked: PropTypes.bool,
   disabled: PropTypes.bool,
 }
 
 Toggle.defaultProps = {
   disabled: false,
 }
+
+// Enable use of `Toggle` as a styled-components CSS class.
+Toggle.toString = Wrapper.toString
 
 export default Toggle

--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -130,5 +130,6 @@ Toggle.defaultProps = {
 
 // Enable use of `Toggle` as a styled-components CSS class.
 Toggle.toString = Wrapper.toString
+Toggle.displayName = 'Toggle'
 
 export default Toggle

--- a/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/modules/cactus-web/src/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -1,15 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`component: Toggle should initialize value to true 1`] = `
+exports[`component: Toggle should initialize checked to true 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c1:disabled {
+  cursor: not-allowed;
+}
+
+.c3 {
   vertical-align: middle;
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c3 {
+  opacity: 0;
 }
 
 .c4 {
@@ -17,85 +40,87 @@ exports[`component: Toggle should initialize value to true 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c4 {
+  opacity: 1;
 }
 
 .c0 {
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
+}
+
+.c2 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
   background-color: hsl(353,84%,44%);
-  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
-.c0:focus {
+input:disabled ~ .c2 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+input:focus ~ .c2 {
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c0::after {
+.c2::after {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   content: '';
-  top: -1px;
-  left: -1px;
+  top: 0;
+  left: 0;
   position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
   background-color: hsl(0,0%,100%);
   box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
-.c0[aria-checked='true'] {
+input:checked ~ .c2 {
   background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
 }
 
-.c0[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+input:checked ~ .c2::after {
+  left: 26px;
 }
 
-.c0[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c0[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c0 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0[disabled] {
-  opacity: 0.5;
-}
-
-<button
-    aria-checked="true"
+<div
     class="c0"
-    role="switch"
-    type="button"
+    role="none"
   >
+    <input
+      aria-checked="true"
+      checked=""
+      class="c1"
+      role="switch"
+      type="checkbox"
+    />
+    <div
+      aria-hidden="true"
+      class="c2"
+    />
     <svg
       aria-hidden="true"
-      class="sc-fzoxnE c1 c2"
+      class="sc-fzoxnE c3"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -107,7 +132,7 @@ exports[`component: Toggle should initialize value to true 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="sc-pZBmh c3 c4"
+      class="sc-pZBmh c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -117,20 +142,43 @@ exports[`component: Toggle should initialize value to true 1`] = `
         d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
       />
     </svg>
-  </button>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`component: Toggle should render a disabled toggle 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c1:disabled {
+  cursor: not-allowed;
+}
+
+.c3 {
   vertical-align: middle;
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c3 {
+  opacity: 0;
 }
 
 .c4 {
@@ -138,86 +186,87 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c4 {
+  opacity: 1;
 }
 
 .c0 {
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
-  background-color: hsl(0,0%,90%);
-  border: 1px solid hsl(0,0%,90%);
-  cursor: cursor;
 }
 
-.c0:focus {
+.c2 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
+  background-color: hsl(353,84%,44%);
+  cursor: pointer;
+}
+
+input:disabled ~ .c2 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+input:focus ~ .c2 {
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c0::after {
+.c2::after {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   content: '';
-  top: -1px;
-  left: -1px;
+  top: 0;
+  left: 0;
   position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
   background-color: hsl(0,0%,100%);
   box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
-.c0[aria-checked='true'] {
+input:checked ~ .c2 {
   background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
 }
 
-.c0[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+input:checked ~ .c2::after {
+  left: 26px;
 }
 
-.c0[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c0[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c0 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0[disabled] {
-  opacity: 0.5;
-}
-
-<button
-    aria-checked="false"
+<div
     class="c0"
-    disabled=""
-    role="switch"
-    type="button"
+    role="none"
   >
+    <input
+      aria-checked="false"
+      class="c1"
+      disabled=""
+      role="switch"
+      type="checkbox"
+    />
+    <div
+      aria-hidden="true"
+      class="c2"
+    />
     <svg
       aria-hidden="true"
-      class="sc-fzoxnE c1 c2"
+      class="sc-fzoxnE c3"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -229,7 +278,7 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="sc-pZBmh c3 c4"
+      class="sc-pZBmh c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -239,20 +288,43 @@ exports[`component: Toggle should render a disabled toggle 1`] = `
         d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
       />
     </svg>
-  </button>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`component: Toggle should render a toggle 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c1:disabled {
+  cursor: not-allowed;
+}
+
+.c3 {
   vertical-align: middle;
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c3 {
+  opacity: 0;
 }
 
 .c4 {
@@ -260,85 +332,86 @@ exports[`component: Toggle should render a toggle 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c4 {
+  opacity: 1;
 }
 
 .c0 {
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
+}
+
+.c2 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
   background-color: hsl(353,84%,44%);
-  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
-.c0:focus {
+input:disabled ~ .c2 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+input:focus ~ .c2 {
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c0::after {
+.c2::after {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   content: '';
-  top: -1px;
-  left: -1px;
+  top: 0;
+  left: 0;
   position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
   background-color: hsl(0,0%,100%);
   box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
-.c0[aria-checked='true'] {
+input:checked ~ .c2 {
   background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
 }
 
-.c0[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+input:checked ~ .c2::after {
+  left: 26px;
 }
 
-.c0[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c0[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c0 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0[disabled] {
-  opacity: 0.5;
-}
-
-<button
-    aria-checked="false"
+<div
     class="c0"
-    role="switch"
-    type="button"
+    role="none"
   >
+    <input
+      aria-checked="false"
+      class="c1"
+      role="switch"
+      type="checkbox"
+    />
+    <div
+      aria-hidden="true"
+      class="c2"
+    />
     <svg
       aria-hidden="true"
-      class="sc-fzoxnE c1 c2"
+      class="sc-fzoxnE c3"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -350,7 +423,7 @@ exports[`component: Toggle should render a toggle 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="sc-pZBmh c3 c4"
+      class="sc-pZBmh c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -360,20 +433,43 @@ exports[`component: Toggle should render a toggle 1`] = `
         d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
       />
     </svg>
-  </button>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`component: Toggle should support margin space props 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c1:disabled {
+  cursor: not-allowed;
+}
+
+.c3 {
   vertical-align: middle;
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c3 {
+  opacity: 0;
 }
 
 .c4 {
@@ -381,86 +477,87 @@ exports[`component: Toggle should support margin space props 1`] = `
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c4 {
+  opacity: 1;
 }
 
 .c0 {
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
-  background-color: hsl(353,84%,44%);
-  border: 1px solid hsl(353,84%,44%);
-  cursor: pointer;
   margin-bottom: 16px;
 }
 
-.c0:focus {
+.c2 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
+  background-color: hsl(353,84%,44%);
+  cursor: pointer;
+}
+
+input:disabled ~ .c2 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+input:focus ~ .c2 {
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c0::after {
+.c2::after {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   content: '';
-  top: -1px;
-  left: -1px;
+  top: 0;
+  left: 0;
   position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
   background-color: hsl(0,0%,100%);
   box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
-.c0[aria-checked='true'] {
+input:checked ~ .c2 {
   background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
 }
 
-.c0[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+input:checked ~ .c2::after {
+  left: 26px;
 }
 
-.c0[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c0[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c0 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0[disabled] {
-  opacity: 0.5;
-}
-
-<button
-    aria-checked="false"
+<div
     class="c0"
-    role="switch"
-    type="button"
+    role="none"
   >
+    <input
+      aria-checked="false"
+      class="c1"
+      role="switch"
+      type="checkbox"
+    />
+    <div
+      aria-hidden="true"
+      class="c2"
+    />
     <svg
       aria-hidden="true"
-      class="sc-fzoxnE c1 c2"
+      class="sc-fzoxnE c3"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -472,7 +569,7 @@ exports[`component: Toggle should support margin space props 1`] = `
     </svg>
     <svg
       aria-hidden="true"
-      class="sc-pZBmh c3 c4"
+      class="sc-pZBmh c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -482,20 +579,43 @@ exports[`component: Toggle should support margin space props 1`] = `
         d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
       />
     </svg>
-  </button>
+  </div>
 </DocumentFragment>
 `;
 
 exports[`component: Toggle with theme customization should not have box shadows on focus 1`] = `
 <DocumentFragment>
-  .c2 {
+  .c1 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c1:disabled {
+  cursor: not-allowed;
+}
+
+.c3 {
   vertical-align: middle;
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c3 {
+  opacity: 0;
 }
 
 .c4 {
@@ -503,80 +623,81 @@ exports[`component: Toggle with theme customization should not have box shadows 
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c4 {
+  opacity: 1;
 }
 
 .c0 {
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
+}
+
+.c2 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
   background-color: hsl(353,84%,44%);
-  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
-.c0::after {
+input:disabled ~ .c2 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+.c2::after {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   content: '';
-  top: -1px;
-  left: -1px;
+  top: 0;
+  left: 0;
   position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
   background-color: hsl(0,0%,100%);
   box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
-.c0[aria-checked='true'] {
+input:checked ~ .c2 {
   background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
 }
 
-.c0[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+input:checked ~ .c2::after {
+  left: 26px;
 }
 
-.c0[aria-checked='true'] .c1 {
-  opacity: 0;
-}
-
-.c0[aria-checked='true'] .c3 {
-  opacity: 1;
-}
-
-.c0 .c1 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0 .c3 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c0[disabled] {
-  opacity: 0.5;
-}
-
-<button
+<div
     class="c0"
-    role="switch"
-    type="button"
+    role="none"
   >
+    <input
+      class="c1"
+      role="switch"
+      type="checkbox"
+    />
+    <div
+      aria-hidden="true"
+      class="c2"
+    />
     <svg
       aria-hidden="true"
-      class="sc-fzoxnE c1 c2"
+      class="sc-fzoxnE c3"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -588,7 +709,7 @@ exports[`component: Toggle with theme customization should not have box shadows 
     </svg>
     <svg
       aria-hidden="true"
-      class="sc-pZBmh c3 c4"
+      class="sc-pZBmh c4"
       fill="currentcolor"
       height="1em"
       viewBox="0 0 24 24"
@@ -598,6 +719,6 @@ exports[`component: Toggle with theme customization should not have box shadows 
         d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
       />
     </svg>
-  </button>
+  </div>
 </DocumentFragment>
 `;

--- a/modules/cactus-web/src/ToggleField/ToggleField.mdx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.mdx
@@ -20,8 +20,8 @@ export const code = `() => {
     <ToggleField
       name="enabled"
       label={state ? 'On' : 'Off'}
-      value={state}
-      onClick={() => setState(!state)}
+      checked={state}
+      onChange={(e) => setState(e.target.checked)}
     />
   )
 }`
@@ -33,17 +33,11 @@ export const code = `() => {
 </LiveProvider>
 <Wrapper />
 
-The ToggleField is a Field component to be used in a Form, is composed of a [`Toggle`](../Toggle.mdx) and a `Label` and requires a `name` and `label`. It also implements our standardized `FieldChangeHandler` interface defined as:
-
-```ts
-type FieldOnChangeHandler<ValueType> = (fieldName: string, fieldValue: ValueType) => void
-```
-
-`ValueType` is a `boolean` for Toggles.
+The ToggleField is a Field component to be used in a Form, is composed of a [`Toggle`](../Toggle.mdx) and a `Label` and requires a `name` and `label`.
 
 ## Best practices
 
-The Toggle cannot manage it's own state, therefore this field **must** be controlled via an onChange handler and value. Any provided `id` will be automatically added to the label and toggle for accessibility; if an id is not provided, one will be created.
+Any provided `id` will be automatically added to the label and toggle for accessibility; if an id is not provided, one will be created.
 
 ## Basic usage
 
@@ -54,8 +48,8 @@ import { Button, ToggleField } from '@repay/cactus-web'
 export default function Form() {
   const [values, setValues] = useState({ enabled: false })
   const handleChange = useCallback(
-    (name, value) => {
-      setValues(state => setValues({ ...state, [name]: value }))
+    (e) => {
+      setValues(state => ({ ...state, [e.target.name]: e.target.checked }))
     },
     [setValues]
   )
@@ -74,7 +68,7 @@ export default function Form() {
         name="enabled"
         label="Is Enabled"
         onChange={handleChange}
-        value={values.enabled}
+        checked={values.enabled}
       />
       <Button type="submit" variant="action">
         Submit

--- a/modules/cactus-web/src/ToggleField/ToggleField.story.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.story.tsx
@@ -1,27 +1,32 @@
-import { actions } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
-import FormHandler from '../storySupport/FormHandler'
 import ToggleField from './ToggleField'
 
-const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
+const eventLoggers = {
+  onClick: (e: any) => console.log(`onClick '${e.target.name}': ${e.target.checked}`),
+  onFocus: (e: any) => console.log('onFocus:', e.target.name),
+  onBlur: (e: any) => console.log('onBlur:', e.target.name),
+}
 
-storiesOf('ToggleField', module).add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <FormHandler defaultValue={false} onChange={(name: string, value: boolean): boolean => value}>
-      {({ value, onChange }): React.ReactElement => (
-        <ToggleField
-          name={text('name', 'boolean_field')}
-          label={text('label', 'Boolean Field')}
-          value={value}
-          onChange={onChange}
-          disabled={boolean('disabled', false)}
-          {...eventLoggers}
-        />
-      )}
-    </FormHandler>
+const ToggleHandler = (props: any) => {
+  const [checked, setChecked] = React.useState<boolean>(false)
+  const onChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      console.log(`onChange '${e.target.name}': ${e.target.checked}`)
+      setChecked(e.target.checked)
+    },
+    [setChecked]
   )
-)
+  return <ToggleField {...props} checked={checked} onChange={onChange} />
+}
+
+storiesOf('ToggleField', module).add('Basic Usage', () => (
+  <ToggleHandler
+    name={text('name', 'boolean_field')}
+    label={text('label', 'Boolean Field')}
+    disabled={boolean('disabled', false)}
+    {...eventLoggers}
+  />
+))

--- a/modules/cactus-web/src/ToggleField/ToggleField.test.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.test.tsx
@@ -1,27 +1,41 @@
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import pick from 'lodash/pick'
 import * as React from 'react'
 
 import { StyleProvider } from '../StyleProvider/StyleProvider'
 import ToggleField from './ToggleField'
 
-afterEach(cleanup)
+// Use this to avoid PropTypes error regarding readonly field.
+const noop = () => undefined
 
 describe('component: ToggleField', (): void => {
   test('snapshot', (): void => {
     const { container } = render(
       <StyleProvider>
-        <ToggleField id="static-id" name="is_enabled" label="Enabled" value={false} />
+        <ToggleField
+          id="static-id"
+          name="is_enabled"
+          label="Enabled"
+          checked={false}
+          onChange={noop}
+        />
       </StyleProvider>
     )
 
     expect(container).toMatchSnapshot()
   })
 
-  test('snapshot when value=true', (): void => {
+  test('snapshot when checked=true', (): void => {
     const { container } = render(
       <StyleProvider>
-        <ToggleField id="static-id" name="is_enabled" label="Enabled" value={true} />
+        <ToggleField
+          id="static-id"
+          name="is_enabled"
+          label="Enabled"
+          checked={true}
+          onChange={noop}
+        />
       </StyleProvider>
     )
 
@@ -31,7 +45,7 @@ describe('component: ToggleField', (): void => {
   test('snapshot when disabled', (): void => {
     const { container } = render(
       <StyleProvider>
-        <ToggleField id="static-id" name="is_enabled" label="Enabled" value={false} disabled />
+        <ToggleField id="static-id" name="is_enabled" label="Enabled" checked={false} disabled />
       </StyleProvider>
     )
 
@@ -41,7 +55,12 @@ describe('component: ToggleField', (): void => {
   test('should generate unique id when one is not provided', (): void => {
     const { getByLabelText } = render(
       <StyleProvider>
-        <ToggleField label="Show me the money" name="show-me-the-money" value={true} />
+        <ToggleField
+          label="Show me the money"
+          name="show-me-the-money"
+          checked={true}
+          onChange={noop}
+        />
       </StyleProvider>
     )
 
@@ -49,27 +68,35 @@ describe('component: ToggleField', (): void => {
   })
 
   test('should trigger onChange event with next value', (): void => {
-    const onChange = jest.fn()
+    const box: any = {}
+    const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['name', 'checked'])))
     const { getByLabelText } = render(
       <StyleProvider>
         <ToggleField
           label="Show me the money"
           name="show-me-the-money"
-          value={true}
+          checked={true}
           onChange={onChange}
         />
       </StyleProvider>
     )
 
     fireEvent.click(getByLabelText('Show me the money'))
-    expect(onChange).toHaveBeenCalledWith('show-me-the-money', false)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(box).toEqual({ name: 'show-me-the-money', checked: false })
   })
 
   test('should trigger onFocus event', (): void => {
     const onFocus = jest.fn()
     const { getByLabelText } = render(
       <StyleProvider>
-        <ToggleField label="Strange Nights" name="strange_nights" value={false} onFocus={onFocus} />
+        <ToggleField
+          label="Strange Nights"
+          name="strange_nights"
+          checked={false}
+          onFocus={onFocus}
+          onChange={noop}
+        />
       </StyleProvider>
     )
 
@@ -81,7 +108,13 @@ describe('component: ToggleField', (): void => {
     const onBlur = jest.fn()
     const { getByLabelText } = render(
       <StyleProvider>
-        <ToggleField label="Washed." name="washed" value={false} onBlur={onBlur} />
+        <ToggleField
+          label="Washed."
+          name="washed"
+          checked={false}
+          onBlur={onBlur}
+          onChange={noop}
+        />
       </StyleProvider>
     )
 
@@ -94,7 +127,7 @@ describe('component: ToggleField', (): void => {
       const onChange = jest.fn()
       const { getByLabelText } = render(
         <StyleProvider>
-          <ToggleField label="Flow" name="flow" value={false} onChange={onChange} disabled />
+          <ToggleField label="Flow" name="flow" checked={false} onChange={onChange} disabled />
         </StyleProvider>
       )
 
@@ -109,7 +142,7 @@ describe('component: ToggleField', (): void => {
           <ToggleField
             label="Not For Sale"
             name="not_for_sale"
-            value={true}
+            checked={true}
             onFocus={onFocus}
             disabled
           />

--- a/modules/cactus-web/src/ToggleField/ToggleField.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.tsx
@@ -1,78 +1,50 @@
 import PropTypes from 'prop-types'
 import * as React from 'react'
 import styled from 'styled-components'
-import { margin, MarginProps } from 'styled-system'
 
 import FieldWrapper from '../FieldWrapper/FieldWrapper'
-import { omitMargins } from '../helpers/omit'
+import { extractMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import Toggle, { ToggleProps } from '../Toggle/Toggle'
-import { FieldOnChangeHandler } from '../types'
 
-export interface ToggleFieldProps extends MarginProps, Omit<ToggleProps, 'id' | 'onChange'> {
+export interface ToggleFieldProps extends ToggleProps {
   label: React.ReactNode
   /** props to be passed to the Label element (available for accessibility considerations) */
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
   /** required for form state management */
   name: string
-  value?: boolean
-  /** !important */
+  checked?: boolean
   disabled?: boolean
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
-  onChange?: FieldOnChangeHandler<boolean>
 }
 
-const ToggleFieldBase = (props: ToggleFieldProps): React.ReactElement => {
-  const {
-    labelProps,
-    className,
-    label,
-    id,
-    name,
-    onChange,
-    onClick,
-    disabled,
-    ...toggleProps
-  } = omitMargins(props) as Omit<ToggleFieldProps, keyof MarginProps>
-  const fieldId = useId(id, name)
+export const ToggleField = React.forwardRef<HTMLInputElement, ToggleFieldProps>(
+  ({ className, disabled, id, label, labelProps, ...props }, ref): React.ReactElement => {
+    const marginProps = extractMargins(props)
+    const fieldId = useId(id, props.name)
 
-  const handleClick = React.useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>): void => {
-      if (typeof onClick === 'function') {
-        onClick(event)
-      }
-      if (typeof onChange === 'function') {
-        const currentTarget = (event.currentTarget as unknown) as HTMLButtonElement
-        onChange(name, currentTarget.getAttribute('aria-checked') !== 'true')
-      }
-    },
-    [onClick, onChange, name]
-  )
+    return (
+      <ToggleFieldWrapper {...marginProps} $disabled={disabled} className={className}>
+        <Toggle {...props} disabled={disabled} id={fieldId} ref={ref} />
+        <Label {...labelProps} htmlFor={fieldId}>
+          {label}
+        </Label>
+      </ToggleFieldWrapper>
+    )
+  }
+)
 
-  return (
-    <FieldWrapper className={className}>
-      <Toggle {...toggleProps} disabled={disabled} name={name} id={fieldId} onClick={handleClick} />
-      <Label {...props.labelProps} htmlFor={fieldId}>
-        {props.label}
-      </Label>
-    </FieldWrapper>
-  )
-}
-
-export const ToggleField = styled(ToggleFieldBase)`
-  ${margin}
-
+const ToggleFieldWrapper = styled(FieldWrapper)<{ $disabled?: boolean }>`
   ${Label} {
-    cursor: ${(p): string => (p.disabled ? 'not-allowed' : 'pointer')};
+    cursor: ${(p): string => (p.$disabled ? 'not-allowed' : 'pointer')};
     margin-left: 8px;
     line-height: 26px;
     vertical-align: -2px;
-    color: ${(p) => p.disabled && p.theme.colors.mediumGray};
+    ${(p) => p.$disabled && `color: ${p.theme.colors.mediumGray}`};
   }
 
-  ${Toggle} {
+  ${Toggle.toString()} {
     vertical-align: middle;
   }
 `
@@ -82,14 +54,12 @@ ToggleField.propTypes = {
   labelProps: PropTypes.object,
   id: PropTypes.string,
   name: PropTypes.string.isRequired,
-  value: PropTypes.bool,
+  checked: PropTypes.bool,
   disabled: PropTypes.bool,
-  onClick: PropTypes.func,
-  onChange: PropTypes.func,
 }
 
 ToggleField.defaultProps = {
-  value: false,
+  checked: false,
 }
 
 export default ToggleField

--- a/modules/cactus-web/src/ToggleField/ToggleField.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.tsx
@@ -62,4 +62,5 @@ ToggleField.defaultProps = {
   checked: false,
 }
 
+ToggleField.displayName = 'ToggleField'
 export default ToggleField

--- a/modules/cactus-web/src/ToggleField/ToggleField.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.tsx
@@ -4,16 +4,13 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import FieldWrapper from '../FieldWrapper/FieldWrapper'
-import handleEvent from '../helpers/eventHandler'
 import { omitMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import Toggle, { ToggleProps } from '../Toggle/Toggle'
-import { FieldOnBlurHandler, FieldOnChangeHandler, FieldOnFocusHandler, Omit } from '../types'
+import { FieldOnChangeHandler } from '../types'
 
-export interface ToggleFieldProps
-  extends MarginProps,
-    Omit<ToggleProps, 'id' | 'onChange' | 'onFocus' | 'onBlur'> {
+export interface ToggleFieldProps extends MarginProps, Omit<ToggleProps, 'id' | 'onChange'> {
   label: React.ReactNode
   /** props to be passed to the Label element (available for accessibility considerations) */
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
@@ -25,8 +22,6 @@ export interface ToggleFieldProps
   disabled?: boolean
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
   onChange?: FieldOnChangeHandler<boolean>
-  onFocus?: FieldOnFocusHandler
-  onBlur?: FieldOnBlurHandler
 }
 
 const ToggleFieldBase = (props: ToggleFieldProps): React.ReactElement => {
@@ -37,8 +32,6 @@ const ToggleFieldBase = (props: ToggleFieldProps): React.ReactElement => {
     id,
     name,
     onChange,
-    onFocus,
-    onBlur,
     onClick,
     disabled,
     ...toggleProps
@@ -58,25 +51,9 @@ const ToggleFieldBase = (props: ToggleFieldProps): React.ReactElement => {
     [onClick, onChange, name]
   )
 
-  const handleFocus = (): void => {
-    handleEvent(onFocus, name)
-  }
-
-  const handleBlur = (): void => {
-    handleEvent(onBlur, name)
-  }
-
   return (
     <FieldWrapper className={className}>
-      <Toggle
-        {...toggleProps}
-        disabled={disabled}
-        name={name}
-        id={fieldId}
-        onClick={handleClick}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-      />
+      <Toggle {...toggleProps} disabled={disabled} name={name} id={fieldId} onClick={handleClick} />
       <Label {...props.labelProps} htmlFor={fieldId}>
         {props.label}
       </Label>
@@ -100,7 +77,6 @@ export const ToggleField = styled(ToggleFieldBase)`
   }
 `
 
-// @ts-ignore
 ToggleField.propTypes = {
   label: PropTypes.node.isRequired,
   labelProps: PropTypes.object,
@@ -110,8 +86,6 @@ ToggleField.propTypes = {
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   onChange: PropTypes.func,
-  onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
 }
 
 ToggleField.defaultProps = {

--- a/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
+++ b/modules/cactus-web/src/ToggleField/__snapshots__/ToggleField.test.tsx.snap
@@ -1,15 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`component: ToggleField snapshot 1`] = `
-.c1 + .c0 {
-  margin-top: 16px;
-}
-
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
   color: hsl(200,10%,20%);
+}
+
+.c4 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c4:disabled {
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -17,99 +29,103 @@ exports[`component: ToggleField snapshot 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
 }
 
-.c8 {
+input:checked ~ .c6 {
+  opacity: 0;
+}
+
+.c7 {
   vertical-align: middle;
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
 }
 
-.c4 {
+input:checked ~ .c7 {
+  opacity: 1;
+}
+
+.c3 {
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
+}
+
+.c5 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
   background-color: hsl(353,84%,44%);
-  border: 1px solid hsl(353,84%,44%);
   cursor: pointer;
 }
 
-.c4:focus {
+input:disabled ~ .c5 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+input:focus ~ .c5 {
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c4::after {
+.c5::after {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   content: '';
-  top: -1px;
-  left: -1px;
+  top: 0;
+  left: 0;
   position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
   background-color: hsl(0,0%,100%);
   box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
-.c4[aria-checked='true'] {
+input:checked ~ .c5 {
   background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
 }
 
-.c4[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+input:checked ~ .c5::after {
+  left: 26px;
 }
 
-.c4[aria-checked='true'] .c5 {
-  opacity: 0;
+.c1 + .c0 {
+  margin-top: 16px;
 }
 
-.c4[aria-checked='true'] .c7 {
-  opacity: 1;
-}
-
-.c4 .c5 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c4 .c7 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c4[disabled] {
-  opacity: 0.5;
-}
-
-.c2 .c9 {
+.c1 .c8 {
   cursor: pointer;
   margin-left: 8px;
   line-height: 26px;
   vertical-align: -2px;
 }
 
-.c2 .c3 {
+.c1 .c2 {
   vertical-align: middle;
 }
 
 @media screen and (min-width:1024px) {
-  .c10 {
+  .c9 {
     font-size: 18px;
     line-height: 1.5;
   }
@@ -117,19 +133,27 @@ exports[`component: ToggleField snapshot 1`] = `
 
 <div>
   <div
-    class="c0 c1 c2"
+    class="sc-AxjAm c0 c1"
   >
-    <button
-      aria-checked="false"
-      class="c3 c4"
-      id="static-id"
-      name="is_enabled"
-      role="switch"
-      type="button"
+    <div
+      class="c2 c3"
+      role="none"
     >
+      <input
+        aria-checked="false"
+        class="c4"
+        id="static-id"
+        name="is_enabled"
+        role="switch"
+        type="checkbox"
+      />
+      <div
+        aria-hidden="true"
+        class="c5"
+      />
       <svg
         aria-hidden="true"
-        class="sc-fzoWqW c5 c6"
+        class="sc-fzoWqW c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -141,7 +165,7 @@ exports[`component: ToggleField snapshot 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="sc-paXsP c7 c8"
+        class="sc-paXsP c7"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -151,9 +175,196 @@ exports[`component: ToggleField snapshot 1`] = `
           d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
         />
       </svg>
-    </button>
+    </div>
     <label
-      class="c9 c10"
+      class="c8 c9"
+      for="static-id"
+    >
+      Enabled
+    </label>
+  </div>
+</div>
+`;
+
+exports[`component: ToggleField snapshot when checked=true 1`] = `
+.c9 {
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 600;
+  color: hsl(200,10%,20%);
+}
+
+.c4 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c4:disabled {
+  cursor: not-allowed;
+}
+
+.c6 {
+  vertical-align: middle;
+  width: 12px;
+  height: 12px;
+  position: absolute;
+  top: 7px;
+  right: 9px;
+  color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c6 {
+  opacity: 0;
+}
+
+.c7 {
+  vertical-align: middle;
+  width: 15px;
+  height: 15px;
+  position: absolute;
+  top: 5px;
+  left: 6px;
+  color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
+
+input:checked ~ .c7 {
+  opacity: 1;
+}
+
+.c3 {
+  display: inline-block;
+  position: relative;
+  width: 51px;
+  height: 26px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
+  outline: none;
+}
+
+.c5 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
+  background-color: hsl(353,84%,44%);
+  cursor: pointer;
+}
+
+input:disabled ~ .c5 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+input:focus ~ .c5 {
+  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
+}
+
+.c5::after {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  content: '';
+  top: 0;
+  left: 0;
+  position: absolute;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
+  background-color: hsl(0,0%,100%);
+  box-shadow: 0 0 3px hsl(200,10%,20%);
+}
+
+input:checked ~ .c5 {
+  background-color: hsl(145,89%,28%);
+}
+
+input:checked ~ .c5::after {
+  left: 26px;
+}
+
+.c1 + .c0 {
+  margin-top: 16px;
+}
+
+.c1 .c8 {
+  cursor: pointer;
+  margin-left: 8px;
+  line-height: 26px;
+  vertical-align: -2px;
+}
+
+.c1 .c2 {
+  vertical-align: middle;
+}
+
+@media screen and (min-width:1024px) {
+  .c9 {
+    font-size: 18px;
+    line-height: 1.5;
+  }
+}
+
+<div>
+  <div
+    class="sc-AxjAm c0 c1"
+  >
+    <div
+      class="c2 c3"
+      role="none"
+    >
+      <input
+        aria-checked="true"
+        checked=""
+        class="c4"
+        id="static-id"
+        name="is_enabled"
+        role="switch"
+        type="checkbox"
+      />
+      <div
+        aria-hidden="true"
+        class="c5"
+      />
+      <svg
+        aria-hidden="true"
+        class="sc-fzoWqW c6"
+        fill="currentcolor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M13.4142136,12 L22.7071068,21.2928932 C23.0976311,21.6834175 23.0976311,22.3165825 22.7071068,22.7071068 C22.3165825,23.0976311 21.6834175,23.0976311 21.2928932,22.7071068 L12,13.4142136 L2.70710678,22.7071068 C2.31658249,23.0976311 1.68341751,23.0976311 1.29289322,22.7071068 C0.902368927,22.3165825 0.902368927,21.6834175 1.29289322,21.2928932 L10.5857864,12 L1.29289322,2.70710678 C0.902368927,2.31658249 0.902368927,1.68341751 1.29289322,1.29289322 C1.68341751,0.902368927 2.31658249,0.902368927 2.70710678,1.29289322 L12,10.5857864 L21.2928932,1.29289322 C21.6834175,0.902368927 22.3165825,0.902368927 22.7071068,1.29289322 C23.0976311,1.68341751 23.0976311,2.31658249 22.7071068,2.70710678 L13.4142136,12 Z"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="sc-paXsP c7"
+        fill="currentcolor"
+        height="1em"
+        viewBox="0 0 24 24"
+        width="1em"
+      >
+        <path
+          d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
+        />
+      </svg>
+    </div>
+    <label
+      class="c8 c9"
       for="static-id"
     >
       Enabled
@@ -163,15 +374,27 @@ exports[`component: ToggleField snapshot 1`] = `
 `;
 
 exports[`component: ToggleField snapshot when disabled 1`] = `
-.c1 + .c0 {
-  margin-top: 16px;
-}
-
-.c10 {
+.c9 {
   font-size: 18px;
   line-height: 1.5;
   font-weight: 600;
   color: hsl(200,10%,20%);
+}
+
+.c4 {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  opacity: 0;
+  margin: 0;
+  z-index: 1;
+  position: absolute;
+  cursor: pointer;
+}
+
+.c4:disabled {
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -179,87 +402,91 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
   width: 12px;
   height: 12px;
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 7px;
+  right: 9px;
   color: hsl(0,0%,100%);
+  opacity: 1;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
 }
 
-.c8 {
+input:checked ~ .c6 {
+  opacity: 0;
+}
+
+.c7 {
   vertical-align: middle;
   width: 15px;
   height: 15px;
   position: absolute;
-  top: 4px;
-  left: 5px;
+  top: 5px;
+  left: 6px;
   color: hsl(0,0%,100%);
+  opacity: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
 }
 
-.c4 {
+input:checked ~ .c7 {
+  opacity: 1;
+}
+
+.c3 {
+  display: inline-block;
   position: relative;
   width: 51px;
   height: 26px;
-  border-radius: 13px;
+  box-sizing: border-box;
+  padding: 0;
+  border: none;
   outline: none;
-  background-color: hsl(0,0%,90%);
-  border: 1px solid hsl(0,0%,90%);
-  cursor: cursor;
 }
 
-.c4:focus {
+.c5 {
+  width: 100%;
+  height: 100%;
+  border-radius: 13px;
+  background-color: hsl(353,84%,44%);
+  cursor: pointer;
+}
+
+input:disabled ~ .c5 {
+  background-color: hsl(0,0%,90%);
+  cursor: cursor;
+  opacity: 0.5;
+}
+
+input:focus ~ .c5 {
   box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
 }
 
-.c4::after {
+.c5::after {
   width: 26px;
   height: 26px;
   border-radius: 50%;
   content: '';
-  top: -1px;
-  left: -1px;
+  top: 0;
+  left: 0;
   position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
+  -webkit-transition: left 0.3s;
+  transition: left 0.3s;
   background-color: hsl(0,0%,100%);
   box-shadow: 0 0 3px hsl(200,10%,20%);
 }
 
-.c4[aria-checked='true'] {
+input:checked ~ .c5 {
   background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
 }
 
-.c4[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+input:checked ~ .c5::after {
+  left: 26px;
 }
 
-.c4[aria-checked='true'] .c5 {
-  opacity: 0;
+.c1 + .c0 {
+  margin-top: 16px;
 }
 
-.c4[aria-checked='true'] .c7 {
-  opacity: 1;
-}
-
-.c4 .c5 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c4 .c7 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c4[disabled] {
-  opacity: 0.5;
-}
-
-.c2 .c9 {
+.c1 .c8 {
   cursor: not-allowed;
   margin-left: 8px;
   line-height: 26px;
@@ -267,12 +494,12 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
   color: hsl(0,0%,70%);
 }
 
-.c2 .c3 {
+.c1 .c2 {
   vertical-align: middle;
 }
 
 @media screen and (min-width:1024px) {
-  .c10 {
+  .c9 {
     font-size: 18px;
     line-height: 1.5;
   }
@@ -280,20 +507,28 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
 
 <div>
   <div
-    class="c0 c1 c2"
+    class="sc-AxjAm c0 c1"
   >
-    <button
-      aria-checked="false"
-      class="c3 c4"
-      disabled=""
-      id="static-id"
-      name="is_enabled"
-      role="switch"
-      type="button"
+    <div
+      class="c2 c3"
+      role="none"
     >
+      <input
+        aria-checked="false"
+        class="c4"
+        disabled=""
+        id="static-id"
+        name="is_enabled"
+        role="switch"
+        type="checkbox"
+      />
+      <div
+        aria-hidden="true"
+        class="c5"
+      />
       <svg
         aria-hidden="true"
-        class="sc-fzoWqW c5 c6"
+        class="sc-fzoWqW c6"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -305,7 +540,7 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
       </svg>
       <svg
         aria-hidden="true"
-        class="sc-paXsP c7 c8"
+        class="sc-paXsP c7"
         fill="currentcolor"
         height="1em"
         viewBox="0 0 24 24"
@@ -315,171 +550,9 @@ exports[`component: ToggleField snapshot when disabled 1`] = `
           d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
         />
       </svg>
-    </button>
+    </div>
     <label
-      class="c9 c10"
-      for="static-id"
-    >
-      Enabled
-    </label>
-  </div>
-</div>
-`;
-
-exports[`component: ToggleField snapshot when value=true 1`] = `
-.c1 + .c0 {
-  margin-top: 16px;
-}
-
-.c10 {
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: hsl(200,10%,20%);
-}
-
-.c6 {
-  vertical-align: middle;
-  width: 12px;
-  height: 12px;
-  position: absolute;
-  top: 6px;
-  right: 8px;
-  color: hsl(0,0%,100%);
-}
-
-.c8 {
-  vertical-align: middle;
-  width: 15px;
-  height: 15px;
-  position: absolute;
-  top: 4px;
-  left: 5px;
-  color: hsl(0,0%,100%);
-}
-
-.c4 {
-  position: relative;
-  width: 51px;
-  height: 26px;
-  border-radius: 13px;
-  outline: none;
-  background-color: hsl(353,84%,44%);
-  border: 1px solid hsl(353,84%,44%);
-  cursor: pointer;
-}
-
-.c4:focus {
-  box-shadow: 0px 3px 8px hsla(200,96%,35%,0.3);
-}
-
-.c4::after {
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  content: '';
-  top: -1px;
-  left: -1px;
-  position: absolute;
-  -webkit-transition: -webkit-transform 0.3s;
-  -webkit-transition: transform 0.3s;
-  transition: transform 0.3s;
-  background-color: hsl(0,0%,100%);
-  box-shadow: 0 0 3px hsl(200,10%,20%);
-}
-
-.c4[aria-checked='true'] {
-  background-color: hsl(145,89%,28%);
-  border-color: hsl(145,89%,28%);
-}
-
-.c4[aria-checked='true']::after {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
-}
-
-.c4[aria-checked='true'] .c5 {
-  opacity: 0;
-}
-
-.c4[aria-checked='true'] .c7 {
-  opacity: 1;
-}
-
-.c4 .c5 {
-  opacity: 1;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c4 .c7 {
-  opacity: 0;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-}
-
-.c4[disabled] {
-  opacity: 0.5;
-}
-
-.c2 .c9 {
-  cursor: pointer;
-  margin-left: 8px;
-  line-height: 26px;
-  vertical-align: -2px;
-}
-
-.c2 .c3 {
-  vertical-align: middle;
-}
-
-@media screen and (min-width:1024px) {
-  .c10 {
-    font-size: 18px;
-    line-height: 1.5;
-  }
-}
-
-<div>
-  <div
-    class="c0 c1 c2"
-  >
-    <button
-      aria-checked="true"
-      class="c3 c4"
-      id="static-id"
-      name="is_enabled"
-      role="switch"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="sc-fzoWqW c5 c6"
-        fill="currentcolor"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-      >
-        <path
-          d="M13.4142136,12 L22.7071068,21.2928932 C23.0976311,21.6834175 23.0976311,22.3165825 22.7071068,22.7071068 C22.3165825,23.0976311 21.6834175,23.0976311 21.2928932,22.7071068 L12,13.4142136 L2.70710678,22.7071068 C2.31658249,23.0976311 1.68341751,23.0976311 1.29289322,22.7071068 C0.902368927,22.3165825 0.902368927,21.6834175 1.29289322,21.2928932 L10.5857864,12 L1.29289322,2.70710678 C0.902368927,2.31658249 0.902368927,1.68341751 1.29289322,1.29289322 C1.68341751,0.902368927 2.31658249,0.902368927 2.70710678,1.29289322 L12,10.5857864 L21.2928932,1.29289322 C21.6834175,0.902368927 22.3165825,0.902368927 22.7071068,1.29289322 C23.0976311,1.68341751 23.0976311,2.31658249 22.7071068,2.70710678 L13.4142136,12 Z"
-        />
-      </svg>
-      <svg
-        aria-hidden="true"
-        class="sc-paXsP c7 c8"
-        fill="currentcolor"
-        height="1em"
-        viewBox="0 0 24 24"
-        width="1em"
-      >
-        <path
-          d="M9.81384674,19.7396292 C9.5249491,19.7396292 9.24415138,19.6325301 9.02725315,19.4381317 L3.38789908,14.3504731 C2.906403,13.9166766 2.86770331,13.1741827 3.30239977,12.6926866 C3.73619624,12.2120905 4.47869019,12.1724908 4.96018627,12.6071873 L9.67974783,16.8641526 L18.9127726,5.4369457 C19.3204693,4.93204981 20.0593633,4.85285046 20.5642592,5.26144713 C21.0682551,5.66914381 21.1465544,6.40803779 20.7388578,6.91293368 L10.7273393,19.3040328 C10.524841,19.5542307 10.2269434,19.7108295 9.90654599,19.7369292 C9.87504624,19.7387292 9.84444649,19.7396292 9.81384674,19.7396292"
-        />
-      </svg>
-    </button>
-    <label
-      class="c9 c10"
+      class="c8 c9"
       for="static-id"
     >
       Enabled

--- a/modules/cactus-web/src/helpers/omit.ts
+++ b/modules/cactus-web/src/helpers/omit.ts
@@ -1,4 +1,5 @@
 import omit from 'lodash/omit'
+import { margin, MarginProps } from 'styled-system'
 
 export default omit
 
@@ -22,3 +23,20 @@ export const omitMargins = <Obj extends { [k: string]: any }>(
     'my',
     ...undesired
   )
+
+function extractor<T>(keys: string[]) {
+  // @ts-ignore Not sure why Typescript doesn't like `key is keyof T`.
+  const isKeyofT = (key: string): key is keyof T => keys.includes(key)
+  return (props: Record<string, any>) => {
+    const extractedProps: Partial<T> = {}
+    for (const key of Object.keys(props)) {
+      if (isKeyofT(key)) {
+        extractedProps[key] = props[key]
+        delete props[key]
+      }
+    }
+    return extractedProps
+  }
+}
+
+export const extractMargins = extractor<MarginProps>(margin.propNames as string[])

--- a/website/src/components/CactusProvider.tsx
+++ b/website/src/components/CactusProvider.tsx
@@ -60,8 +60,8 @@ export function CactusThemeWidget(): ReactElement {
     primary: '',
     secondary: '',
   })
-  const handleOnChange = (name: string, value: any): void => {
-    setValues((v): { [k: string]: any } => ({ ...v, [name]: value }))
+  const handleOnChange = ({ target }: React.ChangeEvent<HTMLInputElement>): void => {
+    setValues((v) => ({ ...v, [target.name]: target.value }))
   }
 
   useEffect((): (() => void) => {
@@ -150,9 +150,7 @@ export function CactusThemeWidget(): ReactElement {
                     min="0"
                     max="360"
                     value={values.primaryHue}
-                    onChange={(e): void =>
-                      handleOnChange(e.currentTarget.name, e.currentTarget.value)
-                    }
+                    onChange={handleOnChange}
                   />
                 </AccessibleField>
                 <Box


### PR DESCRIPTION
These are the field types that are already based on intrinsic elements, so all I had to do was expose the existing event handlers.

Toggle was a little different because it was implemented as a button instead of a checkbox, so I re-implemented it. Styling and behavior should be the same, aside from the fact that it's now controlled by the `checked` prop instead of the `value` prop.