### PR TITLE
Csf stories migration

### DIFF
--- a/modules/cactus-icons/.storybook/addons.js
+++ b/modules/cactus-icons/.storybook/addons.js
@@ -1,1 +1,0 @@
-import '@storybook/addon-knobs/register'

--- a/modules/cactus-icons/.storybook/main.js
+++ b/modules/cactus-icons/.storybook/main.js
@@ -1,0 +1,4 @@
+module.exports = {
+  stories: ['../stories/Icons.story.tsx'],
+  addons: ['@storybook/addon-knobs/register'],
+}

--- a/modules/cactus-icons/.storybook/preview.js
+++ b/modules/cactus-icons/.storybook/preview.js
@@ -1,15 +1,15 @@
 import { StyleProvider } from '@repay/cactus-web'
 import { withKnobs } from '@storybook/addon-knobs'
+import addons from '@storybook/addons'
 import { addDecorator, addParameters, configure } from '@storybook/react'
 import * as React from 'react'
 
 import storybookTheme from './theme'
 
-addParameters({
-  options: {
-    theme: storybookTheme,
-  },
+addons.setConfig({
+  theme: storybookTheme,
 })
+
 addDecorator(withKnobs)
 addDecorator((story) => (
   <div
@@ -26,7 +26,3 @@ addDecorator((story) => (
     <StyleProvider>{story()}</StyleProvider>
   </div>
 ))
-
-configure(() => {
-  require('../stories/Icons.story.tsx')
-}, module)

--- a/modules/cactus-icons/stories/Icons.story.tsx
+++ b/modules/cactus-icons/stories/Icons.story.tsx
@@ -1,6 +1,5 @@
 import cactusTheme, { CactusTheme, generateTheme } from '@repay/cactus-theme'
 import { number, select } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
 import React, { ReactElement } from 'react'
 
 import * as icons from '../i'
@@ -11,44 +10,43 @@ const iconNames: IconName[] = Object.keys(icons) as IconName[]
 type IconSizes = 'tiny' | 'small' | 'medium' | 'large'
 const iconSizes: IconSizes[] = ['tiny', 'small', 'medium', 'large']
 
-storiesOf('Icons', module)
-  .add(
-    'One',
-    (): ReactElement => {
-      const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
-      const Icon = icons[iconName]
-      const hue: number = number('hue', 210)
-      const theme: CactusTheme = generateTheme({ primaryHue: hue })
+export default {
+  title: 'Icons',
+  component: icons as any,
+}
 
-      return (
-        <Icon
-          iconSize={select('iconSize', iconSizes, 'large')}
-          style={{ color: theme.colors.callToAction }}
-        />
-      )
-    }
+export const One = (): ReactElement => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName]
+  const hue: number = number('hue', 210)
+  const theme: CactusTheme = generateTheme({ primaryHue: hue })
+
+  return (
+    <Icon
+      iconSize={select('iconSize', iconSizes, 'large')}
+      style={{ color: theme.colors.callToAction }}
+    />
   )
-  .add(
-    'All',
-    (): ReactElement => {
-      const size = select('iconSize', iconSizes, 'large')
-      return (
-        <div
-          style={{
-            color: cactusTheme.colors.callToAction,
-            display: 'grid',
-            gridTemplateColumns: 'repeat(12, 1fr)',
-            gridGap: '16px',
-          }}
-        >
-          {Object.entries(icons)
-            .filter(([name]): boolean => name !== 'iconSizes')
-            .map(
-              ([name, Icon]): ReactElement => (
-                <Icon key={name} iconSize={size} />
-              )
-            )}
-        </div>
-      )
-    }
+}
+
+export const All = (): ReactElement => {
+  const size = select('iconSize', iconSizes, 'large')
+  return (
+    <div
+      style={{
+        color: cactusTheme.colors.callToAction,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(12, 1fr)',
+        gridGap: '16px',
+      }}
+    >
+      {Object.entries(icons)
+        .filter(([name]): boolean => name !== 'iconSizes')
+        .map(
+          ([name, Icon]): ReactElement => (
+            <Icon key={name} iconSize={size} />
+          )
+        )}
+    </div>
   )
+}

--- a/modules/cactus-web/.storybook/addons.js
+++ b/modules/cactus-web/.storybook/addons.js
@@ -1,4 +1,0 @@
-import '@storybook/addon-knobs/register'
-import '../cactus-addon/register'
-import '@storybook/addon-actions/register'
-import '@storybook/addon-viewport/register'

--- a/modules/cactus-web/.storybook/main.js
+++ b/modules/cactus-web/.storybook/main.js
@@ -1,0 +1,9 @@
+module.exports = {
+  stories: ['../src/**/*.story.tsx'],
+  addons: [
+    '@storybook/addon-knobs/register',
+    '../cactus-addon/register.jsx',
+    '@storybook/addon-actions/register',
+    '@storybook/addon-viewport/register',
+  ],
+}

--- a/modules/cactus-web/.storybook/preview.js
+++ b/modules/cactus-web/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { withKnobs } from '@storybook/addon-knobs'
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
-import { addDecorator, addParameters, configure } from '@storybook/react'
+import addons from '@storybook/addons'
+import { addDecorator, addParameters } from '@storybook/react'
 
 import CactusAddon from '../cactus-addon'
 import storybookTheme from './theme'
@@ -36,11 +37,12 @@ const customViewports = {
   },
 }
 
+addons.setConfig({
+  theme: storybookTheme,
+})
+
 addParameters({
   layout: 'fullscreen',
-  options: {
-    theme: storybookTheme,
-  },
   viewport: {
     viewports: {
       ...INITIAL_VIEWPORTS,
@@ -50,13 +52,3 @@ addParameters({
 })
 addDecorator(withKnobs)
 addDecorator(CactusAddon)
-
-function requireAll(req) {
-  req.keys().forEach((filename) => req(filename))
-}
-
-const componentStories = require.context('../src', true, /\.(story|stories)\.(j|t)sx?$/)
-
-configure(() => {
-  requireAll(componentStories)
-}, module)

--- a/modules/cactus-web/scripts/make-component.js
+++ b/modules/cactus-web/scripts/make-component.js
@@ -87,8 +87,8 @@ async function fileExists(filePath) {
 
 function componentTemplate(componentName) {
   return `
-import { margin, MarginProps } from 'styled-system'
 import styled from 'styled-components'
+import { margin, MarginProps } from 'styled-system'
 
 interface ${componentName}Props extends MarginProps {}
 
@@ -102,9 +102,9 @@ export default ${componentName}
 
 function testTemplate(componentName) {
   return `
+import { render } from '@testing-library/react'
 import * as React from 'react'
 
-import { render } from '@testing-library/react'
 import { StyleProvider } from '../StyleProvider/StyleProvider'
 import ${componentName} from './${componentName}'
 
@@ -124,12 +124,18 @@ describe('component: ${componentName}', () => {
 
 function storyTemplate(componentName) {
   return `
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
-import { storiesOf } from '@storybook/react'
 import ${componentName} from './${componentName}'
 
-storiesOf('${componentName}', module).add('Basic Usage', () => <${componentName} />)`
+export default {
+  title: '${componentName}',
+  component: ${componentName},
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => <${componentName} />
+`
 }
 
 function mdxTemplate(componentName) {

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.story.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.story.tsx
@@ -1,26 +1,28 @@
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import AccessibleField from './AccessibleField'
 
-storiesOf('AccessibleField', module).add(
-  'Basic Usage',
-  (): React.ReactElement => {
-    const disabled = boolean('disabled', false)
-    return (
-      <AccessibleField
-        disabled={disabled}
-        name={text('name', 'field_name')}
-        label={text('label', 'Field Label')}
-        error={text('error (will show field error)', '')}
-        warning={text('warning (will show field warning)', '')}
-        success={text('success (will show field success)', '')}
-        tooltip={text('tooltip?', 'Will only show a tooltip when text is provided.')}
-        autoTooltip={boolean('autoTooltip', true)}
-      >
-        <input style={{ minWidth: '300px' }} />
-      </AccessibleField>
-    )
-  }
-)
+export default {
+  title: 'AccessibleField',
+  component: AccessibleField,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
+  const disabled = boolean('disabled', false)
+  return (
+    <AccessibleField
+      disabled={disabled}
+      name={text('name', 'field_name')}
+      label={text('label', 'Field Label')}
+      error={text('error (will show field error)', '')}
+      warning={text('warning (will show field warning)', '')}
+      success={text('success (will show field success)', '')}
+      tooltip={text('tooltip?', 'Will only show a tooltip when text is provided.')}
+      autoTooltip={boolean('autoTooltip', true)}
+    >
+      <input style={{ minWidth: '300px' }} />
+    </AccessibleField>
+  )
+}

--- a/modules/cactus-web/src/Accordion/Accordion.story.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.story.tsx
@@ -1,6 +1,6 @@
 import { ActionsDelete, NavigationCircleDown, NavigationCircleUp } from '@repay/cactus-icons'
 import { boolean, number, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { Fragment, ReactElement, useCallback, useState } from 'react'
 
 import Box from '../Box/Box'
@@ -184,174 +184,164 @@ const ReorderAccordions = (): ReactElement => {
   )
 }
 
-storiesOf('Accordion', module)
-  .add(
-    'Basic Usage',
-    (): ReactElement => (
-      <Box width="312px">
-        <Accordion
-          variant={select('variant', accordionVariants, 'simple')}
-          useBoxShadows={boolean('useBoxShadows', true)}
-        >
-          <Accordion.Header>
-            <Text as="h3">{text('header', 'Accordion')}</Text>
-          </Accordion.Header>
-          <Accordion.Body>{text('content', 'Some Accordion Content')}</Accordion.Body>
-        </Accordion>
-      </Box>
-    )
-  )
-  .add(
-    'Long',
-    (): ReactElement => (
-      <Box width="960px">
-        <Accordion>
-          <Accordion.Header>
-            <Text as="h3">{text('header', 'Accordion')}</Text>
-          </Accordion.Header>
-          <Accordion.Body>{text('content', 'Some Accordion Content')}</Accordion.Body>
-        </Accordion>
-      </Box>
-    )
-  )
-  .add(
-    'Provider',
-    (): ReactElement => (
-      <Box width="312px">
-        <Accordion.Provider maxOpen={number('maxOpen', 1)}>
-          <Accordion>
-            <Accordion.Header>
-              <Text as="h3">{text('header 1', 'Accordion 1')}</Text>
-            </Accordion.Header>
-            <Accordion.Body>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
-              tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
-              lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex,
-              nec euismod augue aliquam vel.
-            </Accordion.Body>
-          </Accordion>
-          <Accordion>
-            <Accordion.Header>
-              <Text as="h3">{text('header 2', 'Accordion 2')}</Text>
-            </Accordion.Header>
-            <Accordion.Body>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
-              tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
-              lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex,
-              nec euismod augue aliquam vel.
-            </Accordion.Body>
-          </Accordion>
-          <Accordion>
-            <Accordion.Header>
-              <Text as="h3">{text('header 3', 'Accordion 3')}</Text>
-            </Accordion.Header>
-            <Accordion.Body>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
-              tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
-              lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex,
-              nec euismod augue aliquam vel.
-            </Accordion.Body>
-          </Accordion>
-          <Accordion>
-            <Accordion.Header>
-              <Text as="h3">{text('header 4', 'Accordion 4')}</Text>
-            </Accordion.Header>
-            <Accordion.Body>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
-              tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
-              lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex,
-              nec euismod augue aliquam vel.
-            </Accordion.Body>
-          </Accordion>
-        </Accordion.Provider>
-      </Box>
-    ),
-    { cactus: { overrides: { height: '150vh' } } }
-  )
-  .add(
-    'With Dynamic Content',
-    (): ReactElement => (
-      <ContentManager>
-        {({ changeContent, ...state }): ReactElement => {
-          return (
-            <Box width="400px" maxWidth="90vw" height="100vh" py={5} style={{ overflowY: 'auto' }}>
-              <Accordion.Provider maxOpen={1}>
-                {((): JSX.Element[] => {
-                  const blocks = []
-                  let index = 0
-                  while (typeof state[index] === 'number') {
-                    const group = index
-                    blocks.push(
-                      <Accordion key={group}>
-                        <Accordion.Header>
-                          <Text as="h3">{group} Accordion</Text>
-                        </Accordion.Header>
-                        <Accordion.Body>
-                          {(!state[group] || state[group] < 10) && (
-                            <Text>
-                              <TextButton
-                                onClick={(): void => changeContent(group, true)}
-                                variant="action"
-                              >
-                                Add One Block
-                              </TextButton>
-                            </Text>
-                          )}
-                          <ContentBlocks number={state[group]} />
-                          {state[group] > 0 && (
-                            <Text>
-                              <TextButton
-                                onClick={(): void => changeContent(group)}
-                                variant="danger"
-                              >
-                                Remove One Block
-                              </TextButton>
-                            </Text>
-                          )}
-                        </Accordion.Body>
-                      </Accordion>
-                    )
-                    index++
-                  }
+export default {
+  title: 'Accordion',
+  component: Accordion,
+} as Meta
 
-                  return blocks
-                })()}
-              </Accordion.Provider>
-            </Box>
-          )
-        }}
-      </ContentManager>
-    )
-  )
-  .add(
-    'With Open Initialization',
-    (): ReactElement => (
-      <Box width="312px">
-        <Accordion.Provider maxOpen={number('maxOpen', 2)}>
-          <Accordion defaultOpen>
-            <Accordion.Header>
-              <Text as="h3">{text('header 1', 'Accordion 1')}</Text>
-            </Accordion.Header>
-            <Accordion.Body>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
-              tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
-              lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex,
-              nec euismod augue aliquam vel.
-            </Accordion.Body>
-          </Accordion>
-          <Accordion defaultOpen>
-            <Accordion.Header>
-              <Text as="h3">{text('header 2', 'Accordion 2')}</Text>
-            </Accordion.Header>
-            <Accordion.Body>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
-              tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
-              lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex,
-              nec euismod augue aliquam vel.
-            </Accordion.Body>
-          </Accordion>
-        </Accordion.Provider>
-      </Box>
-    )
-  )
-  .add('With Outline', (): ReactElement => <ReorderAccordions />)
+export const BasicUsage = (): ReactElement => (
+  <Box width="312px">
+    <Accordion
+      variant={select('variant', accordionVariants, 'simple')}
+      useBoxShadows={boolean('useBoxShadows', true)}
+    >
+      <Accordion.Header>
+        <Text as="h3">{text('header', 'Accordion')}</Text>
+      </Accordion.Header>
+      <Accordion.Body>{text('content', 'Some Accordion Content')}</Accordion.Body>
+    </Accordion>
+  </Box>
+)
+
+export const Long = (): ReactElement => (
+  <Box width="960px">
+    <Accordion>
+      <Accordion.Header>
+        <Text as="h3">{text('header', 'Accordion')}</Text>
+      </Accordion.Header>
+      <Accordion.Body>{text('content', 'Some Accordion Content')}</Accordion.Body>
+    </Accordion>
+  </Box>
+)
+export const Provider = (): ReactElement => (
+  <Box width="312px">
+    <Accordion.Provider maxOpen={number('maxOpen', 1)}>
+      <Accordion>
+        <Accordion.Header>
+          <Text as="h3">{text('header 1', 'Accordion 1')}</Text>
+        </Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+          tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+          lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+          euismod augue aliquam vel.
+        </Accordion.Body>
+      </Accordion>
+      <Accordion>
+        <Accordion.Header>
+          <Text as="h3">{text('header 2', 'Accordion 2')}</Text>
+        </Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+          tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+          lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+          euismod augue aliquam vel.
+        </Accordion.Body>
+      </Accordion>
+      <Accordion>
+        <Accordion.Header>
+          <Text as="h3">{text('header 3', 'Accordion 3')}</Text>
+        </Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+          tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+          lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+          euismod augue aliquam vel.
+        </Accordion.Body>
+      </Accordion>
+      <Accordion>
+        <Accordion.Header>
+          <Text as="h3">{text('header 4', 'Accordion 4')}</Text>
+        </Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+          tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+          lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+          euismod augue aliquam vel.
+        </Accordion.Body>
+      </Accordion>
+    </Accordion.Provider>
+  </Box>
+)
+
+Provider.parameters = { cactus: { overrides: { height: '150vh' } } }
+
+export const WithDynamicContent = (): ReactElement => (
+  <ContentManager>
+    {({ changeContent, ...state }): ReactElement => {
+      return (
+        <Box width="400px" maxWidth="90vw" height="100vh" py={5} style={{ overflowY: 'auto' }}>
+          <Accordion.Provider maxOpen={1}>
+            {((): JSX.Element[] => {
+              const blocks = []
+              let index = 0
+              while (typeof state[index] === 'number') {
+                const group = index
+                blocks.push(
+                  <Accordion key={group}>
+                    <Accordion.Header>
+                      <Text as="h3">{group} Accordion</Text>
+                    </Accordion.Header>
+                    <Accordion.Body>
+                      {(!state[group] || state[group] < 10) && (
+                        <Text>
+                          <TextButton
+                            onClick={(): void => changeContent(group, true)}
+                            variant="action"
+                          >
+                            Add One Block
+                          </TextButton>
+                        </Text>
+                      )}
+                      <ContentBlocks number={state[group]} />
+                      {state[group] > 0 && (
+                        <Text>
+                          <TextButton onClick={(): void => changeContent(group)} variant="danger">
+                            Remove One Block
+                          </TextButton>
+                        </Text>
+                      )}
+                    </Accordion.Body>
+                  </Accordion>
+                )
+                index++
+              }
+
+              return blocks
+            })()}
+          </Accordion.Provider>
+        </Box>
+      )
+    }}
+  </ContentManager>
+)
+export const WithOpenInitialization = (): ReactElement => (
+  <Box width="312px">
+    <Accordion.Provider maxOpen={number('maxOpen', 2)}>
+      <Accordion defaultOpen>
+        <Accordion.Header>
+          <Text as="h3">{text('header 1', 'Accordion 1')}</Text>
+        </Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+          tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+          lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+          euismod augue aliquam vel.
+        </Accordion.Body>
+      </Accordion>
+      <Accordion defaultOpen>
+        <Accordion.Header>
+          <Text as="h3">{text('header 2', 'Accordion 2')}</Text>
+        </Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pulvinar, mauris eu
+          tempor accumsan, arcu nibh mattis tortor, id feugiat velit diam et massa. Vestibulum
+          lacinia ultrices urna, non rhoncus justo mollis vitae. Integer facilisis gravida ex, nec
+          euismod augue aliquam vel.
+        </Accordion.Body>
+      </Accordion>
+    </Accordion.Provider>
+  </Box>
+)
+
+export const WithOutline = (): ReactElement => <ReorderAccordions />

--- a/modules/cactus-web/src/ActionBar/ActionBar.story.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.story.tsx
@@ -1,6 +1,6 @@
 import { ActionsGear, ActionsRedo, ActionsRefresh, ActionsUndo } from '@repay/cactus-icons'
 import { boolean } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Flex from '../Flex/Flex'
@@ -55,39 +55,44 @@ const SimpleRouter = () => {
   )
 }
 
-storiesOf('ActionBar', module)
-  .add('Basic Usage', () => {
-    const hasItems = boolean('Has Items', true)
-    return (
-      <ScreenSizeProvider>
-        <ActionBar>
-          {hasItems && (
-            <>
-              <ActionBar.Item icon={<ActionsRedo />} onClick={action('redo')} />
-              <ActionBar.Item icon={<Undo />} onClick={action('undo')} />
-            </>
-          )}
-        </ActionBar>
-      </ScreenSizeProvider>
-    )
-  })
-  .add('With Provider', () => {
-    const hasActionBar = boolean('Has ActionBar', true)
-    return (
-      <Layout>
-        {hasActionBar && (
-          <ActionBar>
-            <ActionBar.Item
-              id="gear"
-              icon={<ActionsGear />}
-              onClick={action('gear')}
-              aria-label="Gear up"
-            />
-          </ActionBar>
+export default {
+  title: 'ActionBar',
+  component: ActionBar,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
+  const hasItems = boolean('Has Items', true)
+  return (
+    <ScreenSizeProvider>
+      <ActionBar>
+        {hasItems && (
+          <>
+            <ActionBar.Item icon={<ActionsRedo />} onClick={action('redo')} />
+            <ActionBar.Item icon={<Undo />} onClick={action('undo')} />
+          </>
         )}
-        <Layout.Content>
-          <SimpleRouter />
-        </Layout.Content>
-      </Layout>
-    )
-  })
+      </ActionBar>
+    </ScreenSizeProvider>
+  )
+}
+
+export const WithProvider = (): React.ReactElement => {
+  const hasActionBar = boolean('Has ActionBar', true)
+  return (
+    <Layout>
+      {hasActionBar && (
+        <ActionBar>
+          <ActionBar.Item
+            id="gear"
+            icon={<ActionsGear />}
+            onClick={action('gear')}
+            aria-label="Gear up"
+          />
+        </ActionBar>
+      )}
+      <Layout.Content>
+        <SimpleRouter />
+      </Layout.Content>
+    </Layout>
+  )
+}

--- a/modules/cactus-web/src/Alert/Alert.story.tsx
+++ b/modules/cactus-web/src/Alert/Alert.story.tsx
@@ -1,6 +1,6 @@
 import { actions } from '@storybook/addon-actions'
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import { Flex } from '../index'
@@ -10,54 +10,51 @@ const status: Status[] = ['error', 'warning', 'info', 'success']
 const type: Type[] = ['general', 'push']
 const eventLoggers = actions('onClose')
 
-storiesOf('Alert', module).add(
-  'Basic Usage',
-  (): ReactElement => {
-    return (
-      <Flex width="80%">
-        <Alert
-          status={select('Status', status, 'error')}
-          type={select('Type', type, 'general')}
-          shadow={boolean('Shadow', false)}
-        >
-          {text('Message', 'Message goes here')}
-        </Alert>
-      </Flex>
-    )
-  }
-)
+export default {
+  title: 'Alert',
+  component: Alert,
+} as Meta
 
-storiesOf('Alert', module).add(
-  'Close Button',
-  (): ReactElement => {
-    return (
-      <Flex width="80%">
-        <Alert
-          status={select('Status', status, 'error')}
-          type={select('Type', type, 'general')}
-          shadow={boolean('Shadow', false)}
-          {...eventLoggers}
-        >
-          {text('Message', 'Message goes here')}
-        </Alert>
-      </Flex>
-    )
-  }
-)
-storiesOf('Alert', module).add(
-  'Small Push Alert',
-  (): ReactElement => {
-    return (
-      <Flex width="320px">
-        <Alert
-          status={select('Status', status, 'error')}
-          type={select('Type', type, 'push')}
-          shadow={boolean('Shadow', false)}
-          {...eventLoggers}
-        >
-          {text('Message', 'Message goes here')}
-        </Alert>
-      </Flex>
-    )
-  }
-)
+export const BasicUsage = (): ReactElement => {
+  return (
+    <Flex width="80%">
+      <Alert
+        status={select('Status', status, 'error')}
+        type={select('Type', type, 'general')}
+        shadow={boolean('Shadow', false)}
+      >
+        {text('Message', 'Message goes here')}
+      </Alert>
+    </Flex>
+  )
+}
+
+export const CloseButton = (): ReactElement => {
+  return (
+    <Flex width="80%">
+      <Alert
+        status={select('Status', status, 'error')}
+        type={select('Type', type, 'general')}
+        shadow={boolean('Shadow', false)}
+        {...eventLoggers}
+      >
+        {text('Message', 'Message goes here')}
+      </Alert>
+    </Flex>
+  )
+}
+
+export const SmallPushAlert = (): ReactElement => {
+  return (
+    <Flex width="320px">
+      <Alert
+        status={select('Status', status, 'error')}
+        type={select('Type', type, 'push')}
+        shadow={boolean('Shadow', false)}
+        {...eventLoggers}
+      >
+        {text('Message', 'Message goes here')}
+      </Alert>
+    </Flex>
+  )
+}

--- a/modules/cactus-web/src/Avatar/Avatar.story.tsx
+++ b/modules/cactus-web/src/Avatar/Avatar.story.tsx
@@ -1,5 +1,5 @@
 import { boolean, select } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Avatar, { AvatarStatus, AvatarType } from './Avatar'
@@ -7,15 +7,17 @@ import Avatar, { AvatarStatus, AvatarType } from './Avatar'
 const avatarIcon: AvatarStatus[] = ['error', 'warning', 'info', 'success']
 const avatarUse: AvatarType[] = ['alert', 'feedback']
 
-storiesOf('Avatar', module).add(
-  'Basic Usage',
-  (): React.ReactElement => {
-    return (
-      <Avatar
-        type={select('usage', avatarUse, 'feedback')}
-        status={select('icon', avatarIcon, 'error')}
-        disabled={boolean('disabled', false)}
-      />
-    )
-  }
-)
+export default {
+  title: 'Avatar',
+  component: Avatar,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
+  return (
+    <Avatar
+      type={select('usage', avatarUse, 'feedback')}
+      status={select('icon', avatarIcon, 'error')}
+      disabled={boolean('disabled', false)}
+    />
+  )
+}

--- a/modules/cactus-web/src/Box/Box.story.tsx
+++ b/modules/cactus-web/src/Box/Box.story.tsx
@@ -1,6 +1,6 @@
 import cactusTheme, { TextStyleCollection } from '@repay/cactus-theme'
 import { object, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import { Property } from 'csstype'
 import React from 'react'
 
@@ -39,77 +39,81 @@ const defaultBorderRadiusObj = {
   round: '20px',
 }
 
-storiesOf('Box', module)
-  .add(
-    'Basic Usage with theme build-in values',
-    (): React.ReactElement => (
-      <Box
-        position={select('position', positionOptions, 'initial') as Property.Position}
-        display={select('display', displayOptions, 'initial')}
-        top={text('top', '')}
-        right={text('right', '')}
-        bottom={text('bottom', '')}
-        left={text('left', '')}
-        margin={select('margin', sizes, 0)}
-        padding={select('padding', sizes, 4)}
-        width={text('width', '120px')}
-        maxWidth={text('maxWidth', '')}
-        minWidth={text('minWidth', '')}
-        height={text('height', '120px')}
-        maxHeight={text('maxHeight', '100vh')}
-        minHeight={text('minHeight', '10px')}
-        backgroundColor={select('backgroundColor (bg)', themeColors, 'lightContrast')}
-        color={select('color', themeColors, 'darkestContrast')}
-        borderColor={select('borderColor', themeColors, 'darkestContrast')}
-        borderWidth={text('borderWidth', '2px')}
-        borderRadius={text('borderRadius', '')}
-        borderStyle={text('borderStyle', 'solid')}
-        textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
-        zIndex={text('zIndex', '') as Property.ZIndex}
-        overflow={text('overflow', '') as Property.Overflow}
-        overflowX={text('overflowX', '') as Property.OverflowX}
-        overflowY={text('overflowY', '') as Property.OverflowY}
-      >
-        {text('children', 'Example Content')}
-      </Box>
-    )
-  )
-  .add(
-    'Using colorStyles for color and background',
-    (): React.ReactElement => (
-      <Box
-        colors={select('colors', colorStyles, 'callToAction')}
-        margin={select('margin', sizes, 0)}
-        padding={select('padding', sizes, 4)}
-        width={text('width', '100px')}
-        height={text('height', '100px')}
-        borderColor={select('borderColor', themeColors, 'darkestContrast')}
-        borderWidth={text('borderWidth', '')}
-        borderRadius={text('borderRadius', '')}
-        borderStyle={text('borderStyle', '')}
-        textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
-      >
-        {text('children', 'Example Content')}
-      </Box>
-    )
-  )
-  .add('Custom Border Radius Definitions', () => (
-    <Box
-      width={text('width', '120px')}
-      height={text('height', '120px')}
-      color={select('color', themeColors, 'darkestContrast')}
-      backgroundColor={select('backgroundColor (bg)', themeColors, 'lightContrast')}
-      borderColor={select('borderColor', themeColors, 'darkestContrast')}
-      borderWidth={text('borderWidth', '2px')}
-      borderStyle={text('borderStyle', 'solid')}
-      textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
-      padding={select('padding', sizes, 4)}
-      borderRadius={object('borderRadius', defaultBorderRadiusObj)}
-      borderTopLeftRadius={object('borderTopLeftRadius', {})}
-      borderTopRightRadius={object('borderTopRightRadius', {})}
-      borderBottomRightRadius={object('borderBottomRightRadius', {})}
-      borderBottomLeftRadius={object('borderBottomLeftRadius', {})}
-    >
-      {text('children', 'Example Content')}
-    </Box>
-  ))
+export default {
+  title: 'Box',
+  component: Box,
+} as Meta
+
+export const BasicUsageWithThemeBuildInValues = (): React.ReactElement => (
+  <Box
+    position={select('position', positionOptions, 'initial') as Property.Position}
+    display={select('display', displayOptions, 'initial')}
+    top={text('top', '')}
+    right={text('right', '')}
+    bottom={text('bottom', '')}
+    left={text('left', '')}
+    margin={select('margin', sizes, 0)}
+    padding={select('padding', sizes, 4)}
+    width={text('width', '120px')}
+    maxWidth={text('maxWidth', '')}
+    minWidth={text('minWidth', '')}
+    height={text('height', '120px')}
+    maxHeight={text('maxHeight', '100vh')}
+    minHeight={text('minHeight', '10px')}
+    backgroundColor={select('backgroundColor (bg)', themeColors, 'lightContrast')}
+    color={select('color', themeColors, 'darkestContrast')}
+    borderColor={select('borderColor', themeColors, 'darkestContrast')}
+    borderWidth={text('borderWidth', '2px')}
+    borderRadius={text('borderRadius', '')}
+    borderStyle={text('borderStyle', 'solid')}
+    textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
+    zIndex={text('zIndex', '') as Property.ZIndex}
+    overflow={text('overflow', '') as Property.Overflow}
+    overflowX={text('overflowX', '') as Property.OverflowX}
+    overflowY={text('overflowY', '') as Property.OverflowY}
+  >
+    {text('children', 'Example Content')}
+  </Box>
+)
+
+BasicUsageWithThemeBuildInValues.storyName = 'Basic Usage with theme build-in values'
+
+export const UsingColorStylesForColorAndBackground = (): React.ReactElement => (
+  <Box
+    colors={select('colors', colorStyles, 'callToAction')}
+    margin={select('margin', sizes, 0)}
+    padding={select('padding', sizes, 4)}
+    width={text('width', '100px')}
+    height={text('height', '100px')}
+    borderColor={select('borderColor', themeColors, 'darkestContrast')}
+    borderWidth={text('borderWidth', '')}
+    borderRadius={text('borderRadius', '')}
+    borderStyle={text('borderStyle', '')}
+    textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
+  >
+    {text('children', 'Example Content')}
+  </Box>
+)
+
+UsingColorStylesForColorAndBackground.storyName = 'Using colorStyles for color and background'
+
+export const CustomBorderRadiusDefinitions = (): React.ReactElement => (
+  <Box
+    width={text('width', '120px')}
+    height={text('height', '120px')}
+    color={select('color', themeColors, 'darkestContrast')}
+    backgroundColor={select('backgroundColor (bg)', themeColors, 'lightContrast')}
+    borderColor={select('borderColor', themeColors, 'darkestContrast')}
+    borderWidth={text('borderWidth', '2px')}
+    borderStyle={text('borderStyle', 'solid')}
+    textStyle={select('textStyle', textStyles, 'body') as keyof TextStyleCollection}
+    padding={select('padding', sizes, 4)}
+    borderRadius={object('borderRadius', defaultBorderRadiusObj)}
+    borderTopLeftRadius={object('borderTopLeftRadius', {})}
+    borderTopRightRadius={object('borderTopRightRadius', {})}
+    borderBottomRightRadius={object('borderBottomRightRadius', {})}
+    borderBottomLeftRadius={object('borderBottomLeftRadius', {})}
+  >
+    {text('children', 'Example Content')}
+  </Box>
+)

--- a/modules/cactus-web/src/BrandBar/BrandBar.story.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.story.tsx
@@ -1,12 +1,17 @@
 import { action } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Layout from '../Layout/Layout'
 import BrandBar from './BrandBar'
 
-storiesOf('BrandBar', module).add('Basic Usage', () => (
+export default {
+  title: 'BrandBar',
+  component: BrandBar,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
   <Layout>
     <BrandBar
       isProfilePage={boolean('On profile page?', false)}
@@ -21,4 +26,4 @@ storiesOf('BrandBar', module).add('Basic Usage', () => (
       </BrandBar.UserMenuItem>
     </BrandBar>
   </Layout>
-))
+)

--- a/modules/cactus-web/src/Breadcrumb/Breadcrumb.story.tsx
+++ b/modules/cactus-web/src/Breadcrumb/Breadcrumb.story.tsx
@@ -1,35 +1,36 @@
 import { array, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import Breadcrumb from './Breadcrumb'
 
-storiesOf('Breadcrumb', module).add(
-  'Basic Usage',
-  (): ReactElement => (
+export default {
+  title: 'Breadcrumb',
+  component: Breadcrumb,
+} as Meta
+
+export const BasicUsage = (): ReactElement => (
+  <Breadcrumb>
+    <Breadcrumb.Item label={text('Label 1', 'Account')} linkTo="/" />
+    <Breadcrumb.Item label={<em>{text('Label 2', 'Make a Payment')}</em>} linkTo="/" active />
+  </Breadcrumb>
+)
+
+export const AddMoreBreadcrumbs = (): ReactElement => {
+  const values = array('Add new Links', ['Link 1'])
+
+  return (
     <Breadcrumb>
-      <Breadcrumb.Item label={text('Label 1', 'Account')} linkTo="/" />
-      <Breadcrumb.Item label={<em>{text('Label 2', 'Make a Payment')}</em>} linkTo="/" active />
+      {values.map(
+        (e, i, arr): ReactElement =>
+          arr.length - 1 === i ? (
+            <Breadcrumb.Item label={text(`Label ${i + 1}`, `${e}`)} linkTo="/" active key={i} />
+          ) : (
+            <Breadcrumb.Item label={text(`Label ${i + 1}`, `${e}`)} linkTo="/" key={i} />
+          )
+      )}
     </Breadcrumb>
   )
-)
+}
 
-storiesOf('Breadcrumb', module).add(
-  'Add more Breadcrumbs',
-  (): ReactElement => {
-    const values = array('Add new Links', ['Link 1'])
-
-    return (
-      <Breadcrumb>
-        {values.map(
-          (e, i, arr): ReactElement =>
-            arr.length - 1 === i ? (
-              <Breadcrumb.Item label={text(`Label ${i + 1}`, `${e}`)} linkTo="/" active key={i} />
-            ) : (
-              <Breadcrumb.Item label={text(`Label ${i + 1}`, `${e}`)} linkTo="/" key={i} />
-            )
-        )}
-      </Breadcrumb>
-    )
-  }
-)
+AddMoreBreadcrumbs.storyName = 'Add more Breadcrumbs'

--- a/modules/cactus-web/src/Button/Button.story.tsx
+++ b/modules/cactus-web/src/Button/Button.story.tsx
@@ -1,6 +1,6 @@
 import * as icons from '@repay/cactus-icons'
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import actions from '../helpers/storybookActionsWorkaround'
@@ -10,43 +10,42 @@ type IconName = keyof typeof icons
 const iconNames: IconName[] = Object.keys(icons) as IconName[]
 const buttonVariants: ButtonVariants[] = ['standard', 'action', 'danger', 'warning', 'success']
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
-const buttonStories = storiesOf('Button', module)
 
-buttonStories.add(
-  'Basic Usage',
-  (): ReactElement => (
+export default {
+  title: 'Button',
+  component: Button,
+} as Meta
+
+export const BasicUsage = (): ReactElement => (
+  <Button
+    variant={select('variant', buttonVariants, 'standard')}
+    disabled={boolean('disabled', false)}
+    loading={boolean('loading', false)}
+    inverse={boolean('inverse', false)}
+    loadingText={text('loadingText?', 'loading')}
+    {...eventLoggers}
+  >
+    {text('children', 'A Button')}
+  </Button>
+)
+
+BasicUsage.parameters = { options: { showPanel: true } }
+
+export const WithIcon = (): ReactElement => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName] as React.ComponentType<any>
+  return (
     <Button
       variant={select('variant', buttonVariants, 'standard')}
       disabled={boolean('disabled', false)}
       loading={boolean('loading', false)}
       inverse={boolean('inverse', false)}
-      loadingText={text('loadingText?', 'loading')}
       {...eventLoggers}
     >
-      {text('children', 'A Button')}
+      <Icon /> {text('children', 'Button')}
     </Button>
-  ),
-  { options: { showPanel: true } }
-)
-
-buttonStories.add(
-  'With Icon',
-  (): ReactElement => {
-    const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
-    const Icon = icons[iconName] as React.ComponentType<any>
-    return (
-      <Button
-        variant={select('variant', buttonVariants, 'standard')}
-        disabled={boolean('disabled', false)}
-        loading={boolean('loading', false)}
-        inverse={boolean('inverse', false)}
-        {...eventLoggers}
-      >
-        <Icon /> {text('children', 'Button')}
-      </Button>
-    )
-  }
-)
+  )
+}
 
 interface TimedLoadingProps {
   children: (state: { loading: boolean; onClick: any }) => React.ReactElement<any>
@@ -64,37 +63,35 @@ const TimedLoading: React.FC<TimedLoadingProps> = ({ children }): ReactElement =
   return children({ loading, onClick })
 }
 
-buttonStories.add(
-  'Loading on click',
-  (): ReactElement => {
-    return (
-      <TimedLoading>
-        {({ loading, onClick }): ReactElement => (
-          <Button
-            variant={select('variant', buttonVariants, 'standard')}
-            disabled={boolean('disabled', false)}
-            inverse={boolean('inverse', false)}
-            loading={loading}
-            onClick={onClick}
-          >
-            {text('children', 'Submit')}
-          </Button>
-        )}
-      </TimedLoading>
-    )
-  }
+export const LoadingOnClick = (): ReactElement => {
+  return (
+    <TimedLoading>
+      {({ loading, onClick }): ReactElement => (
+        <Button
+          variant={select('variant', buttonVariants, 'standard')}
+          disabled={boolean('disabled', false)}
+          inverse={boolean('inverse', false)}
+          loading={loading}
+          onClick={onClick}
+        >
+          {text('children', 'Submit')}
+        </Button>
+      )}
+    </TimedLoading>
+  )
+}
+
+LoadingOnClick.storyName = 'Loading on click'
+
+export const AsLink = (): ReactElement => (
+  <Button
+    variant={select('variant', buttonVariants, 'standard')}
+    disabled={boolean('disabled', false)}
+    as="a"
+    href="https://google.com"
+  >
+    Link Button
+  </Button>
 )
 
-buttonStories.add(
-  'as Link',
-  (): ReactElement => (
-    <Button
-      variant={select('variant', buttonVariants, 'standard')}
-      disabled={boolean('disabled', false)}
-      as="a"
-      href="https://google.com"
-    >
-      Link Button
-    </Button>
-  )
-)
+AsLink.storyName = 'As Link'

--- a/modules/cactus-web/src/Card/Card.story.tsx
+++ b/modules/cactus-web/src/Card/Card.story.tsx
@@ -1,73 +1,66 @@
 import { boolean, date, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Box from '../Box/Box'
 import Card from './Card'
 
-storiesOf('Card', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => (
-      <Card
-        margin="40px"
-        useBoxShadow={boolean('useBoxShadow', true)}
-        padding={text('padding', '')}
-        paddingX={text('paddingX', '')}
-        paddingY={text('paddingY', '')}
-      >
-        <h2 style={{ margin: 0 }}>{text('Title', 'Title')}</h2>
-        <h4 style={{ margin: '0 0 8px', fontWeight: 400, fontSize: '12px' }}>
-          {text('Subtitle', 'Subtitle')}
-        </h4>
+export default {
+  title: 'Card',
+  component: Card,
+} as Meta
 
-        <table style={{ fontSize: '15px', borderCollapse: 'collapse' }}>
-          <tbody>
-            <tr>
-              <Box
-                as="th"
-                style={{ textAlign: 'left', padding: '4px 60px 4px 0', fontSize: '12px' }}
-              >
-                Total Amount Due
-              </Box>
-              <td>
-                <span style={{ textAlign: 'right', fontWeight: 600, fontSize: '25.92px' }}>
-                  {text('Total Amount', '$350.20')}
-                </span>
-              </td>
-            </tr>
+export const BasicUsage = (): React.ReactElement => (
+  <Card
+    margin="40px"
+    useBoxShadow={boolean('useBoxShadow', true)}
+    padding={text('padding', '')}
+    paddingX={text('paddingX', '')}
+    paddingY={text('paddingY', '')}
+  >
+    <h2 style={{ margin: 0 }}>{text('Title', 'Title')}</h2>
+    <h4 style={{ margin: '0 0 8px', fontWeight: 400, fontSize: '12px' }}>
+      {text('Subtitle', 'Subtitle')}
+    </h4>
 
-            <tr>
-              <th style={{ textAlign: 'left', fontWeight: 'normal', fontSize: '12px' }}>
-                {' '}
-                Due Date{' '}
-              </th>
-              <td style={{ textAlign: 'right', fontWeight: 600, fontSize: '12px' }}>
-                {new Date(date('Date', new Date('10/5/2020'))).toLocaleDateString()}
-              </td>
-            </tr>
+    <table style={{ fontSize: '15px', borderCollapse: 'collapse' }}>
+      <tbody>
+        <tr>
+          <Box as="th" style={{ textAlign: 'left', padding: '4px 60px 4px 0', fontSize: '12px' }}>
+            Total Amount Due
+          </Box>
+          <td>
+            <span style={{ textAlign: 'right', fontWeight: 600, fontSize: '25.92px' }}>
+              {text('Total Amount', '$350.20')}
+            </span>
+          </td>
+        </tr>
 
-            <tr>
-              <th style={{ textAlign: 'left', fontWeight: 'normal', fontSize: '12px' }}>
-                Minimum Amount Due
-              </th>
-              <td style={{ textAlign: 'right', fontWeight: 600, fontSize: '12px' }}>
-                {text('Minimum Amount', '$127.00')}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </Card>
-    )
-  )
-  .add(
-    'Nested Cards',
-    (): React.ReactElement => (
-      <Card>
-        Card 1
-        <Card>
-          Card 2<Card>Card 3</Card>
-        </Card>
-      </Card>
-    )
-  )
+        <tr>
+          <th style={{ textAlign: 'left', fontWeight: 'normal', fontSize: '12px' }}> Due Date </th>
+          <td style={{ textAlign: 'right', fontWeight: 600, fontSize: '12px' }}>
+            {new Date(date('Date', new Date('10/5/2020'))).toLocaleDateString()}
+          </td>
+        </tr>
+
+        <tr>
+          <th style={{ textAlign: 'left', fontWeight: 'normal', fontSize: '12px' }}>
+            Minimum Amount Due
+          </th>
+          <td style={{ textAlign: 'right', fontWeight: 600, fontSize: '12px' }}>
+            {text('Minimum Amount', '$127.00')}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </Card>
+)
+
+export const NestedCards = (): React.ReactElement => (
+  <Card>
+    Card 1
+    <Card>
+      Card 2<Card>Card 3</Card>
+    </Card>
+  </Card>
+)

--- a/modules/cactus-web/src/CheckBox/CheckBox.story.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.story.tsx
@@ -1,29 +1,27 @@
 import { boolean } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import actions from '../helpers/storybookActionsWorkaround'
 import CheckBox from './CheckBox'
 
-const checkBoxStories = storiesOf('CheckBox', module)
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
-checkBoxStories.add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <CheckBox id="test" name="kaneki" disabled={boolean('disabled', false)} {...eventLoggers} />
-  )
+export default {
+  title: 'CheckBox',
+  component: CheckBox,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <CheckBox id="test" name="kaneki" disabled={boolean('disabled', false)} {...eventLoggers} />
 )
 
-checkBoxStories.add(
-  'Controlling Value Through Props',
-  (): React.ReactElement => (
-    <CheckBox
-      id="test"
-      name="touka"
-      disabled={boolean('disabled', false)}
-      checked={boolean('checked', false)}
-      {...eventLoggers}
-    />
-  )
+export const ControllingValueThroughProps = (): React.ReactElement => (
+  <CheckBox
+    id="test"
+    name="touka"
+    disabled={boolean('disabled', false)}
+    checked={boolean('checked', false)}
+    {...eventLoggers}
+  />
 )

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.story.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.story.tsx
@@ -1,30 +1,29 @@
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import CheckBoxField from './CheckBoxField'
 
-const checkBoxFieldStories = storiesOf('CheckBoxField', module)
+export default {
+  title: 'CheckBoxField',
+  component: CheckBoxField,
+} as Meta
 
-checkBoxFieldStories.add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <CheckBoxField
-      name={text('name', 'CheckBoxFormField')}
-      id={text('id', 'checkbox-1')}
-      label={text('label', 'A Label')}
-      disabled={boolean('disabled', false)}
-    />
-  )
+export const BasicUsage = (): React.ReactElement => (
+  <CheckBoxField
+    name={text('name', 'CheckBoxFormField')}
+    id={text('id', 'checkbox-1')}
+    label={text('label', 'A Label')}
+    disabled={boolean('disabled', false)}
+  />
 )
 
-checkBoxFieldStories.add(
-  'Multiple CheckBox Fields',
-  (): React.ReactElement => (
-    <div>
-      <CheckBoxField name="CheckBoxFormField" label="Label 1" />
-      <CheckBoxField name="CheckBoxFormField" label="Label 2" />
-      <CheckBoxField name="CheckBoxFormField" label="Label 3" />
-    </div>
-  )
+export const MultipleCheckBoxFields = (): React.ReactElement => (
+  <div>
+    <CheckBoxField name="CheckBoxFormField" label="Label 1" />
+    <CheckBoxField name="CheckBoxFormField" label="Label 2" />
+    <CheckBoxField name="CheckBoxFormField" label="Label 3" />
+  </div>
 )
+
+MultipleCheckBoxFields.storyName = 'Multiple CheckBox Fields'

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.story.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.story.tsx
@@ -1,62 +1,59 @@
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { useState } from 'react'
 
 import Flex from '../Flex/Flex'
 import CheckBoxGroup from './CheckBoxGroup'
 
-const checkBoxGroupStories = storiesOf('CheckBoxGroup', module)
+export default {
+  title: 'CheckBoxGroup',
+  component: CheckBoxGroup,
+} as Meta
 
-checkBoxGroupStories.add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <CheckBoxGroup
-      name="checkboxes"
-      id="cbg"
-      label={text('label', 'My Label')}
-      disabled={boolean('disabled', false)}
-      onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
-      onFocus={(name) => console.log(`'${name}' focused`)}
-      onBlur={(name) => console.log(`'${name}' blurred`)}
-      tooltip={text('tooltip', 'Check some boxes')}
-      autoTooltip={boolean('autoTooltip', true)}
-      error={text('error', '')}
-      success={text('success', '')}
-      warning={text('warning', '')}
-    >
-      <CheckBoxGroup.Item name="option-1" label="Option 1" />
-      <CheckBoxGroup.Item name="option-2" label="Option 2" />
-      <CheckBoxGroup.Item name="option-3" label="Option 3" />
-    </CheckBoxGroup>
+export const BasicUsage = (): React.ReactElement => (
+  <CheckBoxGroup
+    name="checkboxes"
+    id="cbg"
+    label={text('label', 'My Label')}
+    disabled={boolean('disabled', false)}
+    onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
+    onFocus={(name) => console.log(`'${name}' focused`)}
+    onBlur={(name) => console.log(`'${name}' blurred`)}
+    tooltip={text('tooltip', 'Check some boxes')}
+    autoTooltip={boolean('autoTooltip', true)}
+    error={text('error', '')}
+    success={text('success', '')}
+    warning={text('warning', '')}
+  >
+    <CheckBoxGroup.Item name="option-1" label="Option 1" />
+    <CheckBoxGroup.Item name="option-2" label="Option 2" />
+    <CheckBoxGroup.Item name="option-3" label="Option 3" />
+  </CheckBoxGroup>
+)
+
+export const WithValues = (): React.ReactElement => {
+  const [value, setValue] = useState<{
+    'option-1': boolean
+    'option-2': boolean
+    'option-3': boolean
+  }>({ 'option-1': true, 'option-2': false, 'option-3': false })
+  return (
+    <Flex>
+      <CheckBoxGroup
+        name="controller"
+        label="Controller"
+        checked={value}
+        onChange={(name, val) => setValue((value) => ({ ...value, [name]: val }))}
+      >
+        <CheckBoxGroup.Item name="option-1" label="Option 1" />
+        <CheckBoxGroup.Item name="option-2" label="Option 2" />
+        <CheckBoxGroup.Item name="option-3" label="Option 3" />
+      </CheckBoxGroup>
+      <CheckBoxGroup name="follower" label="Follower">
+        <CheckBoxGroup.Item checked={value['option-1']} name="option-4" label="Option 4" />
+        <CheckBoxGroup.Item checked={value['option-2']} name="option-5" label="Option 5" />
+        <CheckBoxGroup.Item checked={value['option-3']} name="option-6" label="Option 6" />
+      </CheckBoxGroup>
+    </Flex>
   )
-)
-
-checkBoxGroupStories.add(
-  'With Values',
-  (): React.ReactElement => {
-    const [value, setValue] = useState<{
-      'option-1': boolean
-      'option-2': boolean
-      'option-3': boolean
-    }>({ 'option-1': true, 'option-2': false, 'option-3': false })
-    return (
-      <Flex>
-        <CheckBoxGroup
-          name="controller"
-          label="Controller"
-          checked={value}
-          onChange={(name, val) => setValue((value) => ({ ...value, [name]: val }))}
-        >
-          <CheckBoxGroup.Item name="option-1" label="Option 1" />
-          <CheckBoxGroup.Item name="option-2" label="Option 2" />
-          <CheckBoxGroup.Item name="option-3" label="Option 3" />
-        </CheckBoxGroup>
-        <CheckBoxGroup name="follower" label="Follower">
-          <CheckBoxGroup.Item checked={value['option-1']} name="option-4" label="Option 4" />
-          <CheckBoxGroup.Item checked={value['option-2']} name="option-5" label="Option 5" />
-          <CheckBoxGroup.Item checked={value['option-3']} name="option-6" label="Option 6" />
-        </CheckBoxGroup>
-      </Flex>
-    )
-  }
-)
+}

--- a/modules/cactus-web/src/ConfirmModal/ConfirmModal.story.tsx
+++ b/modules/cactus-web/src/ConfirmModal/ConfirmModal.story.tsx
@@ -1,6 +1,6 @@
 import * as icons from '@repay/cactus-icons'
 import { select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { useState } from 'react'
 
 import Button from '../Button/Button'
@@ -9,7 +9,6 @@ import Text from '../Text/Text'
 import TextInput from '../TextInput/TextInput'
 import ConfirmModal from './ConfirmModal'
 
-const confirmModalStories = storiesOf('ConfirmModal', module)
 type IconName = keyof typeof icons
 const iconNames: IconName[] = Object.keys(icons) as IconName[]
 
@@ -20,6 +19,12 @@ const statusOptions: StatusOptions = {
   warning: 'warning',
   success: 'success',
 }
+
+export default {
+  title: 'ConfirmModal',
+  component: ConfirmModal,
+} as Meta
+
 const ConfirmModalExample = (): React.ReactElement => {
   const [isOpen, setOpen] = useState(false)
   const cancelText = text('Cancel Button Text', 'Cancel')
@@ -90,5 +95,7 @@ const ConfirmModalExample2 = (): React.ReactElement => {
   )
 }
 
-confirmModalStories.add('Basic Usage', (): React.ReactElement => <ConfirmModalExample />)
-confirmModalStories.add('With text input icon', (): React.ReactElement => <ConfirmModalExample2 />)
+export const BasicUsage = (): React.ReactElement => <ConfirmModalExample />
+export const WithTextInputIcon = (): React.ReactElement => <ConfirmModalExample2 />
+
+WithTextInputIcon.storyName = 'With text input icon'

--- a/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
@@ -1,5 +1,5 @@
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement, useState } from 'react'
 
 import ScreenSizeProvider from '../ScreenSizeProvider/ScreenSizeProvider'
@@ -273,57 +273,64 @@ const DataGridContainer = ({
   )
 }
 
-storiesOf('DataGrid', module)
-  .add('Basic Usage', (): ReactElement => <DataGridContainer initialData={INITIAL_DATA} />, {
-    cactus: {
-      overrides: {
-        display: 'block',
-        textAlign: 'center',
-        paddingTop: '16px',
-        paddingBottom: '16px',
-      },
+export default {
+  title: 'DataGrid',
+  component: DataGrid,
+} as Meta
+
+export const BasicUsage = (): ReactElement => <DataGridContainer initialData={INITIAL_DATA} />
+
+BasicUsage.parameters = {
+  cactus: {
+    overrides: {
+      display: 'block',
+      textAlign: 'center',
+      paddingTop: '16px',
+      paddingBottom: '16px',
     },
-  })
-  .add(
-    'Lots and Lots of Rows',
-    () => (
-      <DataGridContainer
-        initialData={INITIAL_DATA.concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)
-          .concat(INITIAL_DATA)}
-        includePaginationAndSort={false}
-      />
-    ),
-    {
-      cactus: {
-        overrides: {
-          display: 'block',
-          textAlign: 'center',
-          paddingTop: '16px',
-          paddingBottom: '16px',
-        },
-      },
-    }
-  )
+  },
+}
+
+export const LotsAndLotsOfRows = (): React.ReactElement => (
+  <DataGridContainer
+    initialData={INITIAL_DATA.concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)
+      .concat(INITIAL_DATA)}
+    includePaginationAndSort={false}
+  />
+)
+
+LotsAndLotsOfRows.storyName = 'Lots and Lots of Rows'
+
+LotsAndLotsOfRows.parameters = {
+  cactus: {
+    overrides: {
+      display: 'block',
+      textAlign: 'center',
+      paddingTop: '16px',
+      paddingBottom: '16px',
+    },
+  },
+}

--- a/modules/cactus-web/src/DateInput/DateInput.story.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.story.tsx
@@ -1,6 +1,6 @@
 import { actions } from '@storybook/addon-actions'
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import FormHandler from '../storySupport/FormHandler'
@@ -8,102 +8,108 @@ import DateInput from './DateInput'
 
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
-storiesOf('DateInput', module)
-  .add(
-    'Basic Usage',
-    (): ReactElement => (
+export default {
+  title: 'DateInput',
+  component: DateInput,
+} as Meta
+
+export const BasicUsage = (): ReactElement => (
+  <DateInput
+    id="date-input-uncontrolled"
+    name="date"
+    {...eventLoggers}
+    disabled={boolean('disabled', false)}
+  />
+)
+
+BasicUsage.parameters = {
+  cactus: { overrides: { alignItems: 'start', paddingTop: '32px' } },
+}
+
+export const ControlledWithDate = (): ReactElement => (
+  <FormHandler
+    defaultValue={new Date('10/1/2020')}
+    onChange={(_, value: string | Date | null): string | Date | null => value}
+  >
+    {({ value, onChange }): ReactElement => (
       <DateInput
-        id="date-input-uncontrolled"
-        name="date"
-        {...eventLoggers}
         disabled={boolean('disabled', false)}
+        id="date-input-1"
+        name={text('name', 'date-input')}
+        type={select('type', ['date', 'datetime', 'time'], 'date')}
+        value={value}
+        onChange={onChange}
       />
-    ),
-    {
-      cactus: { overrides: { alignItems: 'start', paddingTop: '32px' } },
-    }
-  )
-  .add(
-    'Controlled with Date',
-    (): ReactElement => (
-      <FormHandler
-        defaultValue={new Date('10/1/2020')}
-        onChange={(_, value: string | Date | null): string | Date | null => value}
-      >
-        {({ value, onChange }): ReactElement => (
-          <DateInput
-            disabled={boolean('disabled', false)}
-            id="date-input-1"
-            name={text('name', 'date-input')}
-            type={select('type', ['date', 'datetime', 'time'], 'date')}
-            value={value}
-            onChange={onChange}
-          />
-        )}
-      </FormHandler>
-    ),
-    { cactus: { overrides: { alignItems: 'start', paddingTop: '32px' } } }
-  )
-  .add(
-    'Controlled with string',
-    (): ReactElement => (
-      <FormHandler
-        defaultValue="2019-09-16"
-        onChange={(_, value: string | Date | null): string | Date | null => value}
-      >
-        {({ value, onChange }): ReactElement => (
-          <DateInput
-            disabled={boolean('disabled', false)}
-            id="date-input-with-string-value"
-            name={text('name', 'date-input-with-string-value')}
-            value={value}
-            format="YYYY-MM-dd"
-            onChange={onChange}
-          />
-        )}
-      </FormHandler>
-    ),
-    { cactus: { overrides: { alignItems: 'start', paddingTop: '32px' } } }
-  )
-  .add(
-    'type="time"',
-    (): ReactElement => (
+    )}
+  </FormHandler>
+)
+
+ControlledWithDate.storyName = 'Controlled with Date'
+ControlledWithDate.parameters = {
+  cactus: { overrides: { alignItems: 'start', paddingTop: '32px' } },
+}
+
+export const ControlledWithString = (): ReactElement => (
+  <FormHandler
+    defaultValue="2019-09-16"
+    onChange={(_, value: string | Date | null): string | Date | null => value}
+  >
+    {({ value, onChange }): ReactElement => (
       <DateInput
-        id="time-input"
-        name="time"
-        type="time"
-        {...eventLoggers}
         disabled={boolean('disabled', false)}
+        id="date-input-with-string-value"
+        name={text('name', 'date-input-with-string-value')}
+        value={value}
+        format="YYYY-MM-dd"
+        onChange={onChange}
       />
-    )
-  )
-  .add(
-    'type="datetime"',
-    (): ReactElement => (
-      <DateInput
-        id="datetime-input"
-        name="datetime"
-        type="datetime"
-        {...eventLoggers}
-        disabled={boolean('disabled', false)}
-      />
-    )
-  )
-  .add(
-    'with isValidDate',
-    (): ReactElement => (
-      <div>
-        <DateInput
-          disabled={boolean('disabled', false)}
-          type="date"
-          id="date-with-blackouts"
-          name="date_with_blackouts"
-          isValidDate={(date): boolean => {
-            const day = date.getDay()
-            return day !== 0 && day !== 6
-          }}
-        />
-        <p>Only business days are allowed.</p>
-      </div>
-    )
-  )
+    )}
+  </FormHandler>
+)
+
+ControlledWithString.storyName = 'Controlled with string'
+ControlledWithString.parameters = {
+  cactus: { overrides: { alignItems: 'start', paddingTop: '32px' } },
+}
+
+export const TypeTime = (): ReactElement => (
+  <DateInput
+    id="time-input"
+    name="time"
+    type="time"
+    {...eventLoggers}
+    disabled={boolean('disabled', false)}
+  />
+)
+
+TypeTime.storyName = 'type="time"'
+
+export const TypeDatetime = (): ReactElement => (
+  <DateInput
+    id="datetime-input"
+    name="datetime"
+    type="datetime"
+    {...eventLoggers}
+    disabled={boolean('disabled', false)}
+  />
+)
+
+TypeDatetime.storyName = 'type="datetime"'
+
+export const WithIsValidDate = (): ReactElement => (
+  <div>
+    <DateInput
+      disabled={boolean('disabled', false)}
+      type="date"
+      id="date-with-blackouts"
+      name="date_with_blackouts"
+      isValidDate={(date): boolean => {
+        const day = date.getDay()
+        return day !== 0 && day !== 6
+      }}
+    />
+    <p>Only business days are allowed.</p>
+  </div>
+)
+
+WithIsValidDate.storyname = 'with isValidDate'

--- a/modules/cactus-web/src/DateInputField/DateInputField.story.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.story.tsx
@@ -1,37 +1,38 @@
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import DateInputField from './DateInputField'
 
 const dateInputTypes: ('date' | 'datetime' | 'time')[] = ['date', 'datetime', 'time']
 
-storiesOf('DateInputField', module)
-  .add(
-    'Default Usage',
-    (): React.ReactElement => (
-      <DateInputField
-        disabled={boolean('disabled', false)}
-        label={text('label', 'Date Input Field')}
-        name={text('name', 'date_input_field')}
-        type={select('type?', dateInputTypes, 'date')}
-        width="350px"
-      />
-    )
-  )
-  .add(
-    'extended props',
-    (): React.ReactElement => (
-      <DateInputField
-        disabled={boolean('disabled', false)}
-        label={text('label', 'Time field')}
-        name={text('name', 'date_input_field')}
-        type={select('type?', dateInputTypes, 'date')}
-        tooltip={text('tooltip?', '')}
-        error={text('error?', '')}
-        success={text('success?', '')}
-        warning={text('warning?', '')}
-        autoTooltip={boolean('autoTooltip', true)}
-      />
-    )
-  )
+export default {
+  title: 'DateInputField',
+  component: DateInputField,
+} as Meta
+
+export const DefaultUsage = (): React.ReactElement => (
+  <DateInputField
+    disabled={boolean('disabled', false)}
+    label={text('label', 'Date Input Field')}
+    name={text('name', 'date_input_field')}
+    type={select('type?', dateInputTypes, 'date')}
+    width="350px"
+  />
+)
+
+export const ExtendedProps = (): React.ReactElement => (
+  <DateInputField
+    disabled={boolean('disabled', false)}
+    label={text('label', 'Time field')}
+    name={text('name', 'date_input_field')}
+    type={select('type?', dateInputTypes, 'date')}
+    tooltip={text('tooltip?', '')}
+    error={text('error?', '')}
+    success={text('success?', '')}
+    warning={text('warning?', '')}
+    autoTooltip={boolean('autoTooltip', true)}
+  />
+)
+
+ExtendedProps.storyName = 'extended props'

--- a/modules/cactus-web/src/FieldWrapper/FieldWrapper.story.tsx
+++ b/modules/cactus-web/src/FieldWrapper/FieldWrapper.story.tsx
@@ -1,4 +1,4 @@
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement, useCallback, useReducer } from 'react'
 
 import Box from '../Box/Box'
@@ -224,6 +224,9 @@ const ExampleForm = ({ withValidations }: { withValidations?: boolean }): ReactE
   )
 }
 
-storiesOf('FormField', module)
-  .add('Basic Usage', (): ReactElement => <ExampleForm />)
-  .add('With Statuses', (): ReactElement => <ExampleForm withValidations />)
+export default {
+  title: 'FormField',
+} as Meta
+
+export const BasicUsage = (): ReactElement => <ExampleForm />
+export const WithStatuses = (): ReactElement => <ExampleForm withValidations />

--- a/modules/cactus-web/src/FileInput/FileInput.story.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.story.tsx
@@ -1,32 +1,34 @@
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import FileInput from './FileInput'
 
-storiesOf('FileInput', module).add(
-  'Basic Usage',
-  (): React.ReactElement => {
-    const fileTypes = ['.doc', '.txt', '.md']
-    return (
-      <FileInput
-        name="my-file-loader"
-        disabled={boolean('disabled', false)}
-        rawFiles={boolean('rawFiles', false)}
-        multiple={boolean('multiple', true)}
-        accept={fileTypes}
-        labels={{
-          delete: text('delete label', 'Click to delete file'),
-          loading: text('loading label', 'File uploading'),
-          loaded: text('loaded label', 'File uploaded successfully'),
-        }}
-        prompt={text('prompt', 'Drag files here or')}
-        buttonText={text('buttonText', 'Select Files...')}
-        onChange={(name, files): void => {
-          console.log(name)
-          console.log(files)
-        }}
-      />
-    )
-  }
-)
+export default {
+  title: 'FileInput',
+  component: FileInput,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
+  const fileTypes = ['.doc', '.txt', '.md']
+  return (
+    <FileInput
+      name="my-file-loader"
+      disabled={boolean('disabled', false)}
+      rawFiles={boolean('rawFiles', false)}
+      multiple={boolean('multiple', true)}
+      accept={fileTypes}
+      labels={{
+        delete: text('delete label', 'Click to delete file'),
+        loading: text('loading label', 'File uploading'),
+        loaded: text('loaded label', 'File uploaded successfully'),
+      }}
+      prompt={text('prompt', 'Drag files here or')}
+      buttonText={text('buttonText', 'Select Files...')}
+      onChange={(name, files): void => {
+        console.log(name)
+        console.log(files)
+      }}
+    />
+  )
+}

--- a/modules/cactus-web/src/FileInputField/FileInputField.story.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.story.tsx
@@ -1,31 +1,33 @@
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import FileInputField from './FileInputField'
 
-storiesOf('FileInputField', module).add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <FileInputField
-      label={text('label', 'File Input Field')}
-      disabled={boolean('disabled', false)}
-      accept={['.md', '.txt']}
-      name="input-field"
-      tooltip={text('tooltip', 'Upload files from your system')}
-      rawFiles={boolean('rawFiles', false)}
-      multiple={boolean('multiple', true)}
-      labels={{
-        delete: text('delete label', 'Click to delete file'),
-        loading: text('loading label', 'File uploading'),
-        loaded: text('loaded label', 'File uploaded successfully'),
-      }}
-      prompt={text('prompt', 'Drag files here or')}
-      buttonText={text('buttonText', 'Select Files...')}
-      success={text('success', '')}
-      warning={text('warning', '')}
-      error={text('error', '')}
-      autoTooltip={boolean('autoTooltip', false)}
-    />
-  )
+export default {
+  title: 'FileInputField',
+  component: FileInputField,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <FileInputField
+    label={text('label', 'File Input Field')}
+    disabled={boolean('disabled', false)}
+    accept={['.md', '.txt']}
+    name="input-field"
+    tooltip={text('tooltip', 'Upload files from your system')}
+    rawFiles={boolean('rawFiles', false)}
+    multiple={boolean('multiple', true)}
+    labels={{
+      delete: text('delete label', 'Click to delete file'),
+      loading: text('loading label', 'File uploading'),
+      loaded: text('loaded label', 'File uploaded successfully'),
+    }}
+    prompt={text('prompt', 'Drag files here or')}
+    buttonText={text('buttonText', 'Select Files...')}
+    success={text('success', '')}
+    warning={text('warning', '')}
+    error={text('error', '')}
+    autoTooltip={boolean('autoTooltip', false)}
+  />
 )

--- a/modules/cactus-web/src/Flex/Flex.story.tsx
+++ b/modules/cactus-web/src/Flex/Flex.story.tsx
@@ -1,5 +1,5 @@
 import { select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import { Property } from 'csstype'
 import React from 'react'
 
@@ -21,19 +21,24 @@ const directionOptions = ['unset', 'row', 'row-reverse', 'column', 'column-rever
 
 const flexWrapOptions = ['unset', 'initial', 'wrap', 'nowrap', 'wrap-reverse']
 
-storiesOf('Flex', module).add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <Flex
-      justifyContent={select('justifyContent', justifyOptions, 'flex-end')}
-      alignItems={select('alignItems', alignOptions, 'center')}
-      flexWrap={select('flexWrap', flexWrapOptions, 'wrap') as Property.FlexWrap}
-      flexDirection={select('flexDirection', directionOptions, 'row') as Property.FlexDirection}
-      height={text('height', '100%')}
-    >
-      <Flex alignSelf={select('alignSelf', alignOptions, 'unset')} p={5} colors="base" />
-      <Flex p={5} colors="darkestContrast" />
-    </Flex>
-  ),
-  { cactus: { overrides: { width: '100%', height: '100vh', display: 'block' } } }
+export default {
+  title: 'Flex',
+  component: Flex,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <Flex
+    justifyContent={select('justifyContent', justifyOptions, 'flex-end')}
+    alignItems={select('alignItems', alignOptions, 'center')}
+    flexWrap={select('flexWrap', flexWrapOptions, 'wrap') as Property.FlexWrap}
+    flexDirection={select('flexDirection', directionOptions, 'row') as Property.FlexDirection}
+    height={text('height', '100%')}
+  >
+    <Flex alignSelf={select('alignSelf', alignOptions, 'unset')} p={5} colors="base" />
+    <Flex p={5} colors="darkestContrast" />
+  </Flex>
 )
+
+BasicUsage.parameters = {
+  cactus: { overrides: { width: '100%', height: '100vh', display: 'block' } },
+}

--- a/modules/cactus-web/src/Footer/Footer.story.tsx
+++ b/modules/cactus-web/src/Footer/Footer.story.tsx
@@ -1,5 +1,5 @@
 import { number, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import { ScreenSizeProvider } from '../ScreenSizeProvider/ScreenSizeProvider'
@@ -20,7 +20,12 @@ const LINK_TEXT = [
 
 const LINKS = ['repay.com', 'google.com', 'microsoft.com']
 
-storiesOf('Footer', module).add('Basic Usage', () => {
+export default {
+  title: 'Footer',
+  component: Footer,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
   const customContent = text('custom content', 'Some Custom Footer Content')
   let numLinks = number('number of links', 2)
   numLinks -= 2
@@ -52,4 +57,4 @@ storiesOf('Footer', module).add('Basic Usage', () => {
       </Footer>
     </ScreenSizeProvider>
   )
-})
+}

--- a/modules/cactus-web/src/Grid/Grid.story.tsx
+++ b/modules/cactus-web/src/Grid/Grid.story.tsx
@@ -1,150 +1,152 @@
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Box from '../Box/Box'
 import Grid from './Grid'
 
-storiesOf('Grid', module).add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <Grid>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+export default {
+  title: 'Grid',
+  component: Grid,
+} as Meta
 
-      <Grid.Item tiny={4} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+export const BasicUsage = (): React.ReactElement => (
+  <Grid>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={3} medium={3}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={3}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={3}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={3}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={4} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={4} medium={4}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={4}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={4}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={3} medium={3}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={3}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={3}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={3}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={6} medium={5}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={4}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={3}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={4} medium={4}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={4}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={4}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={6} medium={6}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={6} medium={6}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={6} medium={5}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={4}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={3}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={6} medium={7}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={3}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={6} medium={6}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={6} medium={6}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={8} medium={8}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={4} medium={4}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={6} medium={7}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={3}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={9} medium={9}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={3}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={8} medium={8}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={4} medium={4}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={9} medium={10}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={2}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={9} medium={9}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={3}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={9} medium={11}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-      <Grid.Item tiny={3} medium={1}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
+    <Grid.Item tiny={9} medium={10}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={2}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
 
-      <Grid.Item tiny={12} medium={12}>
-        <Box height="25px" width="100%" backgroundColor="pink" />
-      </Grid.Item>
-    </Grid>
-  )
+    <Grid.Item tiny={9} medium={11}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+    <Grid.Item tiny={3} medium={1}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+
+    <Grid.Item tiny={12} medium={12}>
+      <Box height="25px" width="100%" backgroundColor="pink" />
+    </Grid.Item>
+  </Grid>
 )

--- a/modules/cactus-web/src/IconButton/IconButton.story.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.story.tsx
@@ -1,6 +1,6 @@
 import * as icons from '@repay/cactus-icons'
 import { boolean, select } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Grid from '../Grid/Grid'
@@ -13,44 +13,43 @@ type IconName = keyof typeof icons
 const iconNames: IconName[] = Object.keys(icons) as IconName[]
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
 
-storiesOf('IconButton', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => {
-      const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
-      const Icon = icons[iconName] as React.ComponentType<any>
-      return (
-        <IconButton
-          variant={select('variant', iconButtonVariants, 'standard')}
-          iconSize={select('size', iconButtonSizes, 'medium')}
-          disabled={boolean('disabled', false)}
-          inverse={boolean('inverse', false)}
-          label="add"
-          {...eventLoggers}
-        >
-          <Icon />
-        </IconButton>
-      )
-    }
+export default {
+  title: 'IconButton',
+  component: IconButton,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName] as React.ComponentType<any>
+  return (
+    <IconButton
+      variant={select('variant', iconButtonVariants, 'standard')}
+      iconSize={select('size', iconButtonSizes, 'medium')}
+      disabled={boolean('disabled', false)}
+      inverse={boolean('inverse', false)}
+      label="add"
+      {...eventLoggers}
+    >
+      <Icon />
+    </IconButton>
   )
-  .add(
-    'All Icons',
-    (): React.ReactElement => {
-      const variantSelection = select('variant', iconButtonVariants, 'standard')
-      return (
-        <Grid justify="center">
-          {Object.values(icons)
-            .slice(0, Object.keys(icons).length - 2)
-            .map(
-              (Icon: React.ComponentType<any>, ix): React.ReactElement => (
-                <Grid.Item tiny={3} medium={2} large={1} key={ix}>
-                  <IconButton label={`icb-${ix}`} variant={variantSelection}>
-                    <Icon />
-                  </IconButton>
-                </Grid.Item>
-              )
-            )}
-        </Grid>
-      )
-    }
+}
+
+export const AllIcons = (): React.ReactElement => {
+  const variantSelection = select('variant', iconButtonVariants, 'standard')
+  return (
+    <Grid justify="center">
+      {Object.values(icons)
+        .slice(0, Object.keys(icons).length - 2)
+        .map(
+          (Icon: React.ComponentType<any>, ix): React.ReactElement => (
+            <Grid.Item tiny={3} medium={2} large={1} key={ix}>
+              <IconButton label={`icb-${ix}`} variant={variantSelection}>
+                <Icon />
+              </IconButton>
+            </Grid.Item>
+          )
+        )}
+    </Grid>
   )
+}

--- a/modules/cactus-web/src/Label/Label.story.tsx
+++ b/modules/cactus-web/src/Label/Label.story.tsx
@@ -1,12 +1,12 @@
 import { text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Label from './Label'
 
-const labelStories = storiesOf('Label', module)
+export default {
+  title: 'Label',
+  component: Label,
+} as Meta
 
-labelStories.add(
-  'Basic Usage',
-  (): React.ReactElement => <Label>{text('label text', 'A Label')}</Label>
-)
+export const BasicUsage = (): React.ReactElement => <Label>{text('label text', 'A Label')}</Label>

--- a/modules/cactus-web/src/Layout/Layout.story.tsx
+++ b/modules/cactus-web/src/Layout/Layout.story.tsx
@@ -1,6 +1,6 @@
 import { ActionsGear, DescriptiveClock } from '@repay/cactus-icons'
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import ActionBar from '../ActionBar/ActionBar'
@@ -17,102 +17,107 @@ function action(msg: string) {
 const LOGO =
   'https://repay-merchant-resources.s3.amazonaws.com/staging/24bd1970-a677-4ca7-a4d2-e328ddd4691b/repay_logo_new.jpg'
 
-storiesOf('Layout', module).add(
-  'Basic Usage',
-  () => {
-    const hasBrand = boolean('Show Brand Bar', true)
-    const hasMenu = boolean('Show Menu', true)
-    const hasActions = boolean('Show Action Bar', true)
-    const hasFooter = boolean('Show Footer', true)
-    const footerText = text('Footer', 'How will you REPAY us?')
+export default {
+  title: 'Layout',
+  component: Layout,
+} as Meta
 
-    return (
-      <Layout>
-        {hasBrand && (
-          <BrandBar
-            isProfilePage={boolean('On profile page?', false)}
-            userMenuText={text('Menu Title', 'Hershell Jewess')}
-            logo={LOGO}
+export const BasicUsage = (): React.ReactElement => {
+  const hasBrand = boolean('Show Brand Bar', true)
+  const hasMenu = boolean('Show Menu', true)
+  const hasActions = boolean('Show Action Bar', true)
+  const hasFooter = boolean('Show Footer', true)
+  const footerText = text('Footer', 'How will you REPAY us?')
+
+  return (
+    <Layout>
+      {hasBrand && (
+        <BrandBar
+          isProfilePage={boolean('On profile page?', false)}
+          userMenuText={text('Menu Title', 'Hershell Jewess')}
+          logo={LOGO}
+        >
+          <BrandBar.UserMenuItem onSelect={action('Settings')}>Settings</BrandBar.UserMenuItem>
+          <BrandBar.UserMenuItem onSelect={action('Logout')}>Logout</BrandBar.UserMenuItem>
+        </BrandBar>
+      )}
+      {hasMenu && (
+        <MenuBar>
+          <MenuBar.Item onClick={action('Tuesday')}>The Other Day</MenuBar.Item>
+          <MenuBar.Item onClick={action('Mill')}>I saw</MenuBar.Item>
+          <MenuBar.List title="A Bear">
+            <MenuBar.Item onClick={action('RAWR')}>Brown Bear</MenuBar.Item>
+            <MenuBar.Item onClick={action('GRR')}>Polar Bear</MenuBar.Item>
+            <MenuBar.Item onClick={action('ZZZZ')}>Giant Panda</MenuBar.Item>
+            <MenuBar.Item onClick={action('SIZZLE')}>Sun Bear</MenuBar.Item>
+          </MenuBar.List>
+          <MenuBar.Item onClick={action('And Powerful')}>A Great</MenuBar.Item>
+          <MenuBar.Item onClick={action('Iorek Byrnison')}>Big Bear</MenuBar.Item>
+          <MenuBar.Item onClick={action('Dao de jing')}>A Way</MenuBar.Item>
+          <MenuBar.Item onClick={action('Stars')}>Up There</MenuBar.Item>
+        </MenuBar>
+      )}
+      {hasActions && (
+        <ActionBar>
+          <ActionBar.Item
+            id="whattime"
+            icon={<DescriptiveClock />}
+            onClick={() => alert(`It is now ${new Date()}.`)}
+          />
+          <ActionBar.Panel
+            id="settings"
+            icon={<ActionsGear />}
+            popupType="dialog"
+            aria-label="Settings"
           >
-            <BrandBar.UserMenuItem onSelect={action('Settings')}>Settings</BrandBar.UserMenuItem>
-            <BrandBar.UserMenuItem onSelect={action('Logout')}>Logout</BrandBar.UserMenuItem>
-          </BrandBar>
-        )}
-        {hasMenu && (
-          <MenuBar>
-            <MenuBar.Item onClick={action('Tuesday')}>The Other Day</MenuBar.Item>
-            <MenuBar.Item onClick={action('Mill')}>I saw</MenuBar.Item>
-            <MenuBar.List title="A Bear">
-              <MenuBar.Item onClick={action('RAWR')}>Brown Bear</MenuBar.Item>
-              <MenuBar.Item onClick={action('GRR')}>Polar Bear</MenuBar.Item>
-              <MenuBar.Item onClick={action('ZZZZ')}>Giant Panda</MenuBar.Item>
-              <MenuBar.Item onClick={action('SIZZLE')}>Sun Bear</MenuBar.Item>
-            </MenuBar.List>
-            <MenuBar.Item onClick={action('And Powerful')}>A Great</MenuBar.Item>
-            <MenuBar.Item onClick={action('Iorek Byrnison')}>Big Bear</MenuBar.Item>
-            <MenuBar.Item onClick={action('Dao de jing')}>A Way</MenuBar.Item>
-            <MenuBar.Item onClick={action('Stars')}>Up There</MenuBar.Item>
-          </MenuBar>
-        )}
-        {hasActions && (
-          <ActionBar>
-            <ActionBar.Item
-              id="whattime"
-              icon={<DescriptiveClock />}
-              onClick={() => alert(`It is now ${new Date()}.`)}
-            />
-            <ActionBar.Panel
-              id="settings"
-              icon={<ActionsGear />}
-              popupType="dialog"
-              aria-label="Settings"
-            >
-              <TextInputField label="Some Setting" name="setting" />
-            </ActionBar.Panel>
-          </ActionBar>
-        )}
-        <Layout.Content>
-          <h1>Latin Or Something</h1>
-          <TextInputField name="foo" label="Foo" />
-          <TextInputField name="bar" label="Bar" />
-          <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas augue ex, dignissim
-            sed fringilla nec, tincidunt fermentum libero. Mauris ut enim ornare, euismod nibh at,
-            ultricies massa. Ut erat diam, sodales non porta eu, dictum ut neque. Curabitur non
-            justo sed ligula ultricies dapibus. Nulla quis ante nisi. Praesent fermentum iaculis
-            convallis. Mauris ac quam eu turpis volutpat viverra nec ac ligula. Vivamus efficitur
-            dolor quis magna suscipit, eu congue ipsum posuere. Vestibulum ultrices, diam nec
-            rhoncus porttitor, neque nibh euismod mauris, quis posuere mi turpis ac lorem. Ut
-            sodales sodales elit a semper.
-          </p>
-          <p>
-            Mauris eu felis fringilla tortor scelerisque tincidunt et quis risus. Proin dui arcu,
-            tincidunt nec rhoncus eu, blandit ut odio. Donec ac tristique felis. Morbi vel urna
-            commodo, efficitur orci in, condimentum augue. Morbi neque felis, consequat sit amet mi
-            eget, imperdiet consectetur augue. Sed dignissim congue ex at vestibulum. Etiam rutrum,
-            mauris rutrum maximus congue, lectus sem molestie est, eget gravida orci ligula tempus
-            dolor.
-          </p>
-          <p>
-            Curabitur in justo massa. Pellentesque vitae tortor ligula. Morbi vulputate tortor ut
-            dapibus imperdiet. In hac habitasse platea dictumst. Vivamus ornare auctor est, vel
-            aliquet velit scelerisque ac. Mauris sit amet magna vitae dolor volutpat mattis ut et
-            nibh. Donec eu suscipit turpis. Aliquam suscipit massa sed turpis vestibulum faucibus.
-            Maecenas in lectus quis justo auctor euismod vel ut orci. Nunc cursus sit amet quam non
-            dignissim. Nullam in egestas lectus, ut porta leo. Suspendisse sit amet nisi magna.
-            Vestibulum eget porttitor orci. Duis nec elit posuere, condimentum orci in, eleifend
-            quam. Morbi eget tortor a orci finibus vulputate eu id felis.
-          </p>
-        </Layout.Content>
-        {hasFooter && (
-          <Footer logo={LOGO}>
-            <em>{footerText}</em>
-            <Footer.Link to="#">The Link To Nowhere</Footer.Link>
-            <Footer.Link to="https://google.com">The Giant</Footer.Link>
-          </Footer>
-        )}
-      </Layout>
-    )
-  },
-  { cactus: { overrides: { display: 'block', position: 'static', width: '100%', height: '100%' } } }
-)
+            <TextInputField label="Some Setting" name="setting" />
+          </ActionBar.Panel>
+        </ActionBar>
+      )}
+      <Layout.Content>
+        <h1>Latin Or Something</h1>
+        <TextInputField name="foo" label="Foo" />
+        <TextInputField name="bar" label="Bar" />
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas augue ex, dignissim sed
+          fringilla nec, tincidunt fermentum libero. Mauris ut enim ornare, euismod nibh at,
+          ultricies massa. Ut erat diam, sodales non porta eu, dictum ut neque. Curabitur non justo
+          sed ligula ultricies dapibus. Nulla quis ante nisi. Praesent fermentum iaculis convallis.
+          Mauris ac quam eu turpis volutpat viverra nec ac ligula. Vivamus efficitur dolor quis
+          magna suscipit, eu congue ipsum posuere. Vestibulum ultrices, diam nec rhoncus porttitor,
+          neque nibh euismod mauris, quis posuere mi turpis ac lorem. Ut sodales sodales elit a
+          semper.
+        </p>
+        <p>
+          Mauris eu felis fringilla tortor scelerisque tincidunt et quis risus. Proin dui arcu,
+          tincidunt nec rhoncus eu, blandit ut odio. Donec ac tristique felis. Morbi vel urna
+          commodo, efficitur orci in, condimentum augue. Morbi neque felis, consequat sit amet mi
+          eget, imperdiet consectetur augue. Sed dignissim congue ex at vestibulum. Etiam rutrum,
+          mauris rutrum maximus congue, lectus sem molestie est, eget gravida orci ligula tempus
+          dolor.
+        </p>
+        <p>
+          Curabitur in justo massa. Pellentesque vitae tortor ligula. Morbi vulputate tortor ut
+          dapibus imperdiet. In hac habitasse platea dictumst. Vivamus ornare auctor est, vel
+          aliquet velit scelerisque ac. Mauris sit amet magna vitae dolor volutpat mattis ut et
+          nibh. Donec eu suscipit turpis. Aliquam suscipit massa sed turpis vestibulum faucibus.
+          Maecenas in lectus quis justo auctor euismod vel ut orci. Nunc cursus sit amet quam non
+          dignissim. Nullam in egestas lectus, ut porta leo. Suspendisse sit amet nisi magna.
+          Vestibulum eget porttitor orci. Duis nec elit posuere, condimentum orci in, eleifend quam.
+          Morbi eget tortor a orci finibus vulputate eu id felis.
+        </p>
+      </Layout.Content>
+      {hasFooter && (
+        <Footer logo={LOGO}>
+          <em>{footerText}</em>
+          <Footer.Link to="#">The Link To Nowhere</Footer.Link>
+          <Footer.Link to="https://google.com">The Giant</Footer.Link>
+        </Footer>
+      )}
+    </Layout>
+  )
+}
+
+BasicUsage.parameters = {
+  cactus: { overrides: { display: 'block', position: 'static', width: '100%', height: '100%' } },
+}

--- a/modules/cactus-web/src/Link/Link.story.tsx
+++ b/modules/cactus-web/src/Link/Link.story.tsx
@@ -1,33 +1,32 @@
 import { text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import Link from './Link'
 
-storiesOf('Link', module)
-  .add(
-    'Basic Usage',
-    (): ReactElement => (
-      <Link to={text('to', 'https://repaygithub.github.io/cactus/')}>
-        {text('text', 'Click me!')}
-      </Link>
-    )
-  )
-  .add(
-    'Within a block of text',
-    (): ReactElement => (
-      <span>
-        To review the cactus documentation site, click{' '}
-        <Link to={text('to', 'https://repaygithub.github.io/cactus/')}>here</Link>.
-      </span>
-    )
-  )
-  .add(
-    'Multi-line link',
-    (): ReactElement => (
-      <span style={{ width: '375px' }}>
-        To review the cactus documentation site,{' '}
-        <Link to={text('to', 'https://repaygithub.github.io/cactus/')}>click here</Link>.
-      </span>
-    )
-  )
+export default {
+  title: 'Link',
+  component: Link,
+} as Meta
+
+export const BasicUsage = (): ReactElement => (
+  <Link to={text('to', 'https://repaygithub.github.io/cactus/')}>{text('text', 'Click me!')}</Link>
+)
+
+export const WithinABlockOfText = (): ReactElement => (
+  <span>
+    To review the cactus documentation site, click{' '}
+    <Link to={text('to', 'https://repaygithub.github.io/cactus/')}>here</Link>.
+  </span>
+)
+
+WithinABlockOfText.storyName = 'Within a block of text'
+
+export const MultiLineLink = (): ReactElement => (
+  <span style={{ width: '375px' }}>
+    To review the cactus documentation site,{' '}
+    <Link to={text('to', 'https://repaygithub.github.io/cactus/')}>click here</Link>.
+  </span>
+)
+
+MultiLineLink.storyName = 'Multi-line link'

--- a/modules/cactus-web/src/MenuBar/MenuBar.story.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.story.tsx
@@ -1,5 +1,5 @@
 import { number } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import ScreenSizeProvider from '../ScreenSizeProvider/ScreenSizeProvider'
@@ -35,7 +35,12 @@ function action(msg: string) {
   return () => console.log('ITEM CLICKED:', msg)
 }
 
-storiesOf('MenuBar', module).add('Basic Usage', () => {
+export default {
+  title: 'MenuBar',
+  component: MenuBar,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
   const breadth = number('Breadth', 8)
   const totalDepth = number('Depth', 2)
 
@@ -65,4 +70,4 @@ storiesOf('MenuBar', module).add('Basic Usage', () => {
   }
 
   return <ScreenSizeProvider>{makeList(totalDepth, {}, 0, MenuBar)}</ScreenSizeProvider>
-})
+}

--- a/modules/cactus-web/src/MenuButton/MenuButton.story.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.story.tsx
@@ -1,59 +1,60 @@
 import { action } from '@storybook/addon-actions'
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import MenuButton from './MenuButton'
 
 const stopNav = (e: Event): void => e.preventDefault()
 
-storiesOf('MenuButton', module)
-  .add(
-    'Basic Usage',
-    (): ReactElement => (
-      <MenuButton
-        label={text('label', 'Demo Actions')}
-        disabled={boolean('disabled?', false)}
-        variant={select('variant', ['filled', 'unfilled'], 'filled')}
-      >
-        <MenuButton.Item onSelect={action('Action One')}>Action One</MenuButton.Item>
-        <MenuButton.Item onSelect={action('Action Two')}>Action Two</MenuButton.Item>
-        <MenuButton.Item onSelect={action('Action Three')}>Action Three</MenuButton.Item>
-      </MenuButton>
-    )
-  )
-  .add(
-    'with Links',
-    (): ReactElement => (
-      <MenuButton
-        label={text('label', 'Demo')}
-        disabled={boolean('disabled?', false)}
-        variant={select('variant', ['filled', 'unfilled'], 'filled')}
-      >
-        <MenuButton.Link href="#" onClick={stopNav}>
-          Link One
-        </MenuButton.Link>
-        <MenuButton.Link href="#" onClick={stopNav}>
-          Link Two
-        </MenuButton.Link>
-        <MenuButton.Link href="#" onClick={stopNav}>
-          Link Three
-        </MenuButton.Link>
-      </MenuButton>
-    )
-  )
-  .add(
-    'with Collisions',
-    (): ReactElement => (
-      <MenuButton
-        label={text('label', 'Demo')}
-        disabled={boolean('disabled?', false)}
-        variant={select('variant', ['filled', 'unfilled'], 'filled')}
-      >
-        <MenuButton.Item onSelect={action('Action One')}>Action One</MenuButton.Item>
-        <MenuButton.Item onSelect={action('Action Two')}>Action Two</MenuButton.Item>
-        <MenuButton.Item onSelect={action('Action Three')}>Action Three</MenuButton.Item>
-      </MenuButton>
-    ),
-    { cactus: { overrides: { height: '220vh', width: '220vw' } } }
-  )
+export default {
+  title: 'MenuButton',
+  component: MenuButton,
+} as Meta
+
+export const BasicUsage = (): ReactElement => (
+  <MenuButton
+    label={text('label', 'Demo Actions')}
+    disabled={boolean('disabled?', false)}
+    variant={select('variant', ['filled', 'unfilled'], 'filled')}
+  >
+    <MenuButton.Item onSelect={action('Action One')}>Action One</MenuButton.Item>
+    <MenuButton.Item onSelect={action('Action Two')}>Action Two</MenuButton.Item>
+    <MenuButton.Item onSelect={action('Action Three')}>Action Three</MenuButton.Item>
+  </MenuButton>
+)
+
+export const WithLinks = (): ReactElement => (
+  <MenuButton
+    label={text('label', 'Demo')}
+    disabled={boolean('disabled?', false)}
+    variant={select('variant', ['filled', 'unfilled'], 'filled')}
+  >
+    <MenuButton.Link href="#" onClick={stopNav}>
+      Link One
+    </MenuButton.Link>
+    <MenuButton.Link href="#" onClick={stopNav}>
+      Link Two
+    </MenuButton.Link>
+    <MenuButton.Link href="#" onClick={stopNav}>
+      Link Three
+    </MenuButton.Link>
+  </MenuButton>
+)
+
+WithLinks.storyName = 'with Links'
+
+export const WithCollisions = (): ReactElement => (
+  <MenuButton
+    label={text('label', 'Demo')}
+    disabled={boolean('disabled?', false)}
+    variant={select('variant', ['filled', 'unfilled'], 'filled')}
+  >
+    <MenuButton.Item onSelect={action('Action One')}>Action One</MenuButton.Item>
+    <MenuButton.Item onSelect={action('Action Two')}>Action Two</MenuButton.Item>
+    <MenuButton.Item onSelect={action('Action Three')}>Action Three</MenuButton.Item>
+  </MenuButton>
+)
+
+WithCollisions.storyName = 'with Collisions'
+WithCollisions.parameters = { cactus: { overrides: { height: '220vh', width: '220vw' } } }

--- a/modules/cactus-web/src/Modal/Modal.story.tsx
+++ b/modules/cactus-web/src/Modal/Modal.story.tsx
@@ -1,12 +1,15 @@
 import { select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { useState } from 'react'
 
 import Button from '../Button/Button'
 import Text from '../Text/Text'
 import Modal, { ModalType } from './Modal'
 
-const modalStories = storiesOf('Modal', module)
+export default {
+  title: 'Modal',
+  component: Modal,
+} as Meta
 
 type StatusOptions = { [k in ModalType]: ModalType }
 
@@ -39,4 +42,4 @@ const ModalWithState = (): React.ReactElement => {
     </Button>
   )
 }
-modalStories.add('Basic Usage', (): React.ReactElement => <ModalWithState />)
+export const BasicUsage = (): React.ReactElement => <ModalWithState />

--- a/modules/cactus-web/src/Pagination/Pagination.story.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.story.tsx
@@ -1,14 +1,16 @@
 import { number } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Pagination from './Pagination'
 
-const paginationStories = storiesOf('Pagination', module)
+export default {
+  title: 'Pafination',
+  component: Pagination,
+} as Meta
 
-paginationStories.add(
-  'Basic Usage',
-  (): React.ReactElement => <ManagedPagination pageCount={number('Page Count', 10)} />
+export const BasicUsage = (): React.ReactElement => (
+  <ManagedPagination pageCount={number('Page Count', 10)} />
 )
 
 function ManagedPagination({ pageCount }: { pageCount: number }): React.ReactElement {

--- a/modules/cactus-web/src/Pagination/Pagination.story.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.story.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import Pagination from './Pagination'
 
 export default {
-  title: 'Pafination',
+  title: 'Pagination',
   component: Pagination,
 } as Meta
 

--- a/modules/cactus-web/src/PrevNext/PrevNext.story.tsx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.story.tsx
@@ -1,19 +1,21 @@
 import { action } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import PrevNext from './PrevNext'
 
-storiesOf('PrevNext', module).add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <PrevNext
-      disablePrev={boolean('Disable Prev', false)}
-      disableNext={boolean('Disable Next', false)}
-      onNavigate={action('PrevNext Navigate')}
-      prevText={text('Prev Text', 'Prev')}
-      nextText={text('Next Text', 'Next')}
-    />
-  )
+export default {
+  title: 'PrevNext',
+  component: PrevNext,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <PrevNext
+    disablePrev={boolean('Disable Prev', false)}
+    disableNext={boolean('Disable Next', false)}
+    onNavigate={action('PrevNext Navigate')}
+    prevText={text('Prev Text', 'Prev')}
+    nextText={text('Next Text', 'Next')}
+  />
 )

--- a/modules/cactus-web/src/RadioButton/RadioButton.story.tsx
+++ b/modules/cactus-web/src/RadioButton/RadioButton.story.tsx
@@ -1,40 +1,38 @@
 import { boolean } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import actions from '../helpers/storybookActionsWorkaround'
 import RadioButton from './RadioButton'
 
-const radioButtonStories = storiesOf('RadioButton', module)
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
-radioButtonStories.add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <RadioButton id="some-id" name="test" disabled={boolean('disabled', false)} {...eventLoggers} />
-  )
+export default {
+  title: 'RadioButton',
+  component: RadioButton,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <RadioButton id="some-id" name="test" disabled={boolean('disabled', false)} {...eventLoggers} />
 )
 
-radioButtonStories.add(
-  'Multiple Radio Buttons',
-  (): React.ReactElement => (
+export const MultipleRadioButtons = (): React.ReactElement => (
+  <div>
     <div>
-      <div>
-        <RadioButton
-          id="some-id"
-          name="test"
-          disabled={boolean('disabled', false)}
-          {...eventLoggers}
-        />
-      </div>
-      <div>
-        <RadioButton
-          id="some-other-id"
-          name="test"
-          disabled={boolean('disabled', false)}
-          {...eventLoggers}
-        />
-      </div>
+      <RadioButton
+        id="some-id"
+        name="test"
+        disabled={boolean('disabled', false)}
+        {...eventLoggers}
+      />
     </div>
-  )
+    <div>
+      <RadioButton
+        id="some-other-id"
+        name="test"
+        disabled={boolean('disabled', false)}
+        {...eventLoggers}
+      />
+    </div>
+  </div>
 )

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.story.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.story.tsx
@@ -1,33 +1,33 @@
 import { actions } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import RadioButtonField from './RadioButtonField'
 
-const radioButtonFieldStories = storiesOf('RadioButtonField', module)
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
-radioButtonFieldStories.add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <RadioButtonField
-      id="my-id"
-      name="rbf"
-      label={text('label', 'A Label')}
-      disabled={boolean('disabled', false)}
-      {...eventLoggers}
-    />
-  )
+export default {
+  title: 'RadioButtonField',
+  component: RadioButtonField,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <RadioButtonField
+    id="my-id"
+    name="rbf"
+    label={text('label', 'A Label')}
+    disabled={boolean('disabled', false)}
+    {...eventLoggers}
+  />
 )
 
-radioButtonFieldStories.add(
-  'Multiple RadioButton Fields',
-  (): React.ReactElement => (
-    <div>
-      <RadioButtonField name="rbf" label="Label 1" {...eventLoggers} />
-      <RadioButtonField name="rbf" label="Label 2" {...eventLoggers} />
-      <RadioButtonField name="rbf" label="Label 3" {...eventLoggers} />
-    </div>
-  )
+export const MultipleRadioButtonFields = (): React.ReactElement => (
+  <div>
+    <RadioButtonField name="rbf" label="Label 1" {...eventLoggers} />
+    <RadioButtonField name="rbf" label="Label 2" {...eventLoggers} />
+    <RadioButtonField name="rbf" label="Label 3" {...eventLoggers} />
+  </div>
 )
+
+MultipleRadioButtonFields.storyName = 'Multiple RadioButton Fields'

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.story.tsx
@@ -1,37 +1,36 @@
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Flex from '../Flex/Flex'
 import RadioGroup from './RadioGroup'
 
-const radioGroupStories = storiesOf('RadioGroup', module)
-
-radioGroupStories.add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <RadioGroup
-      id="my-id"
-      name="you-are-group-one"
-      label={text('label', 'A Label')}
-      disabled={boolean('disabled', false)}
-      onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
-      onFocus={(name) => console.log(`'${name}' focused`)}
-      onBlur={(name) => console.log(`'${name}' blurred`)}
-      tooltip={text('tooltip', 'Here there be radio buttons')}
-      error={text('error', '')}
-      success={text('success', '')}
-      warning={text('warning', '')}
-      autoTooltip={boolean('autoTooltip', true)}
-    >
-      <RadioGroup.Button label="That's right" value="right" />
-      <RadioGroup.Button disabled label="That's wrong" value="left" />
-      <RadioGroup.Button label={text('button label', "That's...")} value="center" />
-    </RadioGroup>
-  )
+export default {
+  title: 'RadioGroup',
+  component: RadioGroup,
+} as Meta
+export const BasicUsage = (): React.ReactElement => (
+  <RadioGroup
+    id="my-id"
+    name="you-are-group-one"
+    label={text('label', 'A Label')}
+    disabled={boolean('disabled', false)}
+    onChange={(name, value) => console.log(`'${name}' changed: ${value}`)}
+    onFocus={(name) => console.log(`'${name}' focused`)}
+    onBlur={(name) => console.log(`'${name}' blurred`)}
+    tooltip={text('tooltip', 'Here there be radio buttons')}
+    error={text('error', '')}
+    success={text('success', '')}
+    warning={text('warning', '')}
+    autoTooltip={boolean('autoTooltip', true)}
+  >
+    <RadioGroup.Button label="That's right" value="right" />
+    <RadioGroup.Button disabled label="That's wrong" value="left" />
+    <RadioGroup.Button label={text('button label', "That's...")} value="center" />
+  </RadioGroup>
 )
 
-radioGroupStories.add('With Values', () => {
+export const WithValues = (): React.ReactElement => {
   const [value, setValue] = React.useState<string>('strong')
   return (
     <Flex>
@@ -52,9 +51,9 @@ radioGroupStories.add('With Values', () => {
       </RadioGroup>
     </Flex>
   )
-})
+}
 
-radioGroupStories.add('With Default Values', () => {
+export const WithDefaultValues = (): React.ReactElement => {
   const group = React.useRef<HTMLFormElement>(null)
   const button = React.useRef<HTMLFormElement>(null)
   return (
@@ -81,4 +80,4 @@ radioGroupStories.add('With Default Values', () => {
       </form>
     </Flex>
   )
-})
+}

--- a/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.story.tsx
+++ b/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.story.tsx
@@ -1,5 +1,5 @@
 import cactusTheme, { ColorStyle } from '@repay/cactus-theme'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -19,8 +19,8 @@ const BreakpointBox = styled(Box)`
   ${(p): string | undefined => p.theme.mediaQueries && p.theme.mediaQueries.small} {
     max-width: 708px;
     width: 75px;
-    height 75px;
-    line-height 75px;
+    height: 75px;
+    line-height: 75px;
     border-radius: 25%;
   }
   ${(p): string | undefined => p.theme.mediaQueries && p.theme.mediaQueries.medium} {
@@ -51,17 +51,21 @@ const ScreenSize = (): React.ReactElement => {
   return <>{size.size}</>
 }
 
-storiesOf('ScreenSize Provider', module).add(
-  'Display current screen size',
-  (): React.ReactElement => {
-    return (
-      <StyleProvider theme={cactusTheme} global={true}>
-        <ScreenSizeProvider>
-          <BreakpointBox>
-            <ScreenSize />
-          </BreakpointBox>
-        </ScreenSizeProvider>
-      </StyleProvider>
-    )
-  }
-)
+export default {
+  title: 'ScreenSize Provider',
+  component: ScreenSizeProvider,
+} as Meta
+
+export const DisplayCurrentScreenSize = (): React.ReactElement => {
+  return (
+    <StyleProvider theme={cactusTheme} global={true}>
+      <ScreenSizeProvider>
+        <BreakpointBox>
+          <ScreenSize />
+        </BreakpointBox>
+      </ScreenSizeProvider>
+    </StyleProvider>
+  )
+}
+
+DisplayCurrentScreenSize.storyName = 'Display current screen size'

--- a/modules/cactus-web/src/Select/Select.story.tsx
+++ b/modules/cactus-web/src/Select/Select.story.tsx
@@ -1,6 +1,6 @@
 import { actions } from '@storybook/addon-actions'
 import { array, boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import arizonaCities from '../storySupport/arizonaCities'
@@ -17,167 +17,169 @@ const longOptions: OptionType[] = [
 
 const defaultMultiValue = arizonaCities.slice(6, 15)
 
-storiesOf('Select', module)
-  .add(
-    'Basic Usage',
-    (): ReactElement => (
-      <React.Fragment>
+export default {
+  title: 'Select',
+  component: Select,
+} as Meta
+
+export const BasicUsage = (): ReactElement => (
+  <React.Fragment>
+    <Select
+      options={array('options', ['name', 'other', 'three'])}
+      name={text('name', 'random')}
+      id={text('id', 'select-input')}
+      disabled={boolean('disabled', false)}
+      multiple={boolean('multiple', false)}
+      m={text('m', '2')}
+      {...eventLoggers}
+    />
+  </React.Fragment>
+)
+
+export const CollisionsInAnOverSizedContainer = (): ReactElement => (
+  <React.Fragment>
+    <Select
+      options={array('options', ['name', 'other', 'three'])}
+      name={text('name', 'random')}
+      id={text('id', 'select-input')}
+      disabled={boolean('disabled', false)}
+      {...eventLoggers}
+    />
+    <div style={{ position: 'absolute', left: '20px', top: '20px' }}>
+      Scroll down and to the right
+    </div>
+  </React.Fragment>
+)
+
+CollisionsInAnOverSizedContainer.storyName = 'Collisions in an over-sized container'
+CollisionsInAnOverSizedContainer.parameters = {
+  cactus: { overrides: { height: '220vh', width: '220vw' } },
+}
+
+export const LongListOfOptions = (): ReactElement => (
+  <FormHandler
+    defaultValue={arizonaCities[6]}
+    onChange={(
+      name,
+      value: string | number | (string | number)[] | null
+    ): string | number | (string | number)[] | null => value}
+  >
+    {({ value, onChange }): ReactElement => (
+      <Select
+        options={arizonaCities}
+        name="random"
+        id="select-input"
+        disabled={boolean('disabled', false)}
+        {...eventLoggers}
+        onChange={onChange}
+        value={value}
+      />
+    )}
+  </FormHandler>
+)
+
+LongListOfOptions.storyName = 'Long list of options'
+
+export const LongOptionLabels = (): ReactElement => (
+  <FormHandler
+    defaultValue=""
+    onChange={(
+      name,
+      value: string | number | (string | number)[] | null
+    ): string | number | (string | number)[] | null => value}
+  >
+    {({ value, onChange }): ReactElement => (
+      <div style={{ width: '194px' }}>
         <Select
-          options={array('options', ['name', 'other', 'three'])}
-          name={text('name', 'random')}
-          id={text('id', 'select-input')}
-          disabled={boolean('disabled', false)}
-          multiple={boolean('multiple', false)}
-          m={text('m', '2')}
-          {...eventLoggers}
-        />
-      </React.Fragment>
-    )
-  )
-  .add(
-    'Collisions in an over-sized container',
-    (): ReactElement => (
-      <React.Fragment>
-        <Select
-          options={array('options', ['name', 'other', 'three'])}
-          name={text('name', 'random')}
-          id={text('id', 'select-input')}
+          options={longOptions}
+          name="random"
+          id="select-input"
           disabled={boolean('disabled', false)}
           {...eventLoggers}
+          onChange={onChange}
+          value={value}
         />
-        <div style={{ position: 'absolute', left: '20px', top: '20px' }}>
-          Scroll down and to the right
-        </div>
-      </React.Fragment>
-    ),
-    { cactus: { overrides: { height: '220vh', width: '220vw' } } }
-  )
-  .add(
-    'Long list of options',
-    (): ReactElement => (
-      <FormHandler
-        defaultValue={arizonaCities[6]}
-        onChange={(
-          name,
-          value: string | number | (string | number)[] | null
-        ): string | number | (string | number)[] | null => value}
-      >
-        {({ value, onChange }): ReactElement => (
-          <Select
-            options={arizonaCities}
-            name="random"
-            id="select-input"
-            disabled={boolean('disabled', false)}
-            {...eventLoggers}
-            onChange={onChange}
-            value={value}
-          />
-        )}
-      </FormHandler>
-    )
-  )
-  .add(
-    'Long option labels',
-    (): ReactElement => (
-      <FormHandler
-        defaultValue=""
-        onChange={(
-          name,
-          value: string | number | (string | number)[] | null
-        ): string | number | (string | number)[] | null => value}
-      >
-        {({ value, onChange }): ReactElement => (
-          <div style={{ width: '194px' }}>
-            <Select
-              options={longOptions}
-              name="random"
-              id="select-input"
-              disabled={boolean('disabled', false)}
-              {...eventLoggers}
-              onChange={onChange}
-              value={value}
-            />
-          </div>
-        )}
-      </FormHandler>
-    )
-  )
-  .add(
-    'With Multiselect',
-    (): ReactElement => (
-      <FormHandler
-        defaultValue={defaultMultiValue}
-        onChange={(
-          name,
-          value: string | number | (string | number)[] | null
-        ): string | number | (string | number)[] | null => value}
-      >
-        {({ value, onChange }): ReactElement => (
-          <Select
-            options={arizonaCities}
-            name="random"
-            id="select-input"
-            disabled={boolean('disabled', false)}
-            {...eventLoggers}
-            onChange={onChange}
-            value={value}
-            multiple
-          />
-        )}
-      </FormHandler>
-    ),
-    { cactus: { overrides: { overflow: 'hidden' } } }
-  )
-  .add(
-    'With ComboBox',
-    (): ReactElement => (
-      <FormHandler
-        onChange={(
-          name,
-          value: string | number | (string | number)[] | null
-        ): string | number | (string | number)[] | null => value}
-      >
-        {({ value, onChange }): ReactElement => (
-          <Select
-            options={arizonaCities}
-            name="random"
-            id="select-input"
-            disabled={boolean('disabled', false)}
-            {...eventLoggers}
-            onChange={onChange}
-            value={value}
-            comboBox
-            canCreateOption={boolean('canCreateOption', true)}
-          />
-        )}
-      </FormHandler>
-    ),
-    { cactus: { overrides: { overflow: 'hidden' } } }
-  )
-  .add(
-    'With MultiSelect ComboBox',
-    (): ReactElement => (
-      <FormHandler
-        onChange={(
-          name,
-          value: string | number | (string | number)[] | null
-        ): string | number | (string | number)[] | null => value}
-      >
-        {({ value, onChange }): ReactElement => (
-          <Select
-            options={arizonaCities}
-            name="random"
-            id="select-input"
-            disabled={boolean('disabled', false)}
-            {...eventLoggers}
-            onChange={onChange}
-            value={value}
-            comboBox
-            multiple
-            canCreateOption={boolean('canCreateOption', true)}
-          />
-        )}
-      </FormHandler>
-    ),
-    { cactus: { overrides: { overflow: 'hidden' } } }
-  )
+      </div>
+    )}
+  </FormHandler>
+)
+
+LongOptionLabels.storyName = 'Long option labels'
+
+export const WithMultiselect = (): ReactElement => (
+  <FormHandler
+    defaultValue={defaultMultiValue}
+    onChange={(
+      name,
+      value: string | number | (string | number)[] | null
+    ): string | number | (string | number)[] | null => value}
+  >
+    {({ value, onChange }): ReactElement => (
+      <Select
+        options={arizonaCities}
+        name="random"
+        id="select-input"
+        disabled={boolean('disabled', false)}
+        {...eventLoggers}
+        onChange={onChange}
+        value={value}
+        multiple
+      />
+    )}
+  </FormHandler>
+)
+
+WithMultiselect.parameters = { cactus: { overrides: { overflow: 'hidden' } } }
+
+export const WithComboBox = (): ReactElement => (
+  <FormHandler
+    onChange={(
+      name,
+      value: string | number | (string | number)[] | null
+    ): string | number | (string | number)[] | null => value}
+  >
+    {({ value, onChange }): ReactElement => (
+      <Select
+        options={arizonaCities}
+        name="random"
+        id="select-input"
+        disabled={boolean('disabled', false)}
+        {...eventLoggers}
+        onChange={onChange}
+        value={value}
+        comboBox
+        canCreateOption={boolean('canCreateOption', true)}
+      />
+    )}
+  </FormHandler>
+)
+
+WithComboBox.storyName = 'With ComboBox'
+WithComboBox.parameters = { cactus: { overrides: { overflow: 'hidden' } } }
+
+export const WithMultiSelectComboBox = (): ReactElement => (
+  <FormHandler
+    onChange={(
+      name,
+      value: string | number | (string | number)[] | null
+    ): string | number | (string | number)[] | null => value}
+  >
+    {({ value, onChange }): ReactElement => (
+      <Select
+        options={arizonaCities}
+        name="random"
+        id="select-input"
+        disabled={boolean('disabled', false)}
+        {...eventLoggers}
+        onChange={onChange}
+        value={value}
+        comboBox
+        multiple
+        canCreateOption={boolean('canCreateOption', true)}
+      />
+    )}
+  </FormHandler>
+)
+
+WithMultiSelectComboBox.storyName = 'With MultiSelect ComboBox'
+WithMultiSelectComboBox.parameters = { cactus: { overrides: { overflow: 'hidden' } } }

--- a/modules/cactus-web/src/SelectField/SelectField.story.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.story.tsx
@@ -1,15 +1,47 @@
 import { array, boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import { SelectValueType } from '../Select/Select'
 import FormHandler from '../storySupport/FormHandler'
 import SelectField from './SelectField'
 
-storiesOf('SelectField', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => (
+export default {
+  title: 'SelectField',
+  component: SelectField,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <SelectField
+    label={text('label', `What's that in the sky?`)}
+    name={text('name', 'ufo')}
+    options={array('options', ['bird', 'plane', 'superman'])}
+    disabled={boolean('disabled', false)}
+    tooltip={text('tooltip', 'Select what you think you see in the sky.')}
+    success={text('success', '')}
+    warning={text('warning', '')}
+    error={text('error', '')}
+    autoTooltip={boolean('autoTooltip', true)}
+    comboBox={boolean('comboBox', false)}
+    canCreateOption={boolean('canCreateOption', true)}
+  />
+)
+
+BasicUsage.parameters = { knobs: { escapeHTML: false } }
+
+export const CustomStyles = (): React.ReactElement => (
+  <SelectField
+    label="Who ya gonna call?"
+    name="when_there_is_something_strange"
+    options={['Ray Parker Jr.', 'Me maybe?', 'Ghostbusters']}
+    width={text('width', '')}
+    margin={text('margin', '3')}
+  />
+)
+
+export const ControlledForm = (): React.ReactElement => (
+  <FormHandler onChange={(name: string, value: SelectValueType): SelectValueType => value}>
+    {({ value, onChange }): React.ReactElement => (
       <SelectField
         label={text('label', `What's that in the sky?`)}
         name={text('name', 'ufo')}
@@ -19,44 +51,11 @@ storiesOf('SelectField', module)
         success={text('success', '')}
         warning={text('warning', '')}
         error={text('error', '')}
-        autoTooltip={boolean('autoTooltip', true)}
-        comboBox={boolean('comboBox', false)}
-        canCreateOption={boolean('canCreateOption', true)}
+        onChange={onChange}
+        value={value}
       />
-    ),
-    { knobs: { escapeHTML: false } }
-  )
-  .add(
-    'Custom Styles',
-    (): React.ReactElement => (
-      <SelectField
-        label="Who ya gonna call?"
-        name="when_there_is_something_strange"
-        options={['Ray Parker Jr.', 'Me maybe?', 'Ghostbusters']}
-        width={text('width', '')}
-        margin={text('margin', '3')}
-      />
-    )
-  )
-  .add(
-    'Controlled Form',
-    (): React.ReactElement => (
-      <FormHandler onChange={(name: string, value: SelectValueType): SelectValueType => value}>
-        {({ value, onChange }): React.ReactElement => (
-          <SelectField
-            label={text('label', `What's that in the sky?`)}
-            name={text('name', 'ufo')}
-            options={array('options', ['bird', 'plane', 'superman'])}
-            disabled={boolean('disabled', false)}
-            tooltip={text('tooltip', 'Select what you think you see in the sky.')}
-            success={text('success', '')}
-            warning={text('warning', '')}
-            error={text('error', '')}
-            onChange={onChange}
-            value={value}
-          />
-        )}
-      </FormHandler>
-    ),
-    { knobs: { escapeHTML: false } }
-  )
+    )}
+  </FormHandler>
+)
+
+ControlledForm.parameters = { knobs: { escapeHTML: false } }

--- a/modules/cactus-web/src/Spinner/Spinner.story.tsx
+++ b/modules/cactus-web/src/Spinner/Spinner.story.tsx
@@ -1,6 +1,6 @@
 import cactusTheme from '@repay/cactus-theme'
 import { select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Spinner from './Spinner'
@@ -9,22 +9,26 @@ type IconSize = 'tiny' | 'small' | 'medium' | 'large'
 const iconSizes: IconSize[] = ['tiny', 'small', 'medium', 'large']
 const colors = Object.keys(cactusTheme.colors)
 
-storiesOf('Spinner', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => (
-      <Spinner
-        iconSize={select('iconSize', iconSizes, 'large')}
-        color={select('color', colors, 'darkestContrast')}
-      />
-    )
-  )
-  .add('Custom Sizing', (): React.ReactElement => <Spinner iconSize={text('iconSize', '64px')} />)
-  .add(
-    'using spacing',
-    (): React.ReactElement => (
-      <React.Fragment>
-        <Spinner m={text('m', '0 auto')} />
-      </React.Fragment>
-    )
-  )
+export default {
+  title: 'Spinner',
+  component: Spinner,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <Spinner
+    iconSize={select('iconSize', iconSizes, 'large')}
+    color={select('color', colors, 'darkestContrast')}
+  />
+)
+
+export const CustomSizing = (): React.ReactElement => (
+  <Spinner iconSize={text('iconSize', '64px')} />
+)
+
+export const UsingSpacing = (): React.ReactElement => (
+  <React.Fragment>
+    <Spinner m={text('m', '0 auto')} />
+  </React.Fragment>
+)
+
+UsingSpacing.storyName = 'using spacing'

--- a/modules/cactus-web/src/SplitButton/SplitButton.story.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.story.tsx
@@ -1,6 +1,6 @@
 import * as icons from '@repay/cactus-icons'
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import SplitButton, { IconProps, SplitButtonVariant } from './SplitButton'
@@ -16,91 +16,92 @@ const variantOptions: VariantOptions = {
   success: 'success',
 }
 
-storiesOf('SplitButton', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => {
-      iconNames.unshift('None')
-      const mainIconName: IconName = select('mainActionIcon', iconNames, 'None')
-      const actionIconName1: IconName = select('actionIcon1', iconNames, 'None')
-      const actionIconName2: IconName = select('actionIcon2', iconNames, 'None')
-      const variant = select('variant', variantOptions, variantOptions.standard)
+export default {
+  title: 'SplitButton',
+  component: SplitButton,
+} as Meta
 
-      let MainIcon: React.FunctionComponent<IconProps>
-      let ActionIcon1: React.FunctionComponent<IconProps>
-      let ActionIcon2: React.FunctionComponent<IconProps>
-      if (mainIconName !== 'None') {
-        MainIcon = icons[mainIconName] as React.FunctionComponent<IconProps>
-      }
-      if (actionIconName1 !== 'None') {
-        ActionIcon1 = icons[actionIconName1] as React.FunctionComponent<IconProps>
-      }
-      if (actionIconName2 !== 'None') {
-        ActionIcon2 = icons[actionIconName2] as React.FunctionComponent<IconProps>
-      }
-      return (
-        <SplitButton
-          onSelectMainAction={(): void => {
-            console.log('Main Action')
-          }}
-          mainActionLabel={text('mainActionLabel', 'Main Action')}
-          // @ts-ignore
-          mainActionIcon={MainIcon ? MainIcon : undefined}
-          disabled={boolean('disabled', false)}
-          variant={variant}
-        >
-          <SplitButton.Action
-            onSelect={(): void => console.log('Action One')}
-            // @ts-ignore
-            icon={ActionIcon1 && ActionIcon1}
-          >
-            Action One
-          </SplitButton.Action>
-          <SplitButton.Action
-            onSelect={(): void => console.log('Action Two')}
-            // @ts-ignore
-            icon={ActionIcon2 && ActionIcon2}
-          >
-            Action Two
-          </SplitButton.Action>
-        </SplitButton>
-      )
-    }
-  )
-  .add(
-    'With Collisions',
-    (): React.ReactElement => (
-      <React.Fragment>
-        <div style={{ position: 'absolute', left: '20px', top: '20px' }}>
-          Scroll down and to the right
-        </div>
-        <SplitButton
-          onSelectMainAction={(): void => console.log('Main Action')}
-          mainActionLabel="Main Action"
-        >
-          <SplitButton.Action onSelect={(): void => console.log('Action One')}>
-            Action One
-          </SplitButton.Action>
-          <SplitButton.Action onSelect={(): void => console.log('Action Two')}>
-            Action Two
-          </SplitButton.Action>
-        </SplitButton>
-      </React.Fragment>
-    ),
-    { cactus: { overrides: { height: '220vh', width: '220vw' } } }
-  )
-  .add('Fixed Width Container', () => (
-    <div style={{ width: '125px' }}>
-      <SplitButton
-        onSelectMainAction={(): void => console.log('Main Action')}
-        mainActionLabel="Main Action"
+export const BasicUsage = (): React.ReactElement => {
+  iconNames.unshift('None')
+  const mainIconName: IconName = select('mainActionIcon', iconNames, 'None')
+  const actionIconName1: IconName = select('actionIcon1', iconNames, 'None')
+  const actionIconName2: IconName = select('actionIcon2', iconNames, 'None')
+  const variant = select('variant', variantOptions, variantOptions.standard)
+
+  let MainIcon: React.FunctionComponent<IconProps>
+  let ActionIcon1: React.FunctionComponent<IconProps>
+  let ActionIcon2: React.FunctionComponent<IconProps>
+  if (mainIconName !== 'None') {
+    MainIcon = icons[mainIconName] as React.FunctionComponent<IconProps>
+  }
+  if (actionIconName1 !== 'None') {
+    ActionIcon1 = icons[actionIconName1] as React.FunctionComponent<IconProps>
+  }
+  if (actionIconName2 !== 'None') {
+    ActionIcon2 = icons[actionIconName2] as React.FunctionComponent<IconProps>
+  }
+  return (
+    <SplitButton
+      onSelectMainAction={(): void => {
+        console.log('Main Action')
+      }}
+      mainActionLabel={text('mainActionLabel', 'Main Action')}
+      // @ts-ignore
+      mainActionIcon={MainIcon ? MainIcon : undefined}
+      disabled={boolean('disabled', false)}
+      variant={variant}
+    >
+      <SplitButton.Action
+        onSelect={(): void => console.log('Action One')}
+        // @ts-ignore
+        icon={ActionIcon1 && ActionIcon1}
       >
-        <SplitButton.Action onSelect={(): void => console.log('Action One')}>
-          Action One
-        </SplitButton.Action>
-        <SplitButton.Action onSelect={(): void => console.log('Action Two')}>
-          Action Two
-        </SplitButton.Action>
-      </SplitButton>
+        Action One
+      </SplitButton.Action>
+      <SplitButton.Action
+        onSelect={(): void => console.log('Action Two')}
+        // @ts-ignore
+        icon={ActionIcon2 && ActionIcon2}
+      >
+        Action Two
+      </SplitButton.Action>
+    </SplitButton>
+  )
+}
+
+export const WithCollisions = (): React.ReactElement => (
+  <React.Fragment>
+    <div style={{ position: 'absolute', left: '20px', top: '20px' }}>
+      Scroll down and to the right
     </div>
-  ))
+    <SplitButton
+      onSelectMainAction={(): void => console.log('Main Action')}
+      mainActionLabel="Main Action"
+    >
+      <SplitButton.Action onSelect={(): void => console.log('Action One')}>
+        Action One
+      </SplitButton.Action>
+      <SplitButton.Action onSelect={(): void => console.log('Action Two')}>
+        Action Two
+      </SplitButton.Action>
+    </SplitButton>
+  </React.Fragment>
+)
+
+WithCollisions.parameters = { cactus: { overrides: { height: '220vh', width: '220vw' } } }
+
+export const FixedWidthContainer = (): React.ReactElement => (
+  <div style={{ width: '125px' }}>
+    <SplitButton
+      onSelectMainAction={(): void => console.log('Main Action')}
+      mainActionLabel="Main Action"
+    >
+      <SplitButton.Action onSelect={(): void => console.log('Action One')}>
+        Action One
+      </SplitButton.Action>
+      <SplitButton.Action onSelect={(): void => console.log('Action Two')}>
+        Action Two
+      </SplitButton.Action>
+    </SplitButton>
+  </div>
+)

--- a/modules/cactus-web/src/StepAvatar/StepAvatar.story.tsx
+++ b/modules/cactus-web/src/StepAvatar/StepAvatar.story.tsx
@@ -1,5 +1,5 @@
 import { select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Grid from '../Grid/Grid'
@@ -15,132 +15,127 @@ const StepManager = (props: {
   return <>{props.children({ currentStep, setStep })}</>
 }
 
-storiesOf('StepAvatar', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => {
-      return (
-        <StepAvatar status={select('current step', avatarSteps, 'inProcess')}>
-          {text('Step Number', '#')}
-        </StepAvatar>
-      )
-    }
+export default {
+  title: 'StepAvatar',
+  component: StepAvatar,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => {
+  return (
+    <StepAvatar status={select('current step', avatarSteps, 'inProcess')}>
+      {text('Step Number', '#')}
+    </StepAvatar>
   )
-  .add(
-    'Basic Example Horizontal',
-    (): React.ReactElement => {
-      return (
-        <Grid justify="center">
-          <Grid.Item tiny={2} />
-          <Grid.Item tiny={2}>
-            <StepAvatar status="done">1</StepAvatar>
+}
+
+export const BasicExampleHorizontal = (): React.ReactElement => {
+  return (
+    <Grid justify="center">
+      <Grid.Item tiny={2} />
+      <Grid.Item tiny={2}>
+        <StepAvatar status="done">1</StepAvatar>
+      </Grid.Item>
+      <Grid.Item tiny={2}>
+        <StepAvatar status="done">2</StepAvatar>
+      </Grid.Item>
+      <Grid.Item tiny={2}>
+        <StepAvatar status="inProcess">3</StepAvatar>
+      </Grid.Item>
+      <Grid.Item tiny={2}>
+        <StepAvatar status="notDone">4</StepAvatar>
+      </Grid.Item>
+      <Grid.Item tiny={2} />
+    </Grid>
+  )
+}
+
+export const BasicExampleVertical = (): React.ReactElement => {
+  return (
+    <Grid justify="center">
+      <Grid.Item tiny={12}>
+        <StepAvatar status="done">1</StepAvatar>
+      </Grid.Item>
+
+      <Grid.Item tiny={12} />
+      <Grid.Item tiny={12} />
+
+      <Grid.Item tiny={12}>
+        <StepAvatar status="done">2</StepAvatar>
+      </Grid.Item>
+
+      <Grid.Item tiny={12} />
+      <Grid.Item tiny={12} />
+
+      <Grid.Item tiny={12}>
+        <StepAvatar status="inProcess">3</StepAvatar>
+      </Grid.Item>
+
+      <Grid.Item tiny={12} />
+      <Grid.Item tiny={12} />
+
+      <Grid.Item tiny={12}>
+        <StepAvatar status="notDone">4</StepAvatar>
+      </Grid.Item>
+
+      <Grid.Item tiny={12} />
+      <Grid.Item tiny={12} />
+    </Grid>
+  )
+}
+
+export const InteractiveExample = (): React.ReactElement => {
+  function getType(currentStep: number, step: number): 'notDone' | 'inProcess' | 'done' {
+    if (currentStep < step) {
+      return 'notDone'
+    } else if (currentStep === step) {
+      return 'inProcess'
+    } else {
+      return 'done'
+    }
+  }
+
+  return (
+    <StepManager>
+      {({ currentStep, setStep }): React.ReactElement => (
+        <Grid justify="center" style={{ maxWidth: '800px' }}>
+          <Grid.Item tiny={3}>
+            <StepAvatar
+              as="button"
+              onClick={(): void => setStep(1)}
+              status={getType(currentStep, 1)}
+            >
+              1
+            </StepAvatar>
           </Grid.Item>
-          <Grid.Item tiny={2}>
-            <StepAvatar status="done">2</StepAvatar>
+          <Grid.Item tiny={3}>
+            <StepAvatar
+              as="button"
+              onClick={(): void => setStep(2)}
+              status={getType(currentStep, 2)}
+            >
+              2
+            </StepAvatar>
           </Grid.Item>
-          <Grid.Item tiny={2}>
-            <StepAvatar status="inProcess">3</StepAvatar>
+          <Grid.Item tiny={3}>
+            <StepAvatar
+              as="button"
+              onClick={(): void => setStep(3)}
+              status={getType(currentStep, 3)}
+            >
+              3
+            </StepAvatar>
           </Grid.Item>
-          <Grid.Item tiny={2}>
-            <StepAvatar status="notDone">4</StepAvatar>
+          <Grid.Item tiny={3}>
+            <StepAvatar
+              as="button"
+              onClick={(): void => setStep(4)}
+              status={getType(currentStep, 4)}
+            >
+              4
+            </StepAvatar>
           </Grid.Item>
-          <Grid.Item tiny={2} />
         </Grid>
-      )
-    }
+      )}
+    </StepManager>
   )
-  .add(
-    'Basic Example Vertical',
-    (): React.ReactElement => {
-      return (
-        <Grid justify="center">
-          <Grid.Item tiny={12}>
-            <StepAvatar status="done">1</StepAvatar>
-          </Grid.Item>
-
-          <Grid.Item tiny={12} />
-          <Grid.Item tiny={12} />
-
-          <Grid.Item tiny={12}>
-            <StepAvatar status="done">2</StepAvatar>
-          </Grid.Item>
-
-          <Grid.Item tiny={12} />
-          <Grid.Item tiny={12} />
-
-          <Grid.Item tiny={12}>
-            <StepAvatar status="inProcess">3</StepAvatar>
-          </Grid.Item>
-
-          <Grid.Item tiny={12} />
-          <Grid.Item tiny={12} />
-
-          <Grid.Item tiny={12}>
-            <StepAvatar status="notDone">4</StepAvatar>
-          </Grid.Item>
-
-          <Grid.Item tiny={12} />
-          <Grid.Item tiny={12} />
-        </Grid>
-      )
-    }
-  )
-  .add(
-    'Interactive Example',
-    (): React.ReactElement => {
-      function getType(currentStep: number, step: number): 'notDone' | 'inProcess' | 'done' {
-        if (currentStep < step) {
-          return 'notDone'
-        } else if (currentStep === step) {
-          return 'inProcess'
-        } else {
-          return 'done'
-        }
-      }
-
-      return (
-        <StepManager>
-          {({ currentStep, setStep }): React.ReactElement => (
-            <Grid justify="center" style={{ maxWidth: '800px' }}>
-              <Grid.Item tiny={3}>
-                <StepAvatar
-                  as="button"
-                  onClick={(): void => setStep(1)}
-                  status={getType(currentStep, 1)}
-                >
-                  1
-                </StepAvatar>
-              </Grid.Item>
-              <Grid.Item tiny={3}>
-                <StepAvatar
-                  as="button"
-                  onClick={(): void => setStep(2)}
-                  status={getType(currentStep, 2)}
-                >
-                  2
-                </StepAvatar>
-              </Grid.Item>
-              <Grid.Item tiny={3}>
-                <StepAvatar
-                  as="button"
-                  onClick={(): void => setStep(3)}
-                  status={getType(currentStep, 3)}
-                >
-                  3
-                </StepAvatar>
-              </Grid.Item>
-              <Grid.Item tiny={3}>
-                <StepAvatar
-                  as="button"
-                  onClick={(): void => setStep(4)}
-                  status={getType(currentStep, 4)}
-                >
-                  4
-                </StepAvatar>
-              </Grid.Item>
-            </Grid>
-          )}
-        </StepManager>
-      )
-    }
-  )
+}

--- a/modules/cactus-web/src/StyleProvider/StyleProvider.story.tsx
+++ b/modules/cactus-web/src/StyleProvider/StyleProvider.story.tsx
@@ -1,5 +1,5 @@
 import cactusTheme from '@repay/cactus-theme'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 import styled from 'styled-components'
 
@@ -14,11 +14,10 @@ const BreakpointBox = styled(Box)`
   width: 50px;
   height: 50px;
   border-radius: 15%
-
-  ${(p): string | undefined => p.theme.mediaQueries && p.theme.mediaQueries.small} {
+    ${(p): string | undefined => p.theme.mediaQueries && p.theme.mediaQueries.small} {
     max-width: 708px;
     width: 75px;
-    height 75px;
+    height: 75px;
     border-radius: 25%;
   }
   ${(p): string | undefined => p.theme.mediaQueries && p.theme.mediaQueries.medium} {
@@ -41,41 +40,45 @@ const BreakpointBox = styled(Box)`
   }
 `
 
-storiesOf('Style Provider', module).add(
-  'Component Adjusments based on Media Queries',
-  (): React.ReactElement => {
-    return (
-      <StyleProvider theme={cactusTheme} global={true}>
-        <Grid justify="center">
-          <Grid.Item tiny={4}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={4}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={4}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={2}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={2}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={2}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={2}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={2}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-          <Grid.Item tiny={2}>
-            <BreakpointBox backgroundColor={backgroundColors} />
-          </Grid.Item>
-        </Grid>
-      </StyleProvider>
-    )
-  }
-)
+export default {
+  title: 'Style Provider',
+  component: StyleProvider,
+} as Meta
+
+export const ComponentAdjusmentsBasedOnMediaQueries = (): React.ReactElement => {
+  return (
+    <StyleProvider theme={cactusTheme} global={true}>
+      <Grid justify="center">
+        <Grid.Item tiny={4}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={4}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={4}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={2}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={2}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={2}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={2}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={2}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+        <Grid.Item tiny={2}>
+          <BreakpointBox backgroundColor={backgroundColors} />
+        </Grid.Item>
+      </Grid>
+    </StyleProvider>
+  )
+}
+
+ComponentAdjusmentsBasedOnMediaQueries.storyName = 'Component Adjusments based on Media Queries'

--- a/modules/cactus-web/src/Table/Table.story.tsx
+++ b/modules/cactus-web/src/Table/Table.story.tsx
@@ -1,5 +1,5 @@
 import { boolean, number, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import ScreenSizeProvider from '../ScreenSizeProvider/ScreenSizeProvider'
@@ -23,145 +23,142 @@ const varOptions = {
 const createAlignKnob = (): CellAlignment =>
   select('align (prop on Table.Cell)', alignOptions, 'left') as CellAlignment
 
-const tableStories = storiesOf('Table', module)
+export default {
+  title: 'Table',
+  component: Table,
+} as Meta
 
-tableStories.add(
-  'Layout',
-  (): React.ReactElement => {
-    const fullWidth = boolean('fullWidth', true)
-    const captionText = text('Caption', '')
-    const hasHeader = boolean('Has Header', true)
-    const headerText = text('Header Text', 'Header')
-    const cellText = text('Cell Text', 'Cell')
-    const colCount = number('# Columns', 4)
-    const rowCount = number('# Rows', 3)
-    const alignment = createAlignKnob()
-    const hasBody = boolean('Has tbody', true)
-    const variant = select('Variant Override', varOptions, undefined) as Variant
+export const Layout = (): React.ReactElement => {
+  const fullWidth = boolean('fullWidth', true)
+  const captionText = text('Caption', '')
+  const hasHeader = boolean('Has Header', true)
+  const headerText = text('Header Text', 'Header')
+  const cellText = text('Cell Text', 'Cell')
+  const colCount = number('# Columns', 4)
+  const rowCount = number('# Rows', 3)
+  const alignment = createAlignKnob()
+  const hasBody = boolean('Has tbody', true)
+  const variant = select('Variant Override', varOptions, undefined) as Variant
 
-    const makeRow = (
-      content: string,
-      index: number,
-      Row: React.ElementType = Table.Row
-    ): React.ReactElement => {
-      const cols = []
-      for (let i = 0; i < colCount; i++) {
-        cols.push(
-          <Table.Cell align={alignment} key={i}>
-            {content ? `${content} ${i}` : null}
-          </Table.Cell>
-        )
-      }
-      return <Row key={index}>{cols}</Row>
+  const makeRow = (
+    content: string,
+    index: number,
+    Row: React.ElementType = Table.Row
+  ): React.ReactElement => {
+    const cols = []
+    for (let i = 0; i < colCount; i++) {
+      cols.push(
+        <Table.Cell align={alignment} key={i}>
+          {content ? `${content} ${i}` : null}
+        </Table.Cell>
+      )
     }
-
-    const header = hasHeader ? makeRow(headerText, 0, Table.Header) : null
-    const Body = hasBody ? Table.Body : React.Fragment
-    const rows = []
-    for (let i = 0; i < rowCount; i++) {
-      rows.push(makeRow(cellText, i + 1))
-    }
-
-    return (
-      <ScreenSizeProvider>
-        <Table fullWidth={fullWidth} variant={variant}>
-          {captionText && <caption>{captionText}</caption>}
-          {header}
-          <Body>{rows}</Body>
-        </Table>
-      </ScreenSizeProvider>
-    )
+    return <Row key={index}>{cols}</Row>
   }
-)
 
-tableStories.add(
-  'Styles Only',
-  (): React.ReactElement => {
-    const fullWidth = boolean('fullWidth', true)
-    const captionText = text('Caption', '')
-    const hasHeader = boolean('Has Header', true)
-    const headerText = text('Header Text', 'Header')
-    const cellText = text('Cell Text', 'Cell')
-    const colCount = number('# Columns', 4)
-    const rowCount = number('# Rows', 3)
-    const hasBody = boolean('Has tbody', true)
-
-    const makeRow = (
-      content: string,
-      index: number,
-      Cell: React.ElementType = 'td'
-    ): React.ReactElement => {
-      const cols = []
-      for (let i = 0; i < colCount; i++) {
-        cols.push(<Cell key={i}>{`${content} ${i}`}</Cell>)
-      }
-      return <tr key={index}>{cols}</tr>
-    }
-
-    const header = hasHeader ? <thead>{makeRow(headerText, 0, 'th')}</thead> : null
-    const Body = hasBody ? 'tbody' : React.Fragment
-    const rows = []
-    for (let i = 0; i < rowCount; i++) {
-      rows.push(makeRow(cellText, i + 1))
-    }
-
-    return (
-      <ScreenSizeProvider>
-        <Table as="table" fullWidth={fullWidth}>
-          {captionText && <caption>{captionText}</caption>}
-          {header}
-          <Body>{rows}</Body>
-        </Table>
-      </ScreenSizeProvider>
-    )
+  const header = hasHeader ? makeRow(headerText, 0, Table.Header) : null
+  const Body = hasBody ? Table.Body : React.Fragment
+  const rows = []
+  for (let i = 0; i < rowCount; i++) {
+    rows.push(makeRow(cellText, i + 1))
   }
-)
-tableStories.add(
-  'With long values',
-  (): React.ReactElement => {
-    return (
-      <ScreenSizeProvider>
-        <Table variant="card">
-          <Table.Header>
-            <Table.Cell>Header Cell</Table.Cell>
-            <Table.Cell>Header Cell</Table.Cell>
-            <Table.Cell>Header Cell</Table.Cell>
-            <Table.Cell>Header Cell</Table.Cell>
-          </Table.Header>
-          <Table.Body>
-            <Table.Row>
-              <Table.Cell>
-                {text(
-                  'text 1',
-                  'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Soluta perspiciatis dolores autem reiciendis minus voluptates, necessitatibus expedita inventore id vel'
-                )}
-              </Table.Cell>
-              <Table.Cell>Data cell</Table.Cell>
-              <Table.Cell>Data cell</Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>Data cell</Table.Cell>
-              <Table.Cell>
-                {text(
-                  'text 2',
-                  'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Soluta perspiciatis dolores autem reiciendis minus voluptates, necessitatibus expedita inventore id vel'
-                )}
-              </Table.Cell>
-              <Table.Cell>Data cell</Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>Data cell</Table.Cell>
-              <Table.Cell>Data cell</Table.Cell>
-              <Table.Cell>Data cell</Table.Cell>
-            </Table.Row>
-            <Table.Row>
-              <Table.Cell>Data cell</Table.Cell>
-              <Table.Cell>Data cell</Table.Cell>
-              <Table.Cell>Data cell</Table.Cell>
-            </Table.Row>
-          </Table.Body>
-        </Table>
-      </ScreenSizeProvider>
-    )
+
+  return (
+    <ScreenSizeProvider>
+      <Table fullWidth={fullWidth} variant={variant}>
+        {captionText && <caption>{captionText}</caption>}
+        {header}
+        <Body>{rows}</Body>
+      </Table>
+    </ScreenSizeProvider>
+  )
+}
+
+export const StylesOnly = (): React.ReactElement => {
+  const fullWidth = boolean('fullWidth', true)
+  const captionText = text('Caption', '')
+  const hasHeader = boolean('Has Header', true)
+  const headerText = text('Header Text', 'Header')
+  const cellText = text('Cell Text', 'Cell')
+  const colCount = number('# Columns', 4)
+  const rowCount = number('# Rows', 3)
+  const hasBody = boolean('Has tbody', true)
+
+  const makeRow = (
+    content: string,
+    index: number,
+    Cell: React.ElementType = 'td'
+  ): React.ReactElement => {
+    const cols = []
+    for (let i = 0; i < colCount; i++) {
+      cols.push(<Cell key={i}>{`${content} ${i}`}</Cell>)
+    }
+    return <tr key={index}>{cols}</tr>
   }
-)
+
+  const header = hasHeader ? <thead>{makeRow(headerText, 0, 'th')}</thead> : null
+  const Body = hasBody ? 'tbody' : React.Fragment
+  const rows = []
+  for (let i = 0; i < rowCount; i++) {
+    rows.push(makeRow(cellText, i + 1))
+  }
+
+  return (
+    <ScreenSizeProvider>
+      <Table as="table" fullWidth={fullWidth}>
+        {captionText && <caption>{captionText}</caption>}
+        {header}
+        <Body>{rows}</Body>
+      </Table>
+    </ScreenSizeProvider>
+  )
+}
+
+export const WithLongValues = (): React.ReactElement => {
+  return (
+    <ScreenSizeProvider>
+      <Table variant="card">
+        <Table.Header>
+          <Table.Cell>Header Cell</Table.Cell>
+          <Table.Cell>Header Cell</Table.Cell>
+          <Table.Cell>Header Cell</Table.Cell>
+          <Table.Cell>Header Cell</Table.Cell>
+        </Table.Header>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              {text(
+                'text 1',
+                'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Soluta perspiciatis dolores autem reiciendis minus voluptates, necessitatibus expedita inventore id vel'
+              )}
+            </Table.Cell>
+            <Table.Cell>Data cell</Table.Cell>
+            <Table.Cell>Data cell</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Data cell</Table.Cell>
+            <Table.Cell>
+              {text(
+                'text 2',
+                'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Soluta perspiciatis dolores autem reiciendis minus voluptates, necessitatibus expedita inventore id vel'
+              )}
+            </Table.Cell>
+            <Table.Cell>Data cell</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Data cell</Table.Cell>
+            <Table.Cell>Data cell</Table.Cell>
+            <Table.Cell>Data cell</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Data cell</Table.Cell>
+            <Table.Cell>Data cell</Table.Cell>
+            <Table.Cell>Data cell</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </ScreenSizeProvider>
+  )
+}
+
+WithLongValues.storyName = 'With long values'

--- a/modules/cactus-web/src/Tag/Tag.story.tsx
+++ b/modules/cactus-web/src/Tag/Tag.story.tsx
@@ -1,5 +1,5 @@
 import { boolean } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Button from '../Button/Button'
@@ -25,35 +25,39 @@ const options = [
   },
 ]
 
-storiesOf('Tag', module).add(
-  'With close option',
-  (): React.ReactElement => {
-    const [values, setValues] = React.useState(options)
+export default {
+  title: 'Tag',
+  component: Tag,
+} as Meta
 
-    const deleteTag = (id: string) => {
-      setValues(values.filter((e) => e.id !== id))
-    }
-    const closeOption = boolean('close option', true)
-    return (
-      <Flex justifyContent="center" flexDirection="column">
-        <div>
-          {values.map((e) => (
-            <Tag
-              closeOption={closeOption}
-              id={e.id}
-              key={e.id}
-              onCloseIconClick={closeOption ? () => deleteTag(e.id) : undefined}
-            >
-              {e.label}
-            </Tag>
-          ))}
-        </div>
-        {closeOption && (
-          <Button variant="action" onClick={() => setValues(options)} mt="50px">
-            Reset Tags
-          </Button>
-        )}
-      </Flex>
-    )
+export const WithCloseOption = (): React.ReactElement => {
+  const [values, setValues] = React.useState(options)
+
+  const deleteTag = (id: string) => {
+    setValues(values.filter((e) => e.id !== id))
   }
-)
+  const closeOption = boolean('close option', true)
+  return (
+    <Flex justifyContent="center" flexDirection="column">
+      <div>
+        {values.map((e) => (
+          <Tag
+            closeOption={closeOption}
+            id={e.id}
+            key={e.id}
+            onCloseIconClick={closeOption ? () => deleteTag(e.id) : undefined}
+          >
+            {e.label}
+          </Tag>
+        ))}
+      </div>
+      {closeOption && (
+        <Button variant="action" onClick={() => setValues(options)} mt="50px">
+          Reset Tags
+        </Button>
+      )}
+    </Flex>
+  )
+}
+
+WithCloseOption.storyName = 'With close option'

--- a/modules/cactus-web/src/Text/Text.story.tsx
+++ b/modules/cactus-web/src/Text/Text.story.tsx
@@ -1,6 +1,6 @@
 import cactusTheme, { CactusColor, TextStyleCollection } from '@repay/cactus-theme'
 import { select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import { Property } from 'csstype'
 import React from 'react'
 
@@ -16,38 +16,40 @@ bocconcini everyone loves when the cheese comes out everybody's happy
 the big cheese cheddar. Cut the cheese camembert de normandie cheesecake
 cheesy grin cow monterey jack.`
 
-storiesOf('Text', module)
-  .add(
-    'Basic Usage of Text',
-    (): React.ReactElement => (
-      <Text
-        colors={select('colors', COLOR_STYLES, 'base')}
-        margin={text('margin', '0 50px')}
-        padding={text('padding', '3')}
-        fontWeight={text('fontWeight', '400') as Property.FontWeight}
-        fontStyle={text('fontStyle', 'italic')}
-        textAlign={text('textAlign', 'left') as Property.TextAlign}
-        textStyle={select('textStyle', TEXT_STYLES, 'small') as keyof TextStyleCollection}
-      >
-        {text('children', sampleText)}
-      </Text>
-    ),
-    { knobs: { escapeHTML: false } }
-  )
-  .add(
-    'Basic Usage of Span',
-    (): React.ReactElement => (
-      <Span
-        colors={select('colors', COLOR_STYLES, 'base')}
-        margin={text('margin', '0 50px')}
-        padding={text('padding', '3')}
-        fontWeight={text('fontWeight', '400') as Property.FontWeight}
-        fontStyle={text('fontStyle', 'italic')}
-        textAlign={text('textAlign', 'left') as Property.TextAlign}
-        textStyle={select('textStyle', TEXT_STYLES, 'small') as keyof TextStyleCollection}
-      >
-        {text('children', sampleText)}
-      </Span>
-    ),
-    { knobs: { escapeHTML: false } }
-  )
+export default {
+  title: 'Text',
+  component: Text,
+} as Meta
+
+export const BasicUsageOfText = (): React.ReactElement => (
+  <Text
+    colors={select('colors', COLOR_STYLES, 'base')}
+    margin={text('margin', '0 50px')}
+    padding={text('padding', '3')}
+    fontWeight={text('fontWeight', '400') as Property.FontWeight}
+    fontStyle={text('fontStyle', 'italic')}
+    textAlign={text('textAlign', 'left') as Property.TextAlign}
+    textStyle={select('textStyle', TEXT_STYLES, 'small') as keyof TextStyleCollection}
+  >
+    {text('children', sampleText)}
+  </Text>
+)
+BasicUsageOfText.storyName = 'Basic Usage of Text'
+BasicUsageOfText.parameters = { knobs: { escapeHTML: false } }
+
+export const BasicUsageOfSpan = (): React.ReactElement => (
+  <Span
+    colors={select('colors', COLOR_STYLES, 'base')}
+    margin={text('margin', '0 50px')}
+    padding={text('padding', '3')}
+    fontWeight={text('fontWeight', '400') as Property.FontWeight}
+    fontStyle={text('fontStyle', 'italic')}
+    textAlign={text('textAlign', 'left') as Property.TextAlign}
+    textStyle={select('textStyle', TEXT_STYLES, 'small') as keyof TextStyleCollection}
+  >
+    {text('children', sampleText)}
+  </Span>
+)
+
+BasicUsageOfSpan.storyName = 'Basic Usage of Span'
+BasicUsageOfSpan.parameters = { knobs: { escapeHTML: false } }

--- a/modules/cactus-web/src/TextArea/TextArea.story.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.story.tsx
@@ -1,5 +1,5 @@
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import actions from '../helpers/storybookActionsWorkaround'
@@ -16,15 +16,17 @@ const statusOptions: StatusOptions = {
   error: 'error',
 }
 
-storiesOf('TextArea', module).add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <TextArea
-      disabled={boolean('disabled', false)}
-      placeholder={text('placeholder', 'Placeholder')}
-      status={select('status', statusOptions, statusOptions.none)}
-      resize={boolean('resize', false)}
-      {...eventLoggers}
-    />
-  )
+export default {
+  title: 'TextArea',
+  component: TextArea,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <TextArea
+    disabled={boolean('disabled', false)}
+    placeholder={text('placeholder', 'Placeholder')}
+    status={select('status', statusOptions, statusOptions.none)}
+    resize={boolean('resize', false)}
+    {...eventLoggers}
+  />
 )

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.story.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.story.tsx
@@ -1,47 +1,46 @@
 import { actions } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import TextAreaField from './TextAreaField'
 
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
-storiesOf('TextAreaField', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => (
-      <TextAreaField
-        label={text('label', 'Field Label')}
-        name="taf-1"
-        placeholder={text('placeholder', 'Placeholder')}
-        disabled={boolean('disabled', false)}
-        success={text('success', '')}
-        warning={text('warning', '')}
-        error={text('error', '')}
-        tooltip={text('tooltip', 'Some tooltip text')}
-        resize={boolean('resize', false)}
-        autoTooltip={boolean('autoTooltip', true)}
-        {...eventLoggers}
-      />
-    )
-  )
-  .add(
-    'Fixed Width Container',
-    (): React.ReactElement => (
-      <div style={{ width: '336px' }}>
-        <TextAreaField
-          label={text('label', 'Field Label')}
-          placeholder={text('placeholder', 'Placeholder')}
-          disabled={boolean('disabled', false)}
-          error={text(
-            'error',
-            'The input you have entered is unequivocally invalid because we absolutely do not support the information you have provided.'
-          )}
-          tooltip={text('tooltip', 'Enter some text')}
-          name="taf-2"
-          {...eventLoggers}
-        />
-      </div>
-    )
-  )
+export default {
+  title: 'TextAreaField',
+  component: TextAreaField,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <TextAreaField
+    label={text('label', 'Field Label')}
+    name="taf-1"
+    placeholder={text('placeholder', 'Placeholder')}
+    disabled={boolean('disabled', false)}
+    success={text('success', '')}
+    warning={text('warning', '')}
+    error={text('error', '')}
+    tooltip={text('tooltip', 'Some tooltip text')}
+    resize={boolean('resize', false)}
+    autoTooltip={boolean('autoTooltip', true)}
+    {...eventLoggers}
+  />
+)
+
+export const FixedWidthContainer = (): React.ReactElement => (
+  <div style={{ width: '336px' }}>
+    <TextAreaField
+      label={text('label', 'Field Label')}
+      placeholder={text('placeholder', 'Placeholder')}
+      disabled={boolean('disabled', false)}
+      error={text(
+        'error',
+        'The input you have entered is unequivocally invalid because we absolutely do not support the information you have provided.'
+      )}
+      tooltip={text('tooltip', 'Enter some text')}
+      name="taf-2"
+      {...eventLoggers}
+    />
+  </div>
+)

--- a/modules/cactus-web/src/TextButton/TextButton.story.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.story.tsx
@@ -1,6 +1,6 @@
 import * as icons from '@repay/cactus-icons'
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import actions from '../helpers/storybookActionsWorkaround'
@@ -11,60 +11,57 @@ type IconName = keyof typeof icons
 const iconNames: IconName[] = Object.keys(icons) as IconName[]
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
 
-storiesOf('TextButton', module)
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => (
-      <TextButton
-        variant={select('variant', textButtonVariants, 'danger')}
-        disabled={boolean('disabled', false)}
-        inverse={boolean('inverse', false)}
-        m={text('m', '')}
-        {...eventLoggers}
-      >
-        {text('children', 'Cancel')}
-      </TextButton>
-    )
+export default {
+  title: 'TextButton',
+  component: TextButton,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <TextButton
+    variant={select('variant', textButtonVariants, 'danger')}
+    disabled={boolean('disabled', false)}
+    inverse={boolean('inverse', false)}
+    m={text('m', '')}
+    {...eventLoggers}
+  >
+    {text('children', 'Cancel')}
+  </TextButton>
+)
+
+export const Multiple = (): React.ReactElement => (
+  <p>
+    <TextButton
+      variant={select('variant', textButtonVariants, 'standard', 'First')}
+      disabled={boolean('disabled', false, 'First')}
+      inverse={boolean('inverse', false, 'First')}
+      m={text('m', '', 'First')}
+    >
+      {text('children', 'Add')}
+    </TextButton>
+    {' | '}
+    <TextButton
+      variant={select('variant', textButtonVariants, 'danger', 'Second')}
+      disabled={boolean('disabled', false, 'Second')}
+      inverse={boolean('inverse', false, 'Second')}
+      m={text('m', '', 'Second')}
+    >
+      {text('children', 'Remove')}
+    </TextButton>
+  </p>
+)
+
+export const WithIcon = (): React.ReactElement => {
+  const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
+  const Icon = icons[iconName] as React.ComponentType<any>
+  return (
+    <TextButton
+      variant={select('variant', textButtonVariants, 'standard')}
+      disabled={boolean('disabled', false)}
+      inverse={boolean('inverse', false)}
+      {...eventLoggers}
+    >
+      <Icon />
+      {text('children', 'Add')}
+    </TextButton>
   )
-  .add(
-    'Multiple',
-    (): React.ReactElement => (
-      <p>
-        <TextButton
-          variant={select('variant', textButtonVariants, 'standard', 'First')}
-          disabled={boolean('disabled', false, 'First')}
-          inverse={boolean('inverse', false, 'First')}
-          m={text('m', '', 'First')}
-        >
-          {text('children', 'Add')}
-        </TextButton>
-        {' | '}
-        <TextButton
-          variant={select('variant', textButtonVariants, 'danger', 'Second')}
-          disabled={boolean('disabled', false, 'Second')}
-          inverse={boolean('inverse', false, 'Second')}
-          m={text('m', '', 'Second')}
-        >
-          {text('children', 'Remove')}
-        </TextButton>
-      </p>
-    )
-  )
-  .add(
-    'With Icon',
-    (): React.ReactElement => {
-      const iconName: IconName = select('icon', iconNames, 'ActionsAdd')
-      const Icon = icons[iconName] as React.ComponentType<any>
-      return (
-        <TextButton
-          variant={select('variant', textButtonVariants, 'standard')}
-          disabled={boolean('disabled', false)}
-          inverse={boolean('inverse', false)}
-          {...eventLoggers}
-        >
-          <Icon />
-          {text('children', 'Add')}
-        </TextButton>
-      )
-    }
-  )
+}

--- a/modules/cactus-web/src/TextInput/TextInput.story.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.story.tsx
@@ -1,12 +1,16 @@
 import { boolean, select, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import actions from '../helpers/storybookActionsWorkaround'
 import { Status } from '../StatusMessage/StatusMessage'
 import TextInput from './TextInput'
 
-const textInputStories = storiesOf('TextInput', module)
+export default {
+  title: 'TextInput',
+  component: TextInput,
+} as Meta
+
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
 type StatusOptions = { [k in Status | 'none']: Status | null }
@@ -18,14 +22,11 @@ const statusOptions: StatusOptions = {
   error: 'error',
 }
 
-textInputStories.add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <TextInput
-      disabled={boolean('disabled', false)}
-      placeholder={text('placeholder', 'Placeholder')}
-      status={select('status', statusOptions, statusOptions.none)}
-      {...eventLoggers}
-    />
-  )
+export const BasicUsage = (): React.ReactElement => (
+  <TextInput
+    disabled={boolean('disabled', false)}
+    placeholder={text('placeholder', 'Placeholder')}
+    status={select('status', statusOptions, statusOptions.none)}
+    {...eventLoggers}
+  />
 )

--- a/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.story.tsx
@@ -1,11 +1,15 @@
 import { actions } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React, { useState } from 'react'
 
 import TextInputField from './TextInputField'
 
-const textInputFieldStories = storiesOf('TextInputField', module)
+export default {
+  title: 'TextInputField',
+  component: TextInputField,
+} as Meta
+
 const eventLoggers = actions('onChange', 'onFocus', 'onBlur')
 
 const InputValidator = (): React.ReactElement => {
@@ -24,42 +28,38 @@ const InputValidator = (): React.ReactElement => {
   )
 }
 
-textInputFieldStories
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => (
-      <TextInputField
-        label={text('label', 'Input Label')}
-        placeholder={text('placeholder', 'Placeholder')}
-        disabled={boolean('disabled', false)}
-        success={text('success', '')}
-        warning={text('warning', '')}
-        error={text('error', '')}
-        tooltip={text('tooltip', 'Enter some text')}
-        name="input-1"
-        autoTooltip={boolean('autoTooltip', true)}
-        {...eventLoggers}
-      />
-    ),
-    { cactus: { overrides: { height: '110vh', width: '110vw' } } }
-  )
-  .add(
-    'Fixed Width Container',
-    (): React.ReactElement => (
-      <div style={{ width: '235px' }}>
-        <TextInputField
-          label={text('label', 'Input Label')}
-          placeholder={text('placeholder', 'Placeholder')}
-          disabled={boolean('disabled', false)}
-          error={text(
-            'error',
-            'The input you have entered is unequivocally invalid because we absolutely do not support the information you have provided.'
-          )}
-          tooltip={text('tooltip', 'Enter some text')}
-          name="input-2"
-          {...eventLoggers}
-        />
-      </div>
-    )
-  )
-  .add('Accessibility', (): React.ReactElement => <InputValidator />)
+export const BasicUsage = (): React.ReactElement => (
+  <TextInputField
+    label={text('label', 'Input Label')}
+    placeholder={text('placeholder', 'Placeholder')}
+    disabled={boolean('disabled', false)}
+    success={text('success', '')}
+    warning={text('warning', '')}
+    error={text('error', '')}
+    tooltip={text('tooltip', 'Enter some text')}
+    name="input-1"
+    autoTooltip={boolean('autoTooltip', true)}
+    {...eventLoggers}
+  />
+)
+
+BasicUsage.parameters = { cactus: { overrides: { height: '110vh', width: '110vw' } } }
+
+export const FixedWidthContainer = (): React.ReactElement => (
+  <div style={{ width: '235px' }}>
+    <TextInputField
+      label={text('label', 'Input Label')}
+      placeholder={text('placeholder', 'Placeholder')}
+      disabled={boolean('disabled', false)}
+      error={text(
+        'error',
+        'The input you have entered is unequivocally invalid because we absolutely do not support the information you have provided.'
+      )}
+      tooltip={text('tooltip', 'Enter some text')}
+      name="input-2"
+      {...eventLoggers}
+    />
+  </div>
+)
+
+export const Accessibility = (): React.ReactElement => <InputValidator />

--- a/modules/cactus-web/src/Toggle/Toggle.story.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.story.tsx
@@ -1,10 +1,13 @@
 import { boolean } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Toggle from './Toggle'
 
-const toggleStories = storiesOf('Toggle', module)
+export default {
+  title: 'Toggle',
+  component: Toggle,
+} as Meta
 
 const initialState = { value: false }
 type State = Readonly<typeof initialState>
@@ -28,9 +31,6 @@ class ToggleManager extends React.Component {
   }
 }
 
-toggleStories.add(
-  'Basic Usage',
-  (): React.ReactElement => {
-    return <ToggleManager />
-  }
-)
+export const BasicUsage = (): React.ReactElement => {
+  return <ToggleManager />
+}

--- a/modules/cactus-web/src/ToggleField/ToggleField.story.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.story.tsx
@@ -1,6 +1,6 @@
 import { actions } from '@storybook/addon-actions'
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import FormHandler from '../storySupport/FormHandler'
@@ -8,20 +8,22 @@ import ToggleField from './ToggleField'
 
 const eventLoggers = actions('onClick', 'onFocus', 'onBlur')
 
-storiesOf('ToggleField', module).add(
-  'Basic Usage',
-  (): React.ReactElement => (
-    <FormHandler defaultValue={false} onChange={(name: string, value: boolean): boolean => value}>
-      {({ value, onChange }): React.ReactElement => (
-        <ToggleField
-          name={text('name', 'boolean_field')}
-          label={text('label', 'Boolean Field')}
-          value={value}
-          onChange={onChange}
-          disabled={boolean('disabled', false)}
-          {...eventLoggers}
-        />
-      )}
-    </FormHandler>
-  )
+export default {
+  title: 'ToggleField',
+  component: ToggleField,
+} as Meta
+
+export const BasicUsage = (): React.ReactElement => (
+  <FormHandler defaultValue={false} onChange={(name: string, value: boolean): boolean => value}>
+    {({ value, onChange }): React.ReactElement => (
+      <ToggleField
+        name={text('name', 'boolean_field')}
+        label={text('label', 'Boolean Field')}
+        value={value}
+        onChange={onChange}
+        disabled={boolean('disabled', false)}
+        {...eventLoggers}
+      />
+    )}
+  </FormHandler>
 )

--- a/modules/cactus-web/src/Tooltip/Tooltip.story.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.story.tsx
@@ -1,23 +1,20 @@
 import { boolean, text } from '@storybook/addon-knobs'
-import { storiesOf } from '@storybook/react'
+import { Meta } from '@storybook/react/types-6-0'
 import React from 'react'
 
 import Tooltip from './Tooltip'
 
-const tooltipStories = storiesOf('Tooltip', module)
+export default {
+  title: 'Tooltip',
+  component: Tooltip,
+} as Meta
 
-tooltipStories
-  .add(
-    'Basic Usage',
-    (): React.ReactElement => (
-      <Tooltip
-        label={text('label', 'Some tooltip text here')}
-        disabled={boolean('disabled', false)}
-      />
-    )
-  )
-  .add(
-    'Collision Detection',
-    (): React.ReactElement => <Tooltip label={text('label', 'Some tooltip text here')} />,
-    { cactus: { overrides: { height: '200vh', width: '200vw' } } }
-  )
+export const BasicUsage = (): React.ReactElement => (
+  <Tooltip label={text('label', 'Some tooltip text here')} disabled={boolean('disabled', false)} />
+)
+
+export const CollisionDetection = (): React.ReactElement => (
+  <Tooltip label={text('label', 'Some tooltip text here')} />
+)
+
+CollisionDetection.parameters = { cactus: { overrides: { height: '200vh', width: '200vw' } } }


### PR DESCRIPTION
There are a lot of changes in this PR.

Most of them are on each component story, so the best way to review those would be in the storybook itself and see that nothing broke. Do this for both cactus-web and the single story in cactus-icons.

I also changed the configuration files in both modules too, ".storybook/**". I did this because of the way the docs say it needs to be configured. I also updated some things so it would be easier to migrate to other releases in the future.

Lastly, check the make-component function. I changed that to reflect the migration to CSF. A good way to test this is generating a new component.

[CACTUS-402]


[CACTUS-402]: https://repayonline.atlassian.net/browse/CACTUS-402