### PR TITLE
CACTUS-387 MenuBar + usePopup = Winning

### DIFF
--- a/modules/cactus-web/src/MenuBar/MenuBar.test.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.test.tsx
@@ -50,11 +50,11 @@ const Menu = () => {
   const customRef = React.useRef<HTMLDivElement>(null)
   return (
     <MenuBar id="mb" ref={navRef} aria-label="Menu of Main-ness">
-      <MenuBar.List ref={listRef} title={<em>Emphasized</em>} aria-current>
+      <MenuBar.List id="em" ref={listRef} title={<em>Emphasized</em>} aria-current>
         <MenuBar.Item key="item" ref={linkRef} as="a" href="#" aria-current>
           Link to the Past
         </MenuBar.Item>
-        <MenuBar.List key="list" title="Nested">
+        <MenuBar.List id="nested" key="list" title="Nested">
           <MenuBar.Item key="linkish" as={Linkish} to="#">
             Birdy
           </MenuBar.Item>

--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -13,29 +13,27 @@ import ActionBar from '../ActionBar/ActionBar'
 import { useAction } from '../ActionBar/ActionProvider'
 import { keyPressAsClick, preventAction } from '../helpers/a11y'
 import { AsProps, GenericComponent } from '../helpers/asProps'
+import { useFocusControl } from '../helpers/focus'
+import { useMergedRefs } from '../helpers/react'
 import { border, borderSize, boxShadow, radius, textStyle } from '../helpers/theme'
-import usePopup from '../helpers/usePopup'
 import { useLayout } from '../Layout/Layout'
 import { Sidebar as LayoutSidebar } from '../Layout/Sidebar'
 import { ScreenSizeContext, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
 import {
   focusMenu,
   ITEM_SELECTOR,
-  menuKeyHandler,
+  menuFocusControl,
+  useMenu,
+  useMenuKeyHandler,
   useScrollButtons,
-  useSubmenuHandlers,
-  useSubmenuToggle,
+  useSubmenu,
 } from './scroll'
 
 interface ListProps {
+  id?: string
   children: React.ReactNode
   title: React.ReactNode
   'aria-current'?: boolean
-}
-
-interface MenuProps {
-  children: React.ReactNode
-  expanded: boolean
 }
 
 interface MenuBarProps {
@@ -111,36 +109,20 @@ const MenuBarList = React.forwardRef<HTMLButtonElement, ListProps>(
   ({ title, children, ...props }, ref) => {
     const variant = useVariant()
     const isTopbar = variant === 'top'
-    const [expanded, toggle] = useSubmenuToggle(isTopbar)
-
-    const [toggleOnKey, toggleOnClick, closeOnBlur, handleSubmenu] = useSubmenuHandlers(toggle)
+    const { wrapperProps, buttonProps, popupProps } = useSubmenu(props.id, isTopbar)
 
     return (
-      <li role="none" onKeyDown={handleSubmenu} onBlur={closeOnBlur}>
-        <MenuButton
-          {...props}
-          ref={ref}
-          aria-haspopup="menu"
-          aria-expanded={expanded}
-          onClick={toggleOnClick}
-          onKeyDown={toggleOnKey}
-          onKeyUp={preventAction}
-        >
+      <li {...wrapperProps}>
+        <MenuButton {...props} {...buttonProps} ref={ref}>
           <TextWrapper>{title}</TextWrapper>
           <IconWrapper aria-hidden>
             <NavigationChevronDown />
           </IconWrapper>
         </MenuButton>
         {isTopbar ? (
-          <FloatingMenu expanded={expanded}>{children}</FloatingMenu>
+          <FloatingMenu {...popupProps}>{children}</FloatingMenu>
         ) : (
-          <InlineMenu
-            expanded={expanded}
-            role="menu"
-            aria-orientation="vertical"
-            onFocus={focusMenu}
-            onKeyDown={menuKeyHandler}
-          >
+          <InlineMenu {...popupProps} aria-orientation="vertical">
             {children}
           </InlineMenu>
         )}
@@ -161,20 +143,20 @@ const TextWrapper = styled.div`
   flex-grow: 1;
 `
 
-const FloatingMenu: React.FC<MenuProps> = ({ children, expanded }) => {
-  const [scroll, menuRef] = useScrollButtons('vertical', expanded)
+const FloatingMenu: React.FC<React.HTMLAttributes<HTMLElement>> = ({
+  children,
+  'aria-hidden': hidden,
+  tabIndex,
+  onKeyDown,
+  ...props
+}) => {
+  const [menuRef, scroll] = useScrollButtons('vertical', !hidden)
   return (
-    <MenuWrapper aria-hidden={!expanded || undefined} tabIndex={-1}>
+    <MenuWrapper aria-hidden={hidden} tabIndex={tabIndex} onKeyDown={onKeyDown}>
       <ScrollButton show={scroll.showBack} onClick={scroll.clickBack}>
         <NavigationChevronUp />
       </ScrollButton>
-      <MenuList
-        role="menu"
-        aria-orientation="vertical"
-        ref={menuRef}
-        onFocus={focusMenu}
-        onKeyDown={menuKeyHandler}
-      >
+      <MenuList {...props} aria-orientation="vertical" ref={menuRef}>
         {children}
       </MenuList>
       <ScrollButton show={scroll.showFore} onClick={scroll.clickFore}>
@@ -211,24 +193,21 @@ const setTabIndex = (menu: HTMLElement | null, isSidebar: boolean) => {
 
 const Topbar = React.forwardRef<HTMLElement, MenuBarProps>(({ children, ...props }, ref) => {
   const orientation = 'horizontal'
-  const [scroll, menuRef, menu] = useScrollButtons(orientation, true)
+  const [menuRef, scroll] = useScrollButtons(orientation, true)
+  const [setFocus, rootRef] = useFocusControl(menuFocusControl)
+  const menuKeyHandler = useMenuKeyHandler(setFocus)
+  const mergedRef = useMergedRefs(menuRef, rootRef)
 
-  React.useEffect(() => setTabIndex(menu, false), [menu])
+  React.useEffect(() => setTabIndex(menuRef.current, false), [menuRef])
 
   useLayout('menubar', { position: 'flow', offset: 0 })
 
   return (
-    <Nav {...props} ref={ref} tabIndex={-1} onClick={navClickHandler}>
+    <Nav {...props} ref={ref} tabIndex={-1} onClick={navClickHandler} onKeyDown={menuKeyHandler}>
       <ScrollButton show={scroll.showBack} onClick={scroll.clickBack}>
         <NavigationChevronLeft />
       </ScrollButton>
-      <MenuList
-        role="menubar"
-        aria-orientation={orientation}
-        ref={menuRef}
-        onFocus={focusMenu}
-        onKeyDown={menuKeyHandler}
-      >
+      <MenuList role="menubar" aria-orientation={orientation} ref={mergedRef} onFocus={focusMenu}>
         {children}
       </MenuList>
       <ScrollButton show={scroll.showFore} onClick={scroll.clickFore}>
@@ -246,13 +225,9 @@ const Sidebar = React.forwardRef<HTMLElement, MenuBarProps>((props, ref) => {
 
 const NavPanel = React.forwardRef<HTMLElement, MenuBarProps>(({ children, id, ...props }, ref) => {
   const orientation = 'vertical'
-  const { expanded, wrapperProps, buttonProps, popupProps } = usePopup('menu', {
-    id,
-    focusControl: getMenuItems,
-  })
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [_, menuRef, menu] = useScrollButtons(orientation, expanded)
-  React.useEffect(() => setTabIndex(menu, true), [menu])
+  const { expanded, wrapperProps, buttonProps, popupProps } = useMenu(id)
+  const [menuRef] = useScrollButtons(orientation, expanded)
+  React.useEffect(() => setTabIndex(menuRef.current, true), [menuRef])
 
   delete wrapperProps.role
   return (
@@ -272,8 +247,6 @@ const NavPanel = React.forwardRef<HTMLElement, MenuBarProps>(({ children, id, ..
         width="350px"
         as={SidebarMenu}
         aria-orientation={orientation}
-        onFocus={focusMenu}
-        onKeyDown={menuKeyHandler}
         ref={menuRef}
         {...popupProps}
       >
@@ -377,9 +350,12 @@ const listStyle = `
   margin: 0;
 `
 
-const InlineMenu = styled.ul<MenuProps>`
+const InlineMenu = styled.ul`
   ${listStyle}
-  display: ${(p) => (p.expanded ? 'block' : 'none')};
+  display: block;
+  &[aria-hidden='true'] {
+    display: none;
+  }
 `
 
 const SidebarMenu = styled.ul`
@@ -432,9 +408,8 @@ const SidebarMenu = styled.ul`
 const MenuWrapper = styled.div`
   ${(p) => p.theme.colorStyles.standard};
   display: flex;
-  visibility: visible;
   &[aria-hidden='true'] {
-    visibility: hidden;
+    display: none;
   }
   position: absolute;
   top: 100%;
@@ -509,7 +484,7 @@ const buttonStyles = `
   }
 `
 
-const MenuButton = styled.button.attrs({ role: 'menuitem' })`
+const MenuButton = styled.button.attrs({ role: 'menuitem' as string })`
   ${buttonStyles}
   width: 100%;
   height: 100%;

--- a/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
+++ b/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
@@ -198,6 +198,10 @@ exports[`component: MenuBar sidebar 1`] = `
   list-style: none;
   padding: 0;
   margin: 0;
+  display: block;
+}
+
+.c14[aria-hidden='true'] {
   display: none;
 }
 
@@ -348,12 +352,14 @@ exports[`component: MenuBar sidebar 1`] = `
       >
         <li
           role="none"
+          tabindex="-1"
         >
           <button
+            aria-controls="em-popup"
             aria-current="true"
-            aria-expanded="false"
             aria-haspopup="menu"
             class="c9"
+            id="em"
             role="menuitem"
             tabindex="-1"
           >
@@ -383,9 +389,13 @@ exports[`component: MenuBar sidebar 1`] = `
             </div>
           </button>
           <ul
+            aria-hidden="true"
+            aria-labelledby="em"
             aria-orientation="vertical"
             class="c14"
+            id="em-popup"
             role="menu"
+            tabindex="-1"
           >
             <li
               role="none"
@@ -402,11 +412,13 @@ exports[`component: MenuBar sidebar 1`] = `
             </li>
             <li
               role="none"
+              tabindex="-1"
             >
               <button
-                aria-expanded="false"
+                aria-controls="nested-popup"
                 aria-haspopup="menu"
                 class="c9"
+                id="nested"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -434,9 +446,13 @@ exports[`component: MenuBar sidebar 1`] = `
                 </div>
               </button>
               <ul
+                aria-hidden="true"
+                aria-labelledby="nested"
                 aria-orientation="vertical"
                 class="c14"
+                id="nested-popup"
                 role="menu"
+                tabindex="-1"
               >
                 <li
                   role="none"
@@ -654,7 +670,6 @@ exports[`component: MenuBar typechecks 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  visibility: visible;
   position: absolute;
   top: 100%;
   left: 0;
@@ -678,7 +693,7 @@ exports[`component: MenuBar typechecks 1`] = `
 }
 
 .c9[aria-hidden='true'] {
-  visibility: hidden;
+  display: none;
 }
 
 .c9 [role='menuitem'] {
@@ -837,12 +852,14 @@ exports[`component: MenuBar typechecks 1`] = `
     >
       <li
         role="none"
+        tabindex="-1"
       >
         <button
+          aria-controls="em-popup"
           aria-current="true"
-          aria-expanded="false"
           aria-haspopup="menu"
           class="c4"
+          id="em"
           role="menuitem"
           tabindex="0"
         >
@@ -894,8 +911,10 @@ exports[`component: MenuBar typechecks 1`] = `
             </svg>
           </div>
           <ul
+            aria-labelledby="em"
             aria-orientation="vertical"
             class="c11"
+            id="em-popup"
             role="menu"
           >
             <li
@@ -913,11 +932,13 @@ exports[`component: MenuBar typechecks 1`] = `
             </li>
             <li
               role="none"
+              tabindex="-1"
             >
               <button
-                aria-expanded="false"
+                aria-controls="nested-popup"
                 aria-haspopup="menu"
                 class="c4"
+                id="nested"
                 role="menuitem"
                 tabindex="-1"
               >
@@ -967,8 +988,10 @@ exports[`component: MenuBar typechecks 1`] = `
                   </svg>
                 </div>
                 <ul
+                  aria-labelledby="nested"
                   aria-orientation="vertical"
                   class="c11"
+                  id="nested-popup"
                   role="menu"
                 >
                   <li

--- a/modules/cactus-web/src/MenuBar/scroll.ts
+++ b/modules/cactus-web/src/MenuBar/scroll.ts
@@ -98,10 +98,9 @@ function handleArrows(event: React.KeyboardEvent<HTMLElement>, toggle: TogglePop
 }
 
 function handleButtonClick(event: React.MouseEvent<HTMLElement>, toggle: TogglePopup) {
-  if (!isExpanded(event.currentTarget)) {
-    const wrapper = event.currentTarget.nextElementSibling as HTMLElement
-    toggle(true, wrapper, { delay: true })
-  }
+  event.preventDefault()
+  const wrapper = event.currentTarget.nextElementSibling as HTMLElement
+  toggle(undefined, wrapper)
 }
 
 export function menuFocusControl(menu: HTMLElement): HTMLElement[] {

--- a/modules/cactus-web/src/MenuBar/scroll.ts
+++ b/modules/cactus-web/src/MenuBar/scroll.ts
@@ -1,11 +1,12 @@
 import observeRect from '@reach/observe-rect'
 import React from 'react'
 
-import { isActionKey } from '../helpers/a11y'
+import { FocusControl, FocusSetter } from '../helpers/focus'
+import usePopup, { TogglePopup } from '../helpers/usePopup'
 
 type Orientation = 'horizontal' | 'vertical'
 
-const PRINTABLE = /^\S$/
+const IS_CHAR = /^\S$/
 const BUTTON_WIDTH = 34 // 16 padding, 18 icon
 export const ITEM_SELECTOR = '[role="menuitem"]'
 
@@ -28,71 +29,48 @@ const getMenu: (f: HTMLElement) => HTMLElement | undefined = (fromNode) => {
 }
 
 const getMenuItems = (menu: HTMLElement, directChildrenOnly: boolean): HTMLElement[] => {
-  const elements = [...(menu.querySelectorAll(ITEM_SELECTOR) as any)] as HTMLElement[]
+  const elements = Array.from(menu.querySelectorAll(ITEM_SELECTOR)) as HTMLElement[]
   if (directChildrenOnly) {
     return elements.filter((e) => getMenu(e) === menu)
   }
   return elements.filter((e) => e.offsetWidth)
 }
 
-type ToggleSubmenu = (b: HTMLElement | null, o: boolean | undefined, f?: boolean) => void
-
-export function useSubmenuToggle(usePositioning: boolean): [boolean, ToggleSubmenu] {
-  const [expanded, setExpanded] = React.useState<boolean>(false)
-  const toggle = React.useCallback<ToggleSubmenu>(
-    (menuButton, open, focus = false) => {
-      setExpanded((isExpanded: boolean) => {
-        if (open !== isExpanded) {
-          isExpanded = open === undefined ? !isExpanded : open
-          // Was closed, now open
-          if (isExpanded && menuButton) {
-            const menuWrapper = menuButton.nextElementSibling as HTMLElement
-            if (usePositioning) {
-              const maxRight = window.innerWidth - 25 // Include buffer for scrollbar.
-              const maxBottom = window.innerHeight
-              const offsetRect = (menuWrapper.offsetParent as HTMLElement).getBoundingClientRect()
-              const buttonRect = menuButton.getBoundingClientRect()
-              const menuRect = menuWrapper.getBoundingClientRect()
-              const parentMenu = getMenu(menuButton)
-              const orientation = parentMenu && parentMenu.getAttribute('aria-orientation')
-              let left, top
-              if (orientation === 'horizontal') {
-                const expectedRight = buttonRect.left + menuRect.width
-                if (expectedRight > maxRight) {
-                  left = Math.ceil(maxRight - menuRect.width - offsetRect.left)
-                } else {
-                  left = buttonRect.left - offsetRect.left
-                }
-              } else {
-                const expectedRight = buttonRect.right + menuRect.width
-                if (expectedRight > maxRight) {
-                  left = Math.ceil(buttonRect.left - menuRect.width - offsetRect.left)
-                } else {
-                  left = Math.ceil(buttonRect.left - offsetRect.left + buttonRect.width)
-                }
-                const expectedBottom = buttonRect.top + menuRect.height
-                if (expectedBottom > maxBottom) {
-                  top = `${maxBottom - menuRect.height - offsetRect.top}px`
-                } else {
-                  top = `${buttonRect.top - offsetRect.top}px`
-                }
-              }
-              // Using translate instead of left because of an issue I had with inconsistent width.
-              menuWrapper.style.transform = `translateX(${left}px)`
-              menuWrapper.style.top = top || ''
-            }
-            if (focus) {
-              const firstItem = menuWrapper.querySelector(ITEM_SELECTOR) as HTMLElement
-              setTimeout(() => firstItem.focus())
-            }
-          }
-        }
-        return isExpanded
-      })
-    },
-    [setExpanded, usePositioning]
-  )
-  return [expanded, toggle]
+function positionMenu(menuWrapper: HTMLElement, menuButton: HTMLElement | null) {
+  if (!menuButton) return
+  menuWrapper = menuWrapper.parentElement as HTMLElement
+  const maxRight = window.innerWidth - 25 // Include buffer for scrollbar.
+  const maxBottom = window.innerHeight
+  const offsetRect = (menuWrapper.offsetParent as HTMLElement).getBoundingClientRect()
+  const buttonRect = menuButton.getBoundingClientRect()
+  const menuRect = menuWrapper.getBoundingClientRect()
+  const parentMenu = getMenu(menuButton)
+  const orientation = parentMenu && parentMenu.getAttribute('aria-orientation')
+  let left, top
+  if (orientation === 'horizontal') {
+    const expectedRight = buttonRect.left + menuRect.width
+    if (expectedRight > maxRight) {
+      left = Math.ceil(maxRight - menuRect.width - offsetRect.left)
+    } else {
+      left = buttonRect.left - offsetRect.left
+    }
+  } else {
+    const expectedRight = buttonRect.right + menuRect.width
+    if (expectedRight > maxRight) {
+      left = Math.ceil(buttonRect.left - menuRect.width - offsetRect.left)
+    } else {
+      left = Math.ceil(buttonRect.left - offsetRect.left + buttonRect.width)
+    }
+    const expectedBottom = buttonRect.top + menuRect.height
+    if (expectedBottom > maxBottom) {
+      top = `${maxBottom - menuRect.height - offsetRect.top}px`
+    } else {
+      top = `${buttonRect.top - offsetRect.top}px`
+    }
+  }
+  // Using translate instead of left because of an issue I had with inconsistent width.
+  menuWrapper.style.transform = `translateX(${left}px)`
+  menuWrapper.style.top = top || ''
 }
 
 const isExpanded = (button: HTMLElement) => button.getAttribute('aria-expanded') === 'true'
@@ -103,135 +81,124 @@ const getOrientation = (element: HTMLElement) => {
   return menu && menu.getAttribute('aria-orientation')
 }
 
-type SubmenuHandlers = [
-  React.KeyboardEventHandler<HTMLElement>,
-  React.MouseEventHandler<HTMLElement>,
-  React.FocusEventHandler<HTMLElement>,
-  React.KeyboardEventHandler<HTMLElement>
-]
-
-export function useSubmenuHandlers(toggle: ToggleSubmenu): SubmenuHandlers {
-  const toggleOnKey = React.useCallback(
-    (event: React.KeyboardEvent<HTMLElement>) => {
-      const menuButton = event.currentTarget
-      const orientation = getOrientation(menuButton)
-      if (isActionKey(event)) {
-        event.preventDefault()
-        event.stopPropagation()
-        toggle(menuButton, undefined, true)
-      } else if (!isExpanded(menuButton) && event.key === openKey(orientation)) {
-        event.stopPropagation()
-        toggle(menuButton, true, true)
-      }
-    },
-    [toggle]
-  )
-  const closeOnBlur = React.useCallback(
-    (event: React.FocusEvent<HTMLElement>) => {
-      const target = event.currentTarget
-      setTimeout(() => {
-        if (!target.contains(document.activeElement)) {
-          toggle(null, false)
-        }
-      })
-    },
-    [toggle]
-  )
-  const toggleOnClick = React.useCallback(
-    (event: React.MouseEvent<HTMLElement>) => {
-      toggle(event.currentTarget, undefined)
-    },
-    [toggle]
-  )
-  const handleSubmenu = React.useCallback(
-    (event: React.KeyboardEvent<HTMLElement>) => {
-      const menuButton = event.currentTarget.querySelector('[aria-expanded]') as HTMLElement
-      if (isExpanded(menuButton)) {
-        const orientation = getOrientation(event.currentTarget)
-        switch (event.key) {
-          case 'Escape':
-          case closeKey(orientation):
-            toggle(menuButton, false)
-            menuButton.focus()
-            break
-          case openKey(orientation):
-            const menu = event.currentTarget.querySelector('[role="menu"]')
-            const items = getMenuItems(menu as HTMLElement, true)
-            const currentFocus = items.indexOf(document.activeElement as HTMLElement)
-            items[(currentFocus + 1) % items.length].focus()
-            break
-          default:
-            return
-        }
-        event.stopPropagation()
-        event.preventDefault()
-      }
-    },
-    [toggle]
-  )
-  return [toggleOnKey, toggleOnClick, closeOnBlur, handleSubmenu]
+function handleArrows(event: React.KeyboardEvent<HTMLElement>, toggle: TogglePopup) {
+  const menuButton = event.currentTarget.querySelector('[role="menuitem"]')
+  if (menuButton instanceof HTMLElement) {
+    const orientation = getOrientation(event.currentTarget)
+    if (event.key === closeKey(orientation) && isExpanded(menuButton)) {
+      event.stopPropagation()
+      toggle(false, menuButton)
+    } else if (event.key === openKey(orientation)) {
+      event.stopPropagation()
+      toggle(true, 1, { shift: true })
+    } else if (event.key === 'ArrowLeft' && isExpanded(menuButton)) {
+      event.stopPropagation()
+    }
+  }
 }
 
-export const menuKeyHandler = (event: React.KeyboardEvent<HTMLElement>): void => {
-  const menu = event.currentTarget as MenuWithScroll
-  const parentMenu = getMenu(menu)
-  const orientation = menu.getAttribute('aria-orientation')
-  const scrollForward = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight'
-  const scrollBack = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft'
-  const allowWrapBack = !parentMenu || parentMenu.getAttribute('aria-orientation') === orientation
-  const visibleElements = getMenuItems(menu, true)
-  const currentFocus = visibleElements.indexOf(document.activeElement as HTMLElement)
-  let focusIndex = -1
-  switch (event.key) {
-    case scrollForward:
-      focusIndex = (currentFocus + 1) % visibleElements.length
-      break
-    case scrollBack:
-      if (currentFocus > 0) {
-        focusIndex = currentFocus - 1
-        // If wrapback isn't allowed, focus will return to the parent menu.
-      } else if (currentFocus === 0 && allowWrapBack) {
-        focusIndex = visibleElements.length - 1
-      }
-      break
-    // Prevent these from propagating up to the next menu.
-    case 'ArrowRight':
-    case 'Enter':
-    case ' ':
-      event.stopPropagation()
-      return
-    case 'Home':
-    case 'PageUp': // TODO Once the scrolling is implemented, I'll want to shift this to approximately one page-worth of links up
-      focusIndex = 0
-      break
-    case 'End':
-    case 'PageDown':
-      focusIndex = visibleElements.length - 1
-      break
-    default:
-      // Search for the closest menu item that starts with the typed letter.
-      if (PRINTABLE.test(event.key)) {
-        const offset = Math.max(currentFocus, 0)
-        for (let i = 0; i < visibleElements.length; i++) {
-          const index = (i + offset) % visibleElements.length
-          const text = visibleElements[index].textContent
-          if (text && text.toLowerCase().startsWith(event.key.toLowerCase())) {
-            focusIndex = index
+function handleButtonClick(event: React.MouseEvent<HTMLElement>, toggle: TogglePopup) {
+  if (!isExpanded(event.currentTarget)) {
+    const wrapper = event.currentTarget.nextElementSibling as HTMLElement
+    toggle(true, wrapper, { delay: true })
+  }
+}
+
+export function menuFocusControl(menu: HTMLElement): HTMLElement[] {
+  return getMenuItems(menu, true)
+}
+
+export function useSubmenu(
+  id: string | undefined,
+  usePositioning: boolean
+): ReturnType<typeof usePopup> {
+  const popup = usePopup('menu', {
+    id,
+    buttonId: id,
+    onWrapperKeyDown: handleArrows,
+    onButtonClick: handleButtonClick,
+    focusControl: menuFocusControl,
+    positionPopup: usePositioning ? positionMenu : undefined,
+  })
+  delete popup.wrapperProps.id
+  popup.buttonProps.role = 'menuitem'
+  popup.popupProps.onFocus = focusMenu
+  popup.popupProps.onKeyDown = useMenuKeyHandler(popup.setFocus)
+  return popup
+}
+
+export function useMenu(id: string | undefined): ReturnType<typeof usePopup> {
+  const popup = usePopup('menu', {
+    id,
+    onButtonClick: handleButtonClick,
+    focusControl: menuFocusControl,
+  })
+  popup.popupProps.onFocus = focusMenu
+  popup.popupProps.onKeyDown = useMenuKeyHandler(popup.setFocus)
+  return popup
+}
+
+type KeyHandler = React.KeyboardEventHandler<HTMLElement>
+
+export const useMenuKeyHandler = (setFocus: FocusSetter): KeyHandler =>
+  React.useCallback<KeyHandler>(
+    (event) => {
+      const menu = (event.currentTarget.matches('ul')
+        ? event.currentTarget
+        : event.currentTarget.querySelector('ul')) as MenuWithScroll
+      const parentMenu = getMenu(menu)
+      const orientation = menu.getAttribute('aria-orientation')
+      const scrollForward = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight'
+      const scrollBack = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft'
+      const allowWrapBack =
+        !parentMenu || parentMenu.getAttribute('aria-orientation') === orientation
+      let propagate = false
+      switch (event.key) {
+        case scrollForward:
+          setFocus(1, { shift: true })
+          break
+        case scrollBack:
+          let control: FocusControl | undefined
+          if (!allowWrapBack) {
+            control = (root, { focusIndex }) => {
+              if (focusIndex <= 0) {
+                propagate = true
+                return
+              }
+              return menuFocusControl(root)
+            }
+          }
+          setFocus(-1, { shift: true, control })
+          break
+        // Prevent these from propagating up to the next menu.
+        case 'ArrowRight':
+        case 'Enter':
+        case ' ':
+          event.stopPropagation()
+          return
+        case 'Home':
+        case 'PageUp':
+          setFocus(0)
+          break
+        case 'End':
+        case 'PageDown':
+          setFocus(-1)
+          break
+        default:
+          // Search for the closest menu item that starts with the typed letter.
+          if (IS_CHAR.test(event.key)) {
+            setFocus(event.key)
             break
           }
-        }
+          return // If unhandled at this point, we'll allow propagation.
       }
-      break
-  }
-  if (focusIndex >= 0) {
-    const toFocus = visibleElements[focusIndex]
-    if (toFocus !== document.activeElement) {
-      toFocus.focus()
-    }
-    event.stopPropagation()
-    event.preventDefault()
-  }
-}
+      event.preventDefault()
+      if (!propagate) {
+        event.stopPropagation()
+      }
+    },
+    [setFocus]
+  )
 
 interface Scroll {
   showFore?: boolean
@@ -248,11 +215,9 @@ interface MenuWithScroll extends HTMLUListElement {
   scrollToMenuItem?: (target: HTMLElement) => void
 }
 
-type MenuElement = MenuWithScroll | null
+type MenuRef = React.RefObject<HTMLUListElement>
 
-type MenuRef = (m: MenuElement) => void
-
-type ScrollButtonHook = (o: Orientation, e: boolean) => [Scroll, MenuRef, MenuElement]
+type ScrollButtonHook = (o: Orientation, e: boolean) => [MenuRef, Scroll]
 
 function getScrollInfo(element: HTMLElement): [HTMLElement, number, HTMLElement[]] {
   const overflow = window.getComputedStyle(element).overflow
@@ -265,12 +230,13 @@ function getScrollInfo(element: HTMLElement): [HTMLElement, number, HTMLElement[
 }
 
 export const useScrollButtons: ScrollButtonHook = (orientation, expanded) => {
-  const [menu, menuRef] = React.useState<MenuElement>(null)
+  const menuRef = React.useRef<HTMLUListElement>(null)
   const [scroll, setScroll] = React.useState<Scroll>(DEFAULT_SCROLL)
   React.useEffect(() => {
     if (!expanded) {
       setScroll(() => DEFAULT_SCROLL)
-    } else if (menu) {
+    } else if (menuRef.current) {
+      const menu = menuRef.current as MenuWithScroll
       let back: 'left' | 'top' = 'left'
       let fore: 'right' | 'bottom' = 'right'
       let width: 'width' | 'height' = 'width'
@@ -397,8 +363,8 @@ export const useScrollButtons: ScrollButtonHook = (orientation, expanded) => {
       observer.observe()
       return () => observer.unobserve()
     }
-  }, [expanded, menu, orientation])
-  return [scroll, menuRef, menu]
+  }, [expanded, menuRef, orientation])
+  return [menuRef, scroll]
 }
 
 export const focusMenu = (event: React.FocusEvent<HTMLElement>): void => {

--- a/modules/cactus-web/src/helpers/usePopup.ts
+++ b/modules/cactus-web/src/helpers/usePopup.ts
@@ -103,7 +103,7 @@ function usePopup(
       // IE sets activeElement before the blur/focus events, but doesn't support
       // relatedTarget. Note that in React 17 this might change if they switch
       // from focus/blur to focusin/focusout, which DO support relatedTarget.
-      const focused = isIE ? document.activeElement : event.relatedTarget
+      const focused = event.relatedTarget || (isIE ? document.activeElement : null)
       if (!focused || !wrapper.contains(focused as Node)) {
         toggle(false)
       }
@@ -132,9 +132,11 @@ function usePopup(
 
   const toggleOnClick = React.useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
-      toggle(undefined, focusOnClickExpand ? 0 : undefined)
       if (onButtonClick) {
         onButtonClick(event, toggle)
+      }
+      if (!event.isDefaultPrevented()) {
+        toggle(undefined, focusOnClickExpand ? 0 : undefined)
       }
     },
     [toggle, onButtonClick, focusOnClickExpand]
@@ -142,12 +144,12 @@ function usePopup(
 
   const toggleOnKey = React.useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
-      if (isActionKey(event)) {
-        event.preventDefault()
-        toggle(undefined, 0)
-      }
       if (onButtonKeyDown) {
         onButtonKeyDown(event, toggle)
+      }
+      if (!event.isDefaultPrevented() && isActionKey(event)) {
+        event.preventDefault()
+        toggle(undefined, 0)
       }
     },
     [toggle, onButtonKeyDown]


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-387

Works basically the same as before with two minor differences:
- Now when you click a button to expand a menu, you can then use the keyboard (up/down arrows) to start navigating the newly-opened menu.
- If you're using the keyboard to navigate the menu and then you click on a scroll button, you can go back to using the keyboard and it'll pick up where you left off. (Debatably useful, this was just a side effect of `useFocusControl`, not done on purpose.)