### PR TITLE
fix(cactus-web): fix tooltip z index problem with select

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -19,7 +19,6 @@ interface AccessibleProps {
   status?: Status
   statusMessage?: React.ReactNode
   disabled?: boolean
-  isOpen?: boolean
 }
 
 type RenderFunc = (props: AccessibleProps) => JSX.Element | JSX.Element[]
@@ -42,7 +41,6 @@ interface AccessibleFieldProps extends FieldProps, MarginProps, WidthProps {
   className?: string
   children: JSX.Element | RenderFunc
   disabled?: boolean
-  isOpen?: boolean
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -55,7 +53,6 @@ export function useAccessibleField({
   warning,
   success,
   disabled,
-  isOpen,
 }: Partial<AccessibleFieldProps>): AccessibleProps {
   const fieldId = useId(id, name)
   const labelId = `${fieldId}-label`
@@ -85,7 +82,6 @@ export function useAccessibleField({
     statusMessage,
     tooltipId,
     disabled,
-    isOpen,
   }
 }
 
@@ -101,7 +97,6 @@ function AccessibleFieldBase(props: AccessibleFieldProps): React.ReactElement {
     status,
     statusMessage,
     disabled,
-    isOpen,
   } = accessibility
   const { autoTooltip = true } = props
 
@@ -145,7 +140,7 @@ function AccessibleFieldBase(props: AccessibleFieldProps): React.ReactElement {
           id={tooltipId}
           maxWidth={maxWidth}
           disabled={disabled}
-          forceVisible={!isOpen && forceTooltipVisible}
+          forceVisible={!props.isOpen && forceTooltipVisible}
         />
       )}
       {typeof props.children === 'function'

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -19,6 +19,7 @@ interface AccessibleProps {
   status?: Status
   statusMessage?: React.ReactNode
   disabled?: boolean
+  isOpen?: boolean
 }
 
 type RenderFunc = (props: AccessibleProps) => JSX.Element | JSX.Element[]
@@ -33,6 +34,7 @@ export interface FieldProps {
   warning?: React.ReactNode
   success?: React.ReactNode
   autoTooltip?: boolean
+  isOpen?: boolean
 }
 
 interface AccessibleFieldProps extends FieldProps, MarginProps, WidthProps {
@@ -40,6 +42,7 @@ interface AccessibleFieldProps extends FieldProps, MarginProps, WidthProps {
   className?: string
   children: JSX.Element | RenderFunc
   disabled?: boolean
+  isOpen?: boolean
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -52,6 +55,7 @@ export function useAccessibleField({
   warning,
   success,
   disabled,
+  isOpen,
 }: Partial<AccessibleFieldProps>): AccessibleProps {
   const fieldId = useId(id, name)
   const labelId = `${fieldId}-label`
@@ -81,6 +85,7 @@ export function useAccessibleField({
     statusMessage,
     tooltipId,
     disabled,
+    isOpen,
   }
 }
 
@@ -96,6 +101,7 @@ function AccessibleFieldBase(props: AccessibleFieldProps): React.ReactElement {
     status,
     statusMessage,
     disabled,
+    isOpen,
   } = accessibility
   const { autoTooltip = true } = props
 
@@ -139,7 +145,7 @@ function AccessibleFieldBase(props: AccessibleFieldProps): React.ReactElement {
           id={tooltipId}
           maxWidth={maxWidth}
           disabled={disabled}
-          forceVisible={forceTooltipVisible}
+          forceVisible={!isOpen && forceTooltipVisible}
         />
       )}
       {typeof props.children === 'function'

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -52,6 +52,7 @@ export interface SelectProps
   canCreateOption?: boolean
   matchNotFoundText?: string
   comboBoxSearchLabel?: string
+  getSelectOpen?: (prop: boolean) => void
   /**
    * Used when there are multiple selected, but too many to show. place '{}' to insert unshown number in label
    */
@@ -998,6 +999,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     currentTriggerWidth: 0,
     extraOptions: [],
   }
+
   private pendingChars = ''
   private searchIndex = -1
   private keyClear: number | undefined
@@ -1108,6 +1110,8 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
       return
     }
     this.setState({ isOpen: false })
+    this.props.getSelectOpen && this.props.getSelectOpen(false)
+
     const isNotControlledBlur =
       !event.relatedTarget || event.relatedTarget !== this.triggerRef.current
     if (isNotControlledBlur && typeof this.props.onBlur === 'function') {
@@ -1279,6 +1283,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
 
   private openList(): void {
     this.setState({ isOpen: true }, () => {
+      this.props.getSelectOpen && this.props.getSelectOpen(true)
       if (!isResponsiveTouchDevice) {
         window.requestAnimationFrame((): void => {
           if (this.listRef.current !== null && !this.props.comboBox) {
@@ -1293,6 +1298,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
 
   private closeList = (): void => {
     this.setState({ isOpen: false })
+    this.props.getSelectOpen && this.props.getSelectOpen(false)
     window.requestAnimationFrame((): void => {
       if (this.triggerRef.current !== null) {
         if (this.triggerRef.current.children.length > 0) {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1453,6 +1453,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
       matchNotFoundText = 'No match found',
       extraLabel,
       value: propsValue,
+      onDropdownToggle,
       ...rest
     } = omitMargins(this.props) as Omit<SelectProps, keyof MarginProps>
     const { isOpen, searchValue, activeDescendant } = this.state

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -52,7 +52,7 @@ export interface SelectProps
   canCreateOption?: boolean
   matchNotFoundText?: string
   comboBoxSearchLabel?: string
-  getSelectOpen?: (prop: boolean) => void
+  onDropdownToggle?: (prop: boolean) => void
   /**
    * Used when there are multiple selected, but too many to show. place '{}' to insert unshown number in label
    */
@@ -1110,7 +1110,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
       return
     }
     this.setState({ isOpen: false })
-    this.props.getSelectOpen && this.props.getSelectOpen(false)
+    this.props.onDropdownToggle && this.props.onDropdownToggle(false)
 
     const isNotControlledBlur =
       !event.relatedTarget || event.relatedTarget !== this.triggerRef.current
@@ -1283,7 +1283,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
 
   private openList(): void {
     this.setState({ isOpen: true }, () => {
-      this.props.getSelectOpen && this.props.getSelectOpen(true)
+      this.props.onDropdownToggle && this.props.onDropdownToggle(true)
       if (!isResponsiveTouchDevice) {
         window.requestAnimationFrame((): void => {
           if (this.listRef.current !== null && !this.props.comboBox) {
@@ -1298,7 +1298,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
 
   private closeList = (): void => {
     this.setState({ isOpen: false })
-    this.props.getSelectOpen && this.props.getSelectOpen(false)
+    this.props.onDropdownToggle && this.props.onDropdownToggle(false)
     window.requestAnimationFrame((): void => {
       if (this.triggerRef.current !== null) {
         if (this.triggerRef.current.children.length > 0) {

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -36,7 +36,7 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
     autoTooltip,
     ...rest
   } = omitMargins(props) as Omit<SelectFieldProps, keyof MarginProps>
-
+  const [isOpen, setIsOpen] = React.useState(false)
   return (
     <AccessibleField
       disabled={disabled}
@@ -51,6 +51,7 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
       error={error}
       width={width}
       autoTooltip={autoTooltip}
+      isOpen={isOpen}
     >
       {({ fieldId, labelId, name, ariaDescribedBy, status, disabled }): React.ReactElement => (
         <Select
@@ -61,6 +62,7 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
           id={fieldId}
           aria-labelledby={labelId}
           aria-describedby={ariaDescribedBy}
+          getSelectOpen={(e) => setIsOpen(e)}
         />
       )}
     </AccessibleField>

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -62,7 +62,7 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
           id={fieldId}
           aria-labelledby={labelId}
           aria-describedby={ariaDescribedBy}
-          getSelectOpen={(e) => setIsOpen(e)}
+          onDropdownToggle={(newStateOpen) => setIsOpen(newStateOpen)}
         />
       )}
     </AccessibleField>


### PR DESCRIPTION
I don't know if this is the best way to solvew the issue, but it does the job (I think).

TO test:
Go to the select field on storybook and check if the problme has been fixed.


[CACTUS-388]

[CACTUS-388]: https://repayonline.atlassian.net/browse/CACTUS-388