### PR TITLE
Change visual snapshot comparison method to SSIM

### DIFF
--- a/modules/cactus-web/tests/storyshots.test.ts
+++ b/modules/cactus-web/tests/storyshots.test.ts
@@ -7,11 +7,17 @@ const supportedDevices = ['iPhone 5', 'iPad']
 
 interface MatchOptions {
   customSnapshotsDir?: string
+  comparisonMethod?: 'pixelmatch' | 'ssim'
+  failureThreshold?: number
+  failureThresholdType?: 'pixel' | 'percent'
 }
 
 const createCustomizePage = (device: devices.Device) => (page: Page) => page.emulate(device)
 const createGetMatchOptions = (name: string) => (): MatchOptions => ({
   customSnapshotsDir: path.resolve('__image_snapshots__', name),
+  comparisonMethod: 'ssim',
+  failureThreshold: 0.01,
+  failureThresholdType: 'percent',
 })
 const storyKindRegex = /^((?!.*?(Spinner)).)*$/
 


### PR DESCRIPTION
This should hopefully reduce false positives.  See
https://github.com/americanexpress/jest-image-snapshot#recommendations-when-using-ssim-comparison

To test, simply run `yarn test:build` followed by `yarn test:docker` on your machine, and make sure they pass.