### PR TITLE
CACTUS-430 :: Updated Tooltip Triggers

### DIFF
--- a/modules/cactus-web/src/Tooltip/Tooltip.test.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.test.tsx
@@ -75,4 +75,25 @@ describe('component: Tooltip', (): void => {
     const tooltip = document.querySelector('div[role="tooltip"]') as Element
     expect(tooltip).not.toBeNull()
   })
+
+  test('should stay open when tooltip icon is clicked', async (): Promise<void> => {
+    jest.useFakeTimers()
+    render(
+      <StyleProvider>
+        <Tooltip label="Show me the money" />
+        <button>Something Else to Focus</button>
+      </StyleProvider>
+    )
+    const tooltipTrigger = document.querySelector('span') as Element
+    const btn = document.querySelector('button') as Element
+    act((): void => {
+      fireEvent.click(tooltipTrigger)
+      fireEvent.mouseEnter(btn)
+      setTimeout(jest.fn(), 2000)
+      jest.runAllTimers()
+    })
+    expect(document.querySelector('div[role="tooltip"]') as Element).toBeInTheDocument()
+    fireEvent.click(btn)
+    expect(document.querySelector('div[role="tooltip"]') as Element).not.toBeInTheDocument()
+  })
 })

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -129,8 +129,7 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
     const { target } = event
     if (
       !(target instanceof Node) ||
-      (!(triggerRef.current && triggerRef.current.contains(target)) &&
-        !(widgetRef.current && widgetRef.current.contains(target)))
+      (!triggerRef.current?.contains(target) && !widgetRef.current?.contains(target))
     ) {
       setStayOpen(false)
     }
@@ -160,14 +159,10 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
             }
             style={{ maxWidth }}
             onMouseEnter={() => {
-              if (!stayOpen) {
-                setHovering(true)
-              }
+              setHovering(true)
             }}
             onMouseLeave={() => {
-              if (!stayOpen) {
-                setHovering(false)
-              }
+              setHovering(false)
             }}
           />
           <VisuallyHidden role="tooltip" id={id}>

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -118,22 +118,22 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
   const [stayOpen, setStayOpen] = useState<boolean>(false)
 
   useEffect(() => {
+    const handleBodyClick = (event: MouseEvent): void => {
+      const { target } = event
+      if (
+        !(target instanceof Node) ||
+        (!triggerRef.current?.contains(target) && !widgetRef.current?.contains(target))
+      ) {
+        setStayOpen(false)
+      }
+    }
+
     document.body.addEventListener('click', handleBodyClick)
 
     return () => {
       document.body.removeEventListener('click', handleBodyClick)
     }
   }, [])
-
-  const handleBodyClick = (event: MouseEvent): void => {
-    const { target } = event
-    if (
-      !(target instanceof Node) ||
-      (!triggerRef.current?.contains(target) && !widgetRef.current?.contains(target))
-    ) {
-      setStayOpen(false)
-    }
-  }
 
   return (
     <>

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -4,7 +4,7 @@ import VisuallyHidden from '@reach/visually-hidden'
 import { NotificationInfo } from '@repay/cactus-icons'
 import { ColorStyle, Shape } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import React, { cloneElement, useRef, useState } from 'react'
+import React, { cloneElement, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
@@ -112,14 +112,35 @@ const StyledInfo = styled(({ forceVisible, ...props }) => <NotificationInfo {...
 const TooltipBase = (props: TooltipProps): React.ReactElement => {
   const { className, disabled, label, ariaLabel, id, maxWidth, position, forceVisible } = props
   const triggerRef = useRef<HTMLSpanElement | null>(null)
+  const widgetRef = useRef<HTMLDivElement | null>(null)
   const [trigger, tooltip] = useTooltip({ ref: triggerRef })
   const [hovering, setHovering] = useState<boolean>(false)
+  const [stayOpen, setStayOpen] = useState<boolean>(false)
+
+  useEffect(() => {
+    document.body.addEventListener('click', handleBodyClick)
+
+    return () => {
+      document.body.removeEventListener('click', handleBodyClick)
+    }
+  }, [])
+
+  const handleBodyClick = (event: MouseEvent): void => {
+    const { target } = event
+    if (
+      !(target instanceof Node) ||
+      (!(triggerRef.current && triggerRef.current.contains(target)) &&
+        !(widgetRef.current && widgetRef.current.contains(target)))
+    ) {
+      setStayOpen(false)
+    }
+  }
 
   return (
     <>
       {cloneElement(
-        <span className={className}>
-          <StyledInfo disabled={disabled} forceVisible={forceVisible} />
+        <span className={className} onClick={() => setStayOpen(true)}>
+          <StyledInfo disabled={disabled} forceVisible={stayOpen || hovering || forceVisible} />
         </span>,
         trigger
       )}
@@ -127,7 +148,8 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
         <>
           <TooltipPopup
             {...tooltip}
-            isVisible={hovering || forceVisible || tooltip.isVisible}
+            ref={widgetRef}
+            isVisible={stayOpen || hovering || forceVisible || tooltip.isVisible}
             label={label}
             ariaLabel={ariaLabel}
             position={
@@ -138,10 +160,14 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
             }
             style={{ maxWidth }}
             onMouseEnter={() => {
-              setHovering(true)
+              if (!stayOpen) {
+                setHovering(true)
+              }
             }}
             onMouseLeave={() => {
-              setHovering(false)
+              if (!stayOpen) {
+                setHovering(false)
+              }
             }}
           />
           <VisuallyHidden role="tooltip" id={id}>


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-430

Unfortunately, I wasn't able to come up with a solution to close the tooltip without changing the focus when `autoTooltip` is enabled. I did do some investigating, and I think it's possible, but I believe the scope for the changes required would go beyond what I'd feel comfortable adding during work for this ticket. If we want to add that feature, I think we should create a separate ticket for it.

### Testing
1. Pull down this branch and bring up storybook in your web browser
2. Go to the tooltip story and click the icon
3. Verify that the content window stays open until you click outside the icon or the widget

I tested this using my phone and it worked for me, but if you're able to test it on your mobile device (or an emulator) that'd be great too.