### PR TITLE
CACTUS-291 :: Add coverage support for SonarQube

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/dist
 !actions/create-pull-request/dist
 **/coverage
+**/test-report.xml
 .cache
 .DS_Store
 local.env

--- a/modules/cactus-fwk/package.json
+++ b/modules/cactus-fwk/package.json
@@ -40,7 +40,8 @@
     ],
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
-    ]
+    ],
+    "testResultsProcessor": "jest-sonar-reporter"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -53,6 +54,7 @@
     "@types/react": "^16.9.53",
     "babel-jest": "^26.6.0",
     "jest": "^26.6.0",
+    "jest-sonar-reporter": "^2.0.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/modules/cactus-i18n/package.json
+++ b/modules/cactus-i18n/package.json
@@ -36,7 +36,8 @@
     ],
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
-    ]
+    ],
+    "testResultsProcessor": "jest-sonar-reporter"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -50,6 +51,7 @@
     "@types/react": "^16.9.53",
     "babel-jest": "^26.6.0",
     "jest": "^26.6.0",
+    "jest-sonar-reporter": "^2.0.0",
     "prop-types": "^15.7.2",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/modules/cactus-icons/package.json
+++ b/modules/cactus-icons/package.json
@@ -47,7 +47,8 @@
       "lcov",
       "text",
       "json-summary"
-    ]
+    ],
+    "testResultsProcessor": "jest-sonar-reporter"
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",
@@ -73,6 +74,7 @@
     "babel-loader": "^8.1.0",
     "fast-glob": "^3.2.4",
     "jest": "^26.6.0",
+    "jest-sonar-reporter": "^2.0.0",
     "jest-styled-components": "^7.0.3",
     "prop-types": "^15.7.2",
     "react": "^17.0.0",

--- a/modules/cactus-theme/package.json
+++ b/modules/cactus-theme/package.json
@@ -26,6 +26,7 @@
     "@repay/scripts": "^2.0.1",
     "@types/jest": "^26.0.14",
     "babel-jest": "^26.6.0",
+    "jest-sonar-reporter": "^2.0.0",
     "typescript": "^4.0.3"
   },
   "jest": {
@@ -41,6 +42,7 @@
     ],
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
-    ]
+    ],
+    "testResultsProcessor": "jest-sonar-reporter"
   }
 }

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -58,7 +58,8 @@
       "src/**/*.{ts,tsx}",
       "!src/**/*.story.{ts,tsx}",
       "!src/storySupport/**"
-    ]
+    ],
+    "testResultsProcessor": "jest-sonar-reporter"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -91,6 +92,7 @@
     "babel-plugin-require-context-hook": "^1.0.0",
     "csstype": "^3.0.3",
     "jest": "^26.6.0",
+    "jest-sonar-reporter": "^2.0.0",
     "jest-styled-components": "^7.0.3",
     "prop-types": "^15.7.2",
     "puppeteer": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "yarn test:local",
     "test:ci": "yarn lint && yarn ws run test:ci",
     "test:local": "yarn lint && yarn ws run test:local",
+    "test:sonar": "yarn fwk test --coverage && yarn i18n test --coverage && yarn icons test --coverage && yarn theme test --coverage && yarn web test --coverage",
     "build": "yarn fwk build && yarn theme build && yarn icons build && yarn web build && yarn i18n build",
     "predocs:publish": "yarn docs build",
     "docs:publish": "gh-pages -d ./website/public",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16151,6 +16151,13 @@ jest-snapshot@^26.3.0, jest-snapshot@^26.6.0:
     pretty-format "^26.6.0"
     semver "^7.3.2"
 
+jest-sonar-reporter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-sonar-reporter/-/jest-sonar-reporter-2.0.0.tgz#faa54a7d2af7198767ee246a82b78c576789cf08"
+  integrity sha512-ZervDCgEX5gdUbdtWsjdipLN3bKJwpxbvhkYNXTAYvAckCihobSLr9OT/IuyNIRT1EZMDDwR6DroWtrq+IL64w==
+  dependencies:
+    xml "^1.0.1"
+
 jest-specific-snapshot@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jest-specific-snapshot/-/jest-specific-snapshot-4.0.0.tgz#a52a2e223e7576e610dbeaf341207c557ac20554"
@@ -25792,6 +25799,11 @@ xml2js@^0.4.5, xml2js@~0.4.4:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@~11.0.0:
   version "11.0.1"


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-291

The first step is to add a few tools to `cactus` and `ui-tools` so that SonarQube can correctly interpret coverage reports.  There's not much to test here, but you could run `yarn test:sonar` and verify that the `test-report.xml` files are generated, if you want.  Or, you could check out the `cactus` project in SonarQube and make sure that coverage is correctly captured.  See https://sonarqube.repay.ninja/dashboard?id=cactus (you need to be on the VPN)