### PR TITLE
CACTUS-429: allow configurable text for empty optins in select

### DIFF
--- a/modules/cactus-web/src/Select/Select.story.tsx
+++ b/modules/cactus-web/src/Select/Select.story.tsx
@@ -24,20 +24,24 @@ export default {
   component: Select,
 } as Meta
 
-export const BasicUsage = (): ReactElement => (
-  <React.Fragment>
-    <Select
-      options={array('options', ['name', 'other', 'three'])}
-      name={text('name', 'random')}
-      id={text('id', 'select-input')}
-      disabled={boolean('disabled', false)}
-      multiple={boolean('multiple', false)}
-      m={text('m', '2')}
-      {...eventLoggers}
-    />
-  </React.Fragment>
-)
-
+export const BasicUsage = (): ReactElement => {
+  const optionsAvailable = boolean('Show options?', true)
+  const options = array('options', ['name', 'other', 'three'])
+  return (
+    <React.Fragment>
+      <Select
+        options={optionsAvailable ? options : []}
+        noOptionsText={text('No option text', 'No options available')}
+        name={text('name', 'random')}
+        id={text('id', 'select-input')}
+        disabled={boolean('disabled', false)}
+        multiple={boolean('multiple', false)}
+        m={text('m', '2')}
+        {...eventLoggers}
+      />
+    </React.Fragment>
+  )
+}
 export const CollisionsInAnOverSizedContainer = (): ReactElement => (
   <React.Fragment>
     <Select
@@ -115,9 +119,11 @@ WithMultiselect.parameters = { cactus: { overrides: { overflow: 'hidden' } } }
 
 export const WithComboBox = (): ReactElement => {
   const [value, setValue] = React.useState<SelectValueType>(null)
+  const optionsAvailable = boolean('Show options?', true)
   return (
     <Select
-      options={arizonaCities}
+      options={optionsAvailable ? arizonaCities : []}
+      noOptionsText={text('No option text', 'No options available')}
       name="random"
       id="select-input"
       disabled={boolean('disabled', false)}

--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -49,7 +49,7 @@ describe('component: Select', (): void => {
     )
 
     const trigger = getByRole('button')
-    expect(trigger).toHaveTextContent('No options available.')
+    expect(trigger).toHaveTextContent('No options available')
   })
 
   test('can receive options with number values', async (): Promise<void> => {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -251,7 +251,7 @@ const SelectTrigger = styled.button`
   min-width: 194px;
   width: 100%;
   height: 32px;
-  padding: 0 24px 0 16px;
+  padding: 0 28px 0 16px;
   background-color: transparent;
   ${(p): ReturnType<typeof css> => getShape(p.theme.shape)}
   ${(p): ReturnType<typeof css> => getBorder(p.theme.border)}
@@ -1546,6 +1546,7 @@ Select.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
+  noOptionsText: PropTypes.string,
 }
 
 Select.defaultProps = {
@@ -1555,6 +1556,7 @@ Select.defaultProps = {
   canCreateOption: true,
   matchNotFoundText: 'No match found',
   extraLabel: '+{} more',
+  noOptionsText: 'No options available',
 }
 
 export default Select

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -56,6 +56,7 @@ export interface SelectProps
   matchNotFoundText?: string
   comboBoxSearchLabel?: string
   onDropdownToggle?: (prop: boolean) => void
+  noOptionsText?: string
   /**
    * Used when there are multiple selected, but too many to show. place '{}' to insert unshown number in label
    */
@@ -1414,12 +1415,14 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
       matchNotFoundText = 'No match found',
       extraLabel,
       value: propsValue,
+      noOptionsText = 'No options available',
       onDropdownToggle,
       ...rest
     } = omitMargins(this.props) as Omit<SelectProps, keyof MarginProps>
     const { isOpen, searchValue, activeDescendant } = this.state
     const options = this.getExtOptions()
-    const noOptsDisable = !comboBox && options.length === 0
+    const noOptsDisable =
+      (!comboBox && options.length === 0) || (comboBox && !canCreateOption && options.length === 0)
 
     // Added `tabIndex=-1` on the wrapper element to compensate for
     // the fact that Safari cannot focus buttons on click.
@@ -1466,7 +1469,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
               <ValueSwitch
                 extraLabel={extraLabel || '+{} more'}
                 options={options}
-                placeholder={noOptsDisable ? 'No options available.' : placeholder}
+                placeholder={noOptsDisable ? noOptionsText : placeholder}
                 multiple={multiple}
               />
               <NavigationChevronDown iconSize="tiny" />

--- a/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`component: Select snapshot 1`] = `
   min-width: 194px;
   width: 100%;
   height: 32px;
-  padding: 0 24px 0 16px;
+  padding: 0 28px 0 16px;
   background-color: transparent;
   border-radius: 8px;
   border-width: 1px;
@@ -250,7 +250,7 @@ exports[`component: Select with theme customization should have 2px border 1`] =
   min-width: 194px;
   width: 100%;
   height: 32px;
-  padding: 0 24px 0 16px;
+  padding: 0 28px 0 16px;
   background-color: transparent;
   border-radius: 8px;
   border-width: 2px;
@@ -472,7 +472,7 @@ exports[`component: Select with theme customization should match intermediate sh
   min-width: 194px;
   width: 100%;
   height: 32px;
-  padding: 0 24px 0 16px;
+  padding: 0 28px 0 16px;
   background-color: transparent;
   border-radius: 8px;
   border-width: 1px;
@@ -694,7 +694,7 @@ exports[`component: Select with theme customization should match square shape st
   min-width: 194px;
   width: 100%;
   height: 32px;
-  padding: 0 24px 0 16px;
+  padding: 0 28px 0 16px;
   background-color: transparent;
   border-radius: 1px;
   border-width: 1px;
@@ -916,7 +916,7 @@ exports[`component: Select with theme customization should not have box shadows 
   min-width: 194px;
   width: 100%;
   height: 32px;
-  padding: 0 24px 0 16px;
+  padding: 0 28px 0 16px;
   background-color: transparent;
   border-radius: 8px;
   border-width: 1px;

--- a/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
+++ b/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`component: SelectField minimal snapshot 1`] = `
   min-width: 194px;
   width: 100%;
   height: 32px;
-  padding: 0 24px 0 16px;
+  padding: 0 28px 0 16px;
   background-color: transparent;
   border-radius: 8px;
   border-width: 1px;


### PR DESCRIPTION
In the Select story, basic usage there is a knob to disable the option. If it's false the text "No options available" should be displayed.

In WithCombobox there is the same knob, but for it to show the no options available text, the **canCreateOption** knob should also be disabled.

[CACTUS-429]

[CACTUS-429]: https://repayonline.atlassian.net/browse/CACTUS-429