### PR TITLE
CACTUS-268: workaround testcafe click bug in Firefox

### DIFF
--- a/examples/mock-ebpp/package.json
+++ b/examples/mock-ebpp/package.json
@@ -13,7 +13,7 @@
     "build": "repay-scripts build src/index.tsx",
     "test:types": "tsc -p ./tsconfig.json --noEmit",
     "test": "yarn build && node ./run-ete-tests.js",
-    "test:ci": "yarn test:types && yarn test -b 'browserstack:IE@11:Windows 10, browserstack:Chrome:Windows 10'",
+    "test:ci": "yarn test:types && yarn test -b 'browserstack:IE@11:Windows 10, browserstack:Chrome:Windows 10, browserstack:firefox:OS X, browserstack:safari:OS X'",
     "test:local": "yarn test:types && yarn test -b 'browserstack:IE@11:Windows 10, browserstack:Chrome:Windows 10'",
     "cleanup": "rm -rf dist",
     "list-testcafe-browsers": "testcafe -b"

--- a/examples/mock-ebpp/tests/account-integration.test.ts
+++ b/examples/mock-ebpp/tests/account-integration.test.ts
@@ -2,6 +2,7 @@ import { queryAllByText, queryByLabelText, queryByText } from '@testing-library/
 import * as path from 'path'
 import { Selector } from 'testcafe'
 
+import { clickWorkaround } from './helpers/actions'
 import startStaticServer from './helpers/static-server'
 
 // eslint-disable-next-line no-undef
@@ -25,14 +26,13 @@ fixture('Account Integration Tests')
 test('DataGrid interactions in table view', async (t: TestController): Promise<void> => {
   // Set desktop screen size
   await t.resizeWindow(1600, 994)
-  // Sort by first name
-  await t.click(queryByText('First Name'))
+  await clickWorkaround(queryByText('First Name'))
   await t.expect(queryByText('Victoria').exists).ok()
   await t.expect(queryByText('Chris').exists).ok()
   await t.expect(queryByText('Anita').exists).notOk()
 
   // Change sort order
-  await t.click(queryByText('First Name'))
+  await clickWorkaround(queryByText('First Name'))
   await t.expect(queryByText('Anita').exists).ok()
   await t.expect(queryByText('James').exists).ok()
   await t.expect(queryByText('Victoria').exists).notOk()

--- a/examples/mock-ebpp/tests/faq-integration.test.ts
+++ b/examples/mock-ebpp/tests/faq-integration.test.ts
@@ -2,7 +2,7 @@ import { queryByText } from '@testing-library/testcafe'
 import * as path from 'path'
 import { Selector } from 'testcafe'
 
-import makeActions from './helpers/actions'
+import makeActions, { clickWorkaround } from './helpers/actions'
 import startStaticServer from './helpers/static-server'
 
 // eslint-disable-next-line no-undef
@@ -27,7 +27,7 @@ test('use the DOWN arrow key to navigate even after the order changes', async (t
   void
 > => {
   const { focusAccordionHeaderByText, getActiveElement } = makeActions(t)
-  await t.click(queryByText('Insert Accordion'))
+  await clickWorkaround(queryByText('Insert Accordion'))
   await focusAccordionHeaderByText('Lorem Ipsum?')
   await t.pressKey('down')
   const accordionButtonActiveEl = await getActiveElement()
@@ -91,7 +91,7 @@ test('use the HOME key to focus on the first accordion after the order changes',
 > => {
   const { focusAccordionHeaderByText, getActiveElement } = makeActions(t)
 
-  await t.click(queryByText('Insert Accordion'))
+  await clickWorkaround(queryByText('Insert Accordion'))
   await focusAccordionHeaderByText('Office Ipsum?')
   await t.pressKey('home')
   const accordionButtonActiveEl = await getActiveElement()
@@ -110,7 +110,7 @@ test('use the END key to focus on the first accordion after the order changes', 
 > => {
   const { focusAccordionHeaderByText, getActiveElement } = makeActions(t)
 
-  await t.click(queryByText('Insert Accordion'))
+  await clickWorkaround(queryByText('Insert Accordion'))
   await focusAccordionHeaderByText('Lorem Ipsum?')
   await t.pressKey('end')
   const accordionButtonActiveEl = await getActiveElement()

--- a/examples/mock-ebpp/tests/helpers/actions.ts
+++ b/examples/mock-ebpp/tests/helpers/actions.ts
@@ -93,3 +93,7 @@ export default (
   selectDropdownOption: selectDropdownOption(t),
   uploadFile: uploadFile(t),
 })
+
+export const clickWorkaround = (selector: ReturnType<typeof Selector>): Promise<any> =>
+  // @ts-ignore
+  ClientFunction(() => button().click(), { dependencies: { button: selector } })()

--- a/examples/mock-ebpp/tests/rules-integration.test.ts
+++ b/examples/mock-ebpp/tests/rules-integration.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path'
 import { ClientFunction } from 'testcafe'
 
 import { RulesData } from '../types'
-import makeActions from './helpers/actions'
+import makeActions, { clickWorkaround } from './helpers/actions'
 import startStaticServer from './helpers/static-server'
 
 const getApiData = ClientFunction((): RulesData => (window as any).apiData)
@@ -35,7 +35,7 @@ test('fill out and submit the form sequentially', async (t: TestController): Pro
   await selectDropdownOption('Value', '-1')
   await t.click(queryByText('Condition #1')).click(queryByText('Add Action'))
   await selectDropdownOption('Name', 'Do the thing')
-  await t.click(queryByText('Submit'))
+  await clickWorkaround(queryByText('Submit'))
 
   const apiData: RulesData = await getApiData()
   await t.expect(apiData).eql([
@@ -69,7 +69,8 @@ test('fill out and submit the form with deleting and reordering', async (t: Test
   await selectDropdownOption('Name', 'Do the thing')
   await t.click(queryByText('Add Action'))
   await selectDropdownOption('Name', 'Do another thing')
-  await t.click(queryByLabelText('Move Action #1 down')).click(queryByText('Submit'))
+  await t.click(queryByLabelText('Move Action #1 down'))
+  await clickWorkaround(queryByText('Submit'))
 
   const apiData: RulesData = await getApiData()
   await t.expect(apiData).eql([

--- a/examples/standard/package.json
+++ b/examples/standard/package.json
@@ -8,7 +8,7 @@
     "dev": "repay-scripts dev --config webpack.config.js -p 3435 src/index.tsx",
     "build": "repay-scripts build src/index.tsx --config webpack.config.js",
     "test": "yarn build && node ./run-ete-tests.js",
-    "test:ci": "yarn test:types && yarn test -b 'browserstack:IE@11:Windows 10, browserstack:Chrome:Windows 10'",
+    "test:ci": "yarn test:types && yarn test -b 'browserstack:IE@11:Windows 10, browserstack:Chrome:Windows 10, browserstack:firefox:OS X, browserstack:safari:OS X'",
     "test:local": "yarn test:types && yarn test -b 'browserstack:IE@11:Windows 10, browserstack:Chrome:Windows 10'",
     "test:types": "tsc -p ./tsconfig.json --noEmit",
     "list-testcafe-browsers": "testcafe -b"


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-268

Mostly it was the click bug, though it seems Firefox also has a difference in how it formats the file input data, so I had to correct for that.

As far as I could tell, Safari was already passing (at least in browserstack), so I'm not sure what the issue was there.