### PR TITLE
Go back to running BrowserStack tests in parallel

### DIFF
--- a/examples/mock-ebpp/run-ete-tests.js
+++ b/examples/mock-ebpp/run-ete-tests.js
@@ -19,7 +19,7 @@ program.requiredOption(
 )
 program.parse()
 
-const runIndividualTest = async (browser) => {
+const runTests = async () => {
   const testcafe = await createTestCafe()
   try {
     let runner = testcafe.createRunner()
@@ -27,7 +27,7 @@ const runIndividualTest = async (browser) => {
     runner = program.fixture
       ? runner.filter((_, fixtureName) => fixtureName === program.fixture)
       : runner
-    const numFailedTests = await runner.browsers(browser).run()
+    const numFailedTests = await runner.browsers(program.browser).run()
     await testcafe.close()
     if (numFailedTests > 0) {
       process.exit(1)
@@ -36,12 +36,6 @@ const runIndividualTest = async (browser) => {
     console.error(e)
     await testcafe.close()
     process.exit(1)
-  }
-}
-
-const runTests = async () => {
-  for (const browser of program.browser) {
-    await runIndividualTest(browser)
   }
 }
 

--- a/examples/standard/run-ete-tests.js
+++ b/examples/standard/run-ete-tests.js
@@ -19,7 +19,7 @@ program.requiredOption(
 )
 program.parse()
 
-const runIndividualTest = async (browser) => {
+const runTests = async () => {
   const testcafe = await createTestCafe()
   try {
     let runner = testcafe.createRunner()
@@ -27,7 +27,7 @@ const runIndividualTest = async (browser) => {
     runner = program.fixture
       ? runner.filter((_, fixtureName) => fixtureName === program.fixture)
       : runner
-    const numFailedTests = await runner.browsers(browser).run()
+    const numFailedTests = await runner.browsers(program.browser).run()
     await testcafe.close()
     if (numFailedTests > 0) {
       process.exit(1)
@@ -36,12 +36,6 @@ const runIndividualTest = async (browser) => {
     console.error(e)
     await testcafe.close()
     process.exit(1)
-  }
-}
-
-const runTests = async () => {
-  for (const browser of program.browser) {
-    await runIndividualTest(browser)
   }
 }
 


### PR DESCRIPTION
It looks like this is working again.  I'm not sure what happened last week.  If you want, you can make sure you can still run the integration tests locally, but that's up to you.