### PR TITLE
CACTUS-437: fix stretching logo in BrandBar in safari

### DIFF
--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -192,6 +192,7 @@ const LogoWrapper = styled.div`
   max-width: 200px;
   max-height: 80px;
   display: flex;
+  align-items: flex-start;
   & > * {
     flex-shrink: 0;
     max-width: 100%;

--- a/modules/cactus-web/src/BrandBar/__snapshots__/BrandBar.test.tsx.snap
+++ b/modules/cactus-web/src/BrandBar/__snapshots__/BrandBar.test.tsx.snap
@@ -199,6 +199,10 @@ exports[`component: BrandBar snapshot - mobile 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c1 > * {
@@ -465,6 +469,10 @@ exports[`component: BrandBar snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c1 > * {


### PR DESCRIPTION
Check the logo is no longer stretching on safari, and that it looks ok in all other browsers too

[CACTUS-437]

[CACTUS-437]: https://repayonline.atlassian.net/browse/CACTUS-437