### PR TITLE
CACTUS-357 :: Fix non existent describedby

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
@@ -17,6 +17,7 @@ describe('component: AccessibleField', (): void => {
     const input = getByLabelText('Accessible Label')
     expect(input).toHaveAttribute('data-is', 'accessible')
     expect(input).toHaveAttribute('name', 'text_field')
+    expect(input).not.toHaveAttribute('aria-describedby')
   })
 
   test('provides accessible status message', (): void => {
@@ -28,7 +29,7 @@ describe('component: AccessibleField', (): void => {
       </StyleProvider>
     )
 
-    expect(getByLabelText('Accessible Label').getAttribute('aria-describedby')).toContain(
+    expect(getByLabelText('Accessible Label').getAttribute('aria-describedby')).toBe(
       getByText('This field has an error').closest('[id]')?.id
     )
   })
@@ -42,7 +43,7 @@ describe('component: AccessibleField', (): void => {
       </StyleProvider>
     )
 
-    expect(getByLabelText('Accessible Label').getAttribute('aria-describedby')).toContain(
+    expect(getByLabelText('Accessible Label').getAttribute('aria-describedby')).toBe(
       getByText('woot tooltips!').closest('[id]')?.id
     )
   })

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from '../Tooltip/Tooltip'
 interface AccessibleProps {
   name: string
   fieldId: string
-  ariaDescribedBy: string
+  ariaDescribedBy?: string
   labelId: string
   tooltipId: string
   statusId: string
@@ -52,6 +52,7 @@ export function useAccessibleField({
   warning,
   success,
   disabled,
+  tooltip,
 }: Partial<AccessibleFieldProps>): AccessibleProps {
   const fieldId = useId(id, name)
   const labelId = `${fieldId}-label`
@@ -71,9 +72,11 @@ export function useAccessibleField({
     statusMessage = success
   }
 
+  const describedByIds = [tooltip && tooltipId, status && statusId].filter(Boolean)
+
   return {
     fieldId,
-    ariaDescribedBy: `${tooltipId} ${statusId}`,
+    ariaDescribedBy: describedByIds.join(' ') || undefined,
     labelId,
     statusId,
     name: name || '',

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -48,7 +48,7 @@ export const CheckBoxGroup = React.forwardRef<HTMLFieldSetElement, CheckBoxGroup
       statusMessage,
       tooltipId,
       disabled,
-    } = useAccessibleField(props)
+    } = useAccessibleField({ ...props, tooltip })
     const [showTooltip, setTooltipVisible] = React.useState<boolean>(false)
 
     const forwardProps: ForwardProps = { required }

--- a/modules/cactus-web/src/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
+++ b/modules/cactus-web/src/CheckBoxGroup/__snapshots__/CheckBoxGroup.test.tsx.snap
@@ -191,7 +191,7 @@ exports[`component: CheckBoxGroup should render a checkbox group 1`] = `
 
 <div>
   <fieldset
-    aria-describedby="cbg-tip cbg-status"
+    aria-describedby="cbg-tip"
     class="c0"
     id="cbg"
     name="checkboxes"
@@ -502,7 +502,7 @@ exports[`component: CheckBoxGroup should render a disabled checkbox group 1`] = 
 
 <div>
   <fieldset
-    aria-describedby="cbg-tip cbg-status"
+    aria-describedby="cbg-status"
     class="c0"
     disabled=""
     id="cbg"

--- a/modules/cactus-web/src/DateInputField/__snapshots__/DateInputField.test.tsx.snap
+++ b/modules/cactus-web/src/DateInputField/__snapshots__/DateInputField.test.tsx.snap
@@ -249,7 +249,6 @@ exports[`component: DateInputField snapshot 1`] = `
       Date Field
     </label>
     <div
-      aria-describedby="not-random-tip not-random-status"
       aria-labelledby="not-random-label"
       class="c5 c6 "
       role="group"

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -253,7 +253,7 @@ exports[`component: FileInputField should render a disabled file input field 1`]
         </span>
       </div>
       <button
-        aria-describedby="consistent-tip consistent-status"
+        aria-describedby="consistent-tip"
         class="c12 c13"
         disabled=""
         id="consistent"
@@ -734,7 +734,7 @@ exports[`component: FileInputField should render a file with an error 1`] = `
         </div>
       </div>
       <button
-        aria-describedby="consistent-tip consistent-status"
+        aria-describedby="consistent-tip"
         class="c22 c23"
         id="consistent"
         type="button"
@@ -1165,7 +1165,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
         </div>
       </div>
       <button
-        aria-describedby="consistent-tip consistent-status"
+        aria-describedby="consistent-tip"
         class="c19 c20"
         id="consistent"
         type="button"
@@ -1515,7 +1515,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
         </div>
       </div>
       <button
-        aria-describedby="consistent-tip consistent-status"
+        aria-describedby="consistent-tip"
         class="c14 c15"
         id="consistent"
         type="button"
@@ -1796,7 +1796,7 @@ exports[`component: FileInputField should render file input field 1`] = `
         </span>
       </div>
       <button
-        aria-describedby="consistent-tip consistent-status"
+        aria-describedby="consistent-tip"
         class="c12 c13"
         id="consistent"
         type="button"

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
@@ -62,7 +62,7 @@ export const RadioGroup = React.forwardRef<HTMLFieldSetElement, RadioGroupProps>
       statusMessage,
       tooltipId,
       disabled,
-    } = useAccessibleField(props)
+    } = useAccessibleField({ ...props, tooltip })
     const [showTooltip, setTooltipVisible] = React.useState<boolean>(false)
 
     const forwardProps: ForwardProps = { name, required }

--- a/modules/cactus-web/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/modules/cactus-web/src/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -151,7 +151,7 @@ exports[`component: RadioGroup should render a disabled radio group 1`] = `
 
 <div>
   <fieldset
-    aria-describedby="rg-tip rg-status"
+    aria-describedby="rg-status"
     class="c0"
     disabled=""
     id="rg"
@@ -525,7 +525,7 @@ exports[`component: RadioGroup should render a radio group 1`] = `
 
 <div>
   <fieldset
-    aria-describedby="rg-tip rg-status"
+    aria-describedby="rg-tip"
     class="c0"
     id="rg"
     name="places"

--- a/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
+++ b/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
@@ -146,7 +146,6 @@ exports[`component: SelectField minimal snapshot 1`] = `
     >
       <div>
         <button
-          aria-describedby="prevent-random-id-tip prevent-random-id-status"
           aria-haspopup="listbox"
           aria-labelledby="prevent-random-id-label"
           aria-multiselectable="false"

--- a/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
+++ b/modules/cactus-web/src/TextAreaField/__snapshots__/TextAreaField.test.tsx.snap
@@ -165,7 +165,7 @@ exports[`component: TextAreaField should render a TextAreaField 1`] = `
       class="c8"
     >
       <textarea
-        aria-describedby="boolest-tip boolest-status"
+        aria-describedby="boolest-tip"
         class="c9"
         id="boolest"
         name="boolest"

--- a/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
+++ b/modules/cactus-web/src/TextInputField/__snapshots__/TextInputField.test.tsx.snap
@@ -169,7 +169,7 @@ exports[`component: TextInputField should render a TextInputField 1`] = `
       class="c8"
     >
       <input
-        aria-describedby="instigate-tip instigate-status"
+        aria-describedby="instigate-tip"
         class="c9"
         id="instigate"
         name="instigate"


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-357

I'm targeting `cactus-web-v4` because the `ariaDescribedBy` field returned by `useAccessibleField` can now return `undefined` if no `aria-describedby` attribute should be in the DOM.

### Testing

1. Open up a story for one of the accessible fields
2. Add/remove the tooltip and status messages.  Inspect the DOM element for the field to ensure that `aria-describedby` only specifies existing elements (i.e. it doesn't reference the tooltip if there is no tooltip).
3. Use a screen reader to make sure that it still picks up the status message/tooltip when focused on the accessible field.