### PR TITLE
CACTUS-405 :: IE relatedTarget Support

### DIFF
--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1158,8 +1158,9 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
       return
     }
 
-    // In IE, there's no relatedTarget on blur...it's already moved on to activeElement
-    if (isIE()) {
+    // In IE, there's no relatedTarget on blur with React versions lower than v17...it's already moved on to activeElement
+    const isReact17 = event.nativeEvent.type === 'focusout'
+    if (isIE() && !isReact17) {
       setTimeout(() => {
         const focusTarget = document.activeElement
         this.closeListIfNotFocused(focusTarget)

--- a/modules/cactus-web/src/helpers/usePopup.ts
+++ b/modules/cactus-web/src/helpers/usePopup.ts
@@ -100,10 +100,10 @@ function usePopup(
   const closeOnBlur = React.useCallback(
     (event: React.FocusEvent<HTMLElement>) => {
       const wrapper = event.currentTarget
+      const isReact17 = event.nativeEvent.type === 'focusout'
       // IE sets activeElement before the blur/focus events, but doesn't support
-      // relatedTarget. Note that in React 17 this might change if they switch
-      // from focus/blur to focusin/focusout, which DO support relatedTarget.
-      const focused = isIE ? document.activeElement : event.relatedTarget
+      // relatedTarget with versions of React lower than v17.
+      const focused = isIE && !isReact17 ? document.activeElement : event.relatedTarget
       if (!focused || !wrapper.contains(focused as Node)) {
         toggle(false)
       }


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-405

Should be a quick & easy one. I tested other usages of `relatedTarget` that I found, but I didn't notice any problems. If you happen to notice anything I missed, let me know!

### Testing
Test the following in both IE and your preferred browser
1. Open the Select "with comboBox" story and focus the combobox input. Click outside the select and make sure the list closes.
2. Open the Layout story and click the gear icon in the action bar. Click outside the panel to make sure it closes when focus leaves the panel.