### PR TITLE
Fix BrowserStack Tests

### DIFF
--- a/examples/mock-ebpp/run-ete-tests.js
+++ b/examples/mock-ebpp/run-ete-tests.js
@@ -19,7 +19,7 @@ program.requiredOption(
 )
 program.parse()
 
-const runTests = async () => {
+const runIndividualTest = async (browser) => {
   const testcafe = await createTestCafe()
   try {
     let runner = testcafe.createRunner()
@@ -27,7 +27,7 @@ const runTests = async () => {
     runner = program.fixture
       ? runner.filter((_, fixtureName) => fixtureName === program.fixture)
       : runner
-    const numFailedTests = await runner.browsers(program.browser).run()
+    const numFailedTests = await runner.browsers(browser).run()
     await testcafe.close()
     if (numFailedTests > 0) {
       process.exit(1)
@@ -36,6 +36,12 @@ const runTests = async () => {
     console.error(e)
     await testcafe.close()
     process.exit(1)
+  }
+}
+
+const runTests = async () => {
+  for (const browser of program.browser) {
+    await runIndividualTest(browser)
   }
 }
 

--- a/examples/standard/run-ete-tests.js
+++ b/examples/standard/run-ete-tests.js
@@ -19,7 +19,7 @@ program.requiredOption(
 )
 program.parse()
 
-const runTests = async () => {
+const runIndividualTest = async (browser) => {
   const testcafe = await createTestCafe()
   try {
     let runner = testcafe.createRunner()
@@ -27,7 +27,7 @@ const runTests = async () => {
     runner = program.fixture
       ? runner.filter((_, fixtureName) => fixtureName === program.fixture)
       : runner
-    const numFailedTests = await runner.browsers(program.browser).run()
+    const numFailedTests = await runner.browsers(browser).run()
     await testcafe.close()
     if (numFailedTests > 0) {
       process.exit(1)
@@ -36,6 +36,12 @@ const runTests = async () => {
     console.error(e)
     await testcafe.close()
     process.exit(1)
+  }
+}
+
+const runTests = async () => {
+  for (const browser of program.browser) {
+    await runIndividualTest(browser)
   }
 }
 


### PR DESCRIPTION
Tests hang for some reason when run in parallel, so this changes makes them run sequentially.  It's a major bummer, but we'll try to look into why this is happening later.