### PR TITLE
CACTUS-412 MenuBar scroll buttons are both visible or both hidden

### DIFF
--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -153,13 +153,13 @@ const FloatingMenu: React.FC<React.HTMLAttributes<HTMLElement>> = ({
   const [menuRef, scroll] = useScrollButtons('vertical', !hidden)
   return (
     <MenuWrapper aria-hidden={hidden} tabIndex={tabIndex} onKeyDown={onKeyDown}>
-      <ScrollButton show={scroll.showBack} onClick={scroll.clickBack}>
+      <ScrollButton show={scroll.showButtons} onClick={scroll.clickBack}>
         <NavigationChevronUp />
       </ScrollButton>
       <MenuList {...props} aria-orientation="vertical" ref={menuRef}>
         {children}
       </MenuList>
-      <ScrollButton show={scroll.showFore} onClick={scroll.clickFore}>
+      <ScrollButton show={scroll.showButtons} onClick={scroll.clickFore}>
         <NavigationChevronDown />
       </ScrollButton>
     </MenuWrapper>
@@ -204,13 +204,13 @@ const Topbar = React.forwardRef<HTMLElement, MenuBarProps>(({ children, ...props
 
   return (
     <Nav {...props} ref={ref} tabIndex={-1} onClick={navClickHandler} onKeyDown={menuKeyHandler}>
-      <ScrollButton show={scroll.showBack} onClick={scroll.clickBack}>
+      <ScrollButton show={scroll.showButtons} onClick={scroll.clickBack}>
         <NavigationChevronLeft />
       </ScrollButton>
       <MenuList role="menubar" aria-orientation={orientation} ref={mergedRef} onFocus={focusMenu}>
         {children}
       </MenuList>
-      <ScrollButton show={scroll.showFore} onClick={scroll.clickFore}>
+      <ScrollButton show={scroll.showButtons} onClick={scroll.clickFore}>
         <NavigationChevronRight />
       </ScrollButton>
     </Nav>
@@ -292,13 +292,21 @@ const ScrollButton = styled.div.attrs({ 'aria-hidden': true })<{ show?: boolean 
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  cursor: pointer;
   background-color: transparent;
   text-align: center;
   outline: none;
-  :hover {
-    color: ${(p) => p.theme.colors.callToAction};
-  }
+  ${(p) =>
+    !!p.onClick
+      ? `
+    cursor: pointer;
+    :hover {
+      color: ${p.theme.colors.callToAction};
+    }
+    `
+      : `
+    cursor: not-allowed;
+    color: ${p.theme.colors.lightGray};
+    `}
   svg {
     width: 18px;
     height: 18px;

--- a/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
+++ b/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
@@ -545,14 +545,11 @@ exports[`component: MenuBar typechecks 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  cursor: pointer;
   background-color: transparent;
   text-align: center;
   outline: none;
-}
-
-.c1:hover {
-  color: hsl(200,96%,35%);
+  cursor: not-allowed;
+  color: hsl(0,0%,90%);
 }
 
 .c1 svg {
@@ -564,10 +561,7 @@ exports[`component: MenuBar typechecks 1`] = `
 .c12 {
   background-color: hsl(0,0%,100%);
   color: hsl(200,10%,20%);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: none;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -579,10 +573,10 @@ exports[`component: MenuBar typechecks 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  cursor: pointer;
   background-color: transparent;
   text-align: center;
   outline: none;
+  cursor: pointer;
 }
 
 .c12:hover {


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-412

I looked into using IconButton like the ticket said, but it didn't work out:
- The icons are 18px, which is not an available `IconSize`. Looking at the code I think you could actually pass `iconSize="18px"` and it would work, but you'd have to do `@ts-ignore` _and_ you'd still get a PropTypes warning.
- (I had more reasons, but when I considered them more deeply while writing them out here, I realized they weren't as good as I thought they were.)