### PR TITLE
Fix overflow for long words in table card view

### DIFF
--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -266,6 +266,9 @@ const HeaderBox = styled.div.attrs({ 'aria-hidden': 'true' })`
 const ContentBox = styled.div`
   flex-grow: 1;
   text-align: right;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  min-width: 20%;
   &:only-child,
   ${HeaderBox}:empty + & {
     text-align: center;

--- a/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
+++ b/modules/cactus-web/src/Table/__snapshots__/Table.test.tsx.snap
@@ -29,6 +29,9 @@ exports[`component: Table card carousel 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   text-align: right;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  min-width: 20%;
 }
 
 .c8:only-child,


### PR DESCRIPTION
See https://repay.slack.com/archives/CABGTU4S3/p1603824711026100

### Testing

1. Open up the Table -> With Long Values story
2. Change one of the values provided to be a long word instead of text with a bunch of spaces.
3. Ensure that the text wraps and does not overflow the card
4. Open up the Table -> Layout story
5. Switch to the Card variant and play around with the Cell and Header text to be sure that everything is behaving as you'd expect for both short and long values.