### PR TITLE
CACTUS-431 add support for fallback & hierarchies in i18n

### DIFF
--- a/docs/Internationalization/API Documentation.md
+++ b/docs/Internationalization/API Documentation.md
@@ -12,124 +12,133 @@ capabilities to provide translations for an application. There are a few pieces 
 
 ### Load
 
-The `load` function is what will load your translations into the controller. You must extend this class because the `load` function should be overridden to provide the correct translations.
+The `load` function is what will load your translations into the controller. You must extend `BaseI18nController` in order to provide an implementation of the `load` function.
 
-- The developer is responsible for handling failures when loading resources in the load function. (e.g. retry loading languages or loading the fallback languages)
-- The developer is also responsible for handling the case in which all translations fail to load for a given section (e.g. reload browser or redirect to error page)
-- The `load` function accepts a single object argument with the following attributes:
+- The developer is responsible for handling failures when loading resources in the load function. (e.g. retry loading, or loading from an alternate source)
+- The `load` function accepts two arguments: an object that represents the section being loaded, and an options object. The section info argument has following properties:
 
-| Attr      | Type   | Required | Description                                                                   |
+| Property  | Type   | Required | Description                                                                   |
 | --------- | ------ | -------- | ----------------------------------------------------------------------------- |
 | `lang`    | String | Y        | The language that should be loaded                                            |
 | `section` | String | Y        | The section of the app that the controller should be loading translations for |
 
-### SetDict
+- The return value is a Promise that resolves to an object with one required and one optional property:
+  - `resources` is an array of Fluent translation strings; you can also put instances of the `FluentResource` class, and the return value of the `loadRef` method (more below). The array is combined such that if the same Fluent translation key exists in two of the resources, the later resource will override the earlier one.
+  - `version` if present should be a number indicating the version of the translations. This is tracked per section, and if (when reloading a section) the returned version is less than the current version, the translations will not be updated.
+- The options object is completely customizable for your use case: for instance, if you have a mix of hard-coded and stored-in-database translations, you might set `options.dynamic = true` to tell the loader it should look in the DB for a particular section.
+- There are two "built-in" options that are useless in `load` but can be passed to `_load` or `I18nSection`:
+  - `loader` is a function that replaces the `load` method; it can be used if you have a section with a very different loading mechanism than the rest, and you don't want to special case it in your controller class.
+  - `onLoad` is a function that is called once the section is loaded (or an error occurred while loading). It takes three arguments: the section info object, the state the section was in before loading (usually "new", but could be "error" if you're retrying), and the error (if there was one). The default `onLoad` behavior is to call any listeners that have been set on the controller.
+  - Both functions bind `this` to the controller when called, which can enable you to keep the default behavior and just do something custom on the side:
 
-The `setDict` function can be used to load a specific translation resource into the controller manually. This function accepts three arguments:
+```js
+// Add an extra translation source on top of the normal ones:
+const loader = async (sectionInfo, opts) => {
+  const { resources } = await this.load(sectionInfo, opts)
+  const ftl = getSuperSpecialTranslations(sectionInfo)
+  return { resources: [...resources, ftl] }
+}
 
-| Arg       | Type   | Required | Description                                                     |
-| --------- | ------ | -------- | --------------------------------------------------------------- |
-| `lang`    | String | Y        | The language that is being loaded                               |
-| `section` | String | Y        | The section of the app that the translation is being loaded for |
-| `ftl`     | String | Y        | The actual ftl-formatted translation                            |
+// Do some custom onLoad logic, but still call the controller's listeners:
+const onLoad = (sectionInfo, prevState, error) => {
+  doCustomLogic()
+  this.onLoad(sectionInfo, prevState, error)
+}
+```
+
+### LoadRef
+
+The `loadRef` function is meant as a supplement to `load` for specific use cases. Say you have some common translations that appear on multiple pages. They're not quite global enough to wrap the entire app in an `I18nSection`, but it's also inconvenient to put a section everyplace they're used; instead, you can include those translations as a reference. The "common" section will only be loaded once, but can be referenced by as many other sections as needed:
+
+```
+load(sectionInfo, opts) {
+  const resources = []
+  if (needsCommonTranslations(sectionInfo.section)) {
+    resources.push(this.loadRef(sectionInfo, 'common', opts))
+  }
+  resources.push(getTranslations(sectionInfo.section, sectionInfo.lang))
+  return Promise.resolve({ resources })
+}
+```
+
+Another use case could be if you have two languages that are mostly the same with only a few differences, like en-US and en-GB: one language can include a ref to the other, and only the Fluent keys that are actually different need to be overridden.
+
+| Argument   | Required | Description                                                          |
+| ---------- | -------- | -------------------------------------------------------------------- |
+| `referrer` | Y        | The object that was received as the first argument to `load`         |
+| `section`  | Y        | The section to be included as a reference                            |
+| `loadOpts` | Y        | The options that were passed as the second argument to `load`        |
+| `lang`     | N        | The language of the reference section (defaults to same as referrer) |
 
 ### Get
 
-The `get` function will search language bundles for the requested message, then return the message and an object of attached attributes.
+The `get` function will search for the requested translation. It searches through all matching languages (see [language matching](https://www.projectfluent.org/fluent.js/langneg/#matching)), plus the `defaultLang` if there is one. It accepts a single object argument with the following properties:
 
-#### Params
+| Property   | Type        | Required | Description                                           |
+| ---------- | ----------- | -------- | ----------------------------------------------------- |
+| `lang`     | String      | N        | Override the controller's current language            |
+| `section`  | String      | Y        | The section to search in                              |
+| `id`       | String      | Y        | ID of the message (see `getKey` method)               |
+| `args`     | Object      | N        | Used to resolve variables in the translations         |
 
-The `get()` function accepts one argument which is an object with the following properties.
+The return value is always an object with three properties:
 
-| Attr      | Type   | Required | Description                                                                        |
-| --------- | ------ | -------- | ---------------------------------------------------------------------------------- |
-| `lang`    | String | N        | Override the currently selected language                                           |
-| `section` | String | N        | The section where the id resides, defaults to `global`                             |
-| `id`      | String | Y        | `id` of the message, if section is not `global` they will be concatenated together |
-| `args`    | Object | N        | Used to resolve variables in the translations                                      |
+| Property   | Type     | Description                                                                      |
+| ---------- | -------- | -------------------------------------------------------------------------------- |
+| `text`     | Str/null | The main line from the Fluent translation, null if empty or no translation found |
+| `attrs`    | Object   | Any attrs included with the translation                                          |
+| `found`    | Boolean  | Indicates if a translation was found or not                                      |
 
-#### Returns
+### getKey
 
-The `get()` function will always return a tuple but if the requested message doesn't exist the first value will be `null` and if there are no associated attributes with the message the second argument will be an empty object.
+In some cases the `id` you pass into `get` may not be the same as the Fluent translation key. In that case, you can override the `getKey` method to transform the `id` into the correct format. This mostly exists for backwards compatibility, because in previous versions the key format was hardcoded:
 
-```ts
-type GetReturn = [string | null, { [key: string]: string }]
 ```
+// Implementation to maintain the old key format.
+getKey(id, section, lang) {
+  return section === 'global' ? id : `${section}__${id}`
+}
+```
+Other use cases might be if you use IDs that contain invalid Fluent characters like "." and you need to sanitize the ID before passing it to Fluent.
 
 ### GetText
 
-The `getText` function will search language bundles for the requested message, then return the message only.
-
-#### Params
-
-The `getText(params)` function accepts one argument which is an object with the following properties.
-
-| Attr      | Type   | Required | Description                                                                        |
-| --------- | ------ | -------- | ---------------------------------------------------------------------------------- |
-| `lang`    | String | N        | Override the currently selected language                                           |
-| `section` | String | N        | The section where the id resides, defaults to `global`                             |
-| `id`      | String | Y        | `id` of the message, if section is not `global` they will be concatenated together |
-| `args`    | Object | N        | Used to resolve variables in the translations                                      |
-
-#### Returns
-
-The `getText(params)` function will return either a string or null.
-
-```ts
-type GetTextReturn = null | string
-```
+The `getText` has the same purpose and arguments as `get`, but only returns the main message (or null).
 
 ### HasText
 
-The `hasText` function will search language bundles for the requested message, then return a boolean signifying it was found or not.
-
-#### Params
-
-The `hasText(params)` function accepts one argument which is an object with the following properties.
-
-| Attr      | Type   | Required | Description                                                                        |
-| --------- | ------ | -------- | ---------------------------------------------------------------------------------- |
-| `lang`    | String | N        | Override the currently selected language                                           |
-| `section` | String | N        | The section where the id resides, defaults to `global`                             |
-| `id`      | String | Y        | `id` of the message, if section is not `global` they will be concatenated together |
-
-#### Returns
-
-The `hasText(params)` function will return either `true` if the message exists or `false` if it does not.
+The `hasText` returns the same as the `get` method's `found` property. It has the same arguments, except it doesn't take the `args` variables (because it doesn't actually do any translating).
 
 ### Constructor
 
-The `BaseI18nController` constructor accepts a single options object with the following attributes:
+The `BaseI18nController` constructor accepts a single options object with the following properties:
 
-| Attr             | Type     | Required | Description                                                                                                   |
-| ---------------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| `defaultLang`    | String   | Y        | The default language                                                                                          |
-| `supportedLangs` | String[] | Y        | A list of all languages the application supports                                                              |
-| `lang`           | String   | N        | The current language that should be rendered                                                                  |
-| `global`         | String   | N        | A global ftl translation, used for loading the initial global dictionary at time of instantiation             |
-| `debugMode`      | Boolean  | N        | A flag to indicate whether or not certain console warnings should be displayed. This flag defaults to `false` |
+| Property         | Type     | Required | Description                                                                                     |
+| ---------------- | -------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `supportedLangs` | String[] | Y        | A list of all languages the application supports                                                |
+| `defaultLang`    | String   | N        | The default & fallback language; if not given, then `lang` becomes a required argument          |
+| `lang`           | String   | N        | The current language that should be rendered; defaults to `defaultLang`                         |
+| `debugMode`      | Boolean  | N        | A flag to indicate whether or not certain console warnings should be displayed; default `false` |
+| `useIsolating`   | Boolean  | N        | Passed directly to `FluentBundle` class; default `true` for using bidi isolation marks          |
+| `functions`      | Object   | N        | Passed directly to `FluentBundle` class; provide custom functions to use in Fluent translations |
 
 ### Extending The Base
 
 ```js
 class I18nController extends BaseI18nController {
-  // This is the minimum implementation, load() must be implemented or
-  // the constructor will throw
-  load(args) {
-    const { lang, section } = args
+  // Minimum implementation with required load() method
+  load(sectionInfo) {
+    const { lang, section } = sectionInfo
     // Load ftl translations from the source
-    import(`./locales/${lang}/${section}.js`).then(({ default: ftl }) => {
-      return [{ lang, ftl }]
-    })
+    return import(`./locales/${lang}/${section}.js`)
+      .then(({ default: ftl }) => ({ resources: [ftl] }))
   }
 }
 
-const enGlobalFTL = 'greeting = Hello and welcome'
 const controller = new I18nController({
   defaultLang: 'en',
   supportedLangs: ['en', 'es'],
-  lang: 'en',
-  global: enGlobalFTL,
+  useIsolating: false,
 })
 export default controller
 ```
@@ -145,14 +154,14 @@ class I18nController extends BaseI18nController {
   }
 
   get(args) {
-    const tuple = super.get(args)
-    if (tuple[0] === null) {
-      const key = args.section === 'global' ? args.id : `${args.section}__${args.id}`
+    const result = super.get(args)
+    if (!result.found) {
+      const key = this.getKey(args.id, args.section, args.lang)
       if (!missingKeys.has(key)) {
         missingKeys.add(key)
       }
     }
-    return tuple
+    return result
   }
 }
 ```
@@ -163,10 +172,13 @@ The `<I18nProvider />` component is a top-level component that is used to provid
 
 ### Props
 
-| Prop         | Type   | Required | Description                                                    |
-| ------------ | ------ | -------- | -------------------------------------------------------------- |
-| `controller` | String | Y        | Used for passing the controller to the `I18nProvider`.         |
-| `lang`       | String | N        | Used for setting the current language that should be rendered. |
+| Prop         | Type   | Required | Description                                                   |
+| ------------ | ------ | -------- | ------------------------------------------------------------- |
+| `controller` | String | Y        | Used for passing the controller to the `I18nProvider`         |
+| `lang`       | String | N        | Used for setting the current language that should be rendered |
+| `section`    | String | N        | Sets a default section for the entire app; default "global"   |
+
+Unlike `I18nSection`, `I18nProvider` doesn't accept any extra section load arguments, so if you need those (or just don't need a default section) you should set `section=""`.
 
 ### Example Usage
 
@@ -206,15 +218,17 @@ function App(props) {
 
 ## I18nSection
 
-The `<I18nSection />` component was designed to allow the translations to be broken up into separate sections and loaded only when a specific section is needed. A section component alone will not render anything; it must be used with other internationalization components like `I18nText` or `I18nElement` in order to render any actual translations. This component is really there to tell any of its children i18n components where to look for translated text. It can also be used to manually change the rendered language in cases where a user wants to present information to another person.
+The `<I18nSection />` component was designed to allow the translations to be broken up into separate sections and loaded only when a specific section is needed. A section component alone will not render anything; it must be used with other internationalization components like `I18nText` or `I18nElement` in order to render any actual translations. This component is really there to tell any of its children i18n components where to look for translated text. It can also be used to locally change the rendered language, for example in cases where a user wants to present information to another person in the second person's language.
 
 ### Props
 
-| Prop           | Type                | Required | Description                                                                                                                 |
-| -------------- | ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `name`         | String              | Y        | Used for telling the component which section is to be loaded                                                                |
-| `lang`         | String              | N        | Used to override the globally selected language                                                                             |
-| `dependencies` | Array<String \| {}> | N        | Used to provide additional section dependencies that will not become the default `section` for components lower in the tree |
+| Prop           | Type                | Required | Description                                                                                             |
+| -------------- | ------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `name`         | String              | Y        | Name of the section to load and use as the default in descendant components                             |
+| `lang`         | String              | N        | Used to override the globally selected language                                                         |
+| `dependencies` | Array<String \| {}> | N        | Load additional sections that will be used in descendants, but should not be set as the default section |
+
+Any additional props will be passed as part of the `loadOpts` argument to the `load` function.
 
 ### Example Usage
 
@@ -252,7 +266,7 @@ The `<I18nText />` component is used for rendering translated text in an applica
 
 | Prop      | Type   | Required | Description                                                                              |
 | --------- | ------ | -------- | ---------------------------------------------------------------------------------------- |
-| `get`     | String | Y        | Tells the component which translation to look for in the loaded section                  |
+| `get`     | String | Y        | Equivalent to the `id` arg to the controller's `get` method                              |
 | `args`    | Object | N        | Provides a key-value mapping for any variables that should be displayed in a translation |
 | `section` | String | N        | Used for overriding the current section to load translations from another                |
 
@@ -285,27 +299,17 @@ const override = () => {
     </I18nSection>
   )
 }
-
-// The developer may also write the entire key out while providing the section as "global"
-const alsoOverride = () => {
-  return (
-    <I18nSection name="example">
-      ...
-      <I18nText get="my-section__translation-key" section="global" args={{ groupName: "example" }} />
-    </I18nSection>
-  )
-}
 ```
 
 ## I18nElement
 
-The `<I18nElement />` component was created to allow translations to be rendered as dom elements with support for attributes in an ftl translation. It's common to use the `I18nElement` component in conjunction with the `I18nSection` component to pull a translation from a certain section. If no section is defined, global translations will be used.
+The `<I18nElement />` component was created to allow translations to be rendered as DOM elements with support for attributes in an ftl translation. It's common to use the `I18nElement` component in conjunction with the `I18nSection` component to pull a translation from a certain section. If no section is defined, global translations will be used.
 
 ### Props
 
 | Prop      | Type   | Required | Description                                                                              |
 | --------- | ------ | -------- | ---------------------------------------------------------------------------------------- |
-| `get`     | String | Y        | Tells the component which translation to look for in the loaded section                  |
+| `get`     | String | Y        | Equivalent to the `id` arg to the controller's `get` method                              |
 | `args`    | Object | N        | Provides a key-value mapping for any variables that should be displayed in a translation |
 | `section` | String | N        | Used for overriding the current section to load translations from another                |
 | `as`      | String | Y        | Tells the component what type of dom element should be rendered                          |
@@ -343,13 +347,13 @@ const override = () => {
 ## I18nFormatted
 
 The `<I18nFormatted />` component can be used to carry out any custom formatting on the translations by providing a formatter function to the component. You can
-write your formatter function such that it returns a formatted string or a dom element.
+write your formatter function such that it returns a formatted string or a DOM element.
 
 ### Props
 
 | Prop        | Type     | Required | Description                                                                              |
 | ----------- | -------- | -------- | ---------------------------------------------------------------------------------------- |
-| `get`       | String   | Y        | Tells the component which translation to look for in the loaded section                  |
+| `get`       | String   | Y        | Equivalent to the `id` arg to the controller's `get` method                              |
 | `args`      | Object   | N        | Provides a key-value mapping for any variables that should be displayed in a translation |
 | `section`   | String   | N        | Used for overriding the current section to load translations from another                |
 | `formatter` | Function | Y        | Function to do any extra formatting                                                      |
@@ -378,7 +382,7 @@ The `<I18nResource />` component is used to access the message and attributes wh
 
 | Prop       | Type       | Required | Description                                                                              |
 | ---------- | ---------- | -------- | ---------------------------------------------------------------------------------------- |
-| `get`      | String     | Y        | Tells the component which translation to look for in the loaded section                  |
+| `get`      | String     | Y        | Equivalent to the `id` arg to the controller's `get` method                              |
 | `args`     | Object     | N        | Provides a key-value mapping for any variables that should be displayed in a translation |
 | `section`  | String     | N        | Used for overriding the current section to load translations from another                |
 | `children` | RenderFunc | N        | A function that receives message and attributes and returns React elements               |
@@ -439,8 +443,10 @@ The translation has an `aria-label` attribute associated with it, meaning you co
 ```js
 import { useI18nText, useI18nResource } from '@repay/cactus-i18n'
 ...
-const message = useI18nText('welcome-message', { user: 'CS Human' }) // "Welcome, CS Human"
-const [message, attrs] = useI18nResource('welcome-message', { user: 'CS Human' }) // ["Welcome, CS Human", { aria-label: "Greetings" }]
+// "Welcome, CS Human"
+const message = useI18nText('welcome-message', { user: 'CS Human' })
+// { text: "Welcome, CS Human", attrs: { aria-label: "Greetings" }, found: true }
+const { text, attrs, found } = useI18nResource('welcome-message', { user: 'CS Human' })
 ```
 
 ## Testing
@@ -448,13 +454,12 @@ const [message, attrs] = useI18nResource('welcome-message', { user: 'CS Human' }
 Fluent supports BiDi text by default by wrapping provided values (placeables) in bi-directional unicode characters, specifically the _First Strong Isolate_ and _Pop Directional Isolate_ characters. To test exact text matches you must account for these extra characters.
 
 ```js
-const global = `key-for-the-group= We are the { $groupName }!`
-const controller = new I18nController({
-  defaultLang: 'en-US',
-  supportedLangs: ['en-US'],
-  global,
-})
-const translatedText = controller.get({ id: 'key-for-the-group', args: { groupName: 'people' } })
+// Assume the following global section:
+`
+key-for-the-group= We are the { $groupName }!
+`
+...
+const translatedText = controller.get({ section: 'global', id: 'key-for-the-group', args: { groupName: 'people' } })
 expect(translatedText).toBe('We are the \u2068people\u2069!')
 expect(translatedText).toMatch(/We are the .people.!/)
 ```

--- a/docs/Internationalization/Getting Started.md
+++ b/docs/Internationalization/Getting Started.md
@@ -24,7 +24,7 @@ welcome-message = Welcome, { $user }!`
 
 // en/accounts.js
 export default `
-accounts__welcome-message = Welcome to the accounts page, { $user }!`
+welcome-message = Welcome to the accounts page, { $user }!`
 
 // es/global.js
 export default `
@@ -32,7 +32,7 @@ welcome-message = ¡Bienvenido, { $user }!`
 
 // es/accounts.js
 export default `
-accounts__welcome-message =
+welcome-message =
   ¡Bienvenido a la página de cuentas, { $user }!`
 ```
 
@@ -49,13 +49,13 @@ Let's see what this might look like:
 import { BaseI18nController } from '@repay/cactus-i18n'
 
 class I18nController extends BaseI18nController {
- async load(args) {
-    const { lang, section } = args
+ async load(sectionInfo) {
+    const { lang, section } = sectionInfo
     // load ftl translations from the source
     const { default: ftl } = await import(`./locales/${lang}/${section}.ftl`)
-    
-    return [{ lang, ftl }]
-    
+
+    return { resources: [ftl] }
+
   }
 }
 
@@ -87,7 +87,7 @@ Here, we make `<I18nProvider />` the top-level component in our app, and we prov
 
 ## Using I18n Components
 
-Now that our setup is complete, we can add on to the work we did in the last step to render some translations. We'll use two extra components: `I18nSection` and `I18nText`. `I18nSection` can be used to tell the controller which section to load (In this case, we have either "global" or "accounts"). If you don't use `I18nSection` to specify a section to choose a translation from, the controller will use the "global" translations. Let's add on to what we did in the previous step with some examples.
+Now that our setup is complete, we can add on to the work we did in the last step to render some translations. We'll use two extra components: `I18nSection` and `I18nText`. `I18nSection` can be used to tell the controller which section to load (In this case, we have either "global" or "accounts"). If you don't use `I18nSection` to specify a section to choose a translation from, the controller will use the section specified by the `I18nProvider` (default "global"). Let's add on to what we did in the previous step with some examples.
 
 ```jsx
 // index.js
@@ -101,7 +101,7 @@ const mainComponent = () => {
 } // Welcome, CS Human!
 ```
 
-Notice that we told `I18nText` that we wanted to get the `welcome-message` translation, but we didn't use an `I18nSection` component. This means the controller will look for the global translation. We also made use of the `args` prop to pass an object that contains the value for the `user` variable in the translation. But what if we had used a section? Let's check it out:
+Notice that we told `I18nText` that we wanted to get the `welcome-message` translation, but we didn't use an `I18nSection` component. This means the controller will look for the translation in the default section "global". We also made use of the `args` prop to pass an object that contains the value for the `user` variable in the translation. But what if we had used a section? Let's check it out:
 
 ```jsx
 // index.js
@@ -117,7 +117,7 @@ const mainComponent = () => {
 } // Welcome to the accounts page, CS Human!
 ```
 
-Notice that we used the same `get` value on `I18nText`, but by making the `I18nText` component as a child of `I18nSection`, we told the controller that we should be loading translations for the "accounts" section, instead of global, the library then merges the section name and the get key to find the scopped message under `accounts__welcome-message`. What if we wanted to load translations for a different language, though? To do so, we'll just need to change the `lang` prop on `I18nProvider`:
+Notice that we used the same `get` value on `I18nText`, but by making the `I18nText` component as a child of `I18nSection`, we told the controller that we should be loading translations for the "accounts" section, instead of the default. What if we wanted to load translations for a different language, though? To do so, we'll just need to change the `lang` prop on `I18nProvider`:
 
 ```jsx
 // index.js

--- a/examples/standard/src/i18nController.ts
+++ b/examples/standard/src/i18nController.ts
@@ -1,18 +1,14 @@
-import { BaseI18nController } from '@repay/cactus-i18n'
-
-interface ResourceDefinition {
-  lang: string
-  ftl: string
-}
+import { BaseI18nController, BundleInfo, LoadResult } from '@repay/cactus-i18n'
 
 class I18nController extends BaseI18nController {
-  public load(args: { lang: string; section: string }): Promise<ResourceDefinition[]> {
+  protected getKey(id: string, section: string) {
+    return section === 'global' ? id : `${section}__${id}`
+  }
+
+  protected async load(args: BundleInfo): Promise<LoadResult> {
     const [lang] = args.lang.split('-')
-    return import(`./locales/${lang}/${args.section}.js`).then(({ default: ftl }): [
-      { lang: string; ftl: string }
-    ] => {
-      return [{ lang, ftl }]
-    })
+    const { default: ftl } = await import(`./locales/${lang}/${args.section}.js`)
+    return { resources: [ftl] }
   }
 }
 

--- a/modules/cactus-i18n/package.json
+++ b/modules/cactus-i18n/package.json
@@ -48,6 +48,7 @@
     "@types/fluent__bundle": "^0.14.3",
     "@types/fluent__langneg": "^0.3.1",
     "@types/jest": "^26.0.14",
+    "@types/lodash": "^4.14.162",
     "@types/react": "^16.9.53",
     "babel-jest": "^26.6.0",
     "jest": "^26.6.0",
@@ -61,7 +62,8 @@
     "@fluent/bundle": "^0.16.0",
     "@fluent/langneg": "^0.5.0",
     "intl": "^1.2.5",
-    "intl-pluralrules": "^1.2.2"
+    "intl-pluralrules": "^1.2.2",
+    "lodash": "^4.17.19"
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",

--- a/modules/cactus-i18n/package.json
+++ b/modules/cactus-i18n/package.json
@@ -48,7 +48,6 @@
     "@types/fluent__bundle": "^0.14.3",
     "@types/fluent__langneg": "^0.3.1",
     "@types/jest": "^26.0.14",
-    "@types/lodash": "^4.14.162",
     "@types/react": "^16.9.53",
     "babel-jest": "^26.6.0",
     "jest": "^26.6.0",
@@ -62,8 +61,7 @@
     "@fluent/bundle": "^0.16.0",
     "@fluent/langneg": "^0.5.0",
     "intl": "^1.2.5",
-    "intl-pluralrules": "^1.2.2",
-    "lodash": "^4.17.19"
+    "intl-pluralrules": "^1.2.2"
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",

--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -55,7 +55,7 @@ export interface LoadResult {
 
 export type AsyncLoadResult = Promise<LoadResult | undefined>
 
-export type Resource = BundleInfo | FluentResource
+export type Resource = BundleInfo | FluentResource | string
 
 interface BundleOpts {
   /**
@@ -328,8 +328,14 @@ export class BundleInfo {
       return this.bundle
     }
     const resources: FluentResource[] = []
-    for (const maybeRef of this.resources) {
-      if (isRef(maybeRef)) {
+    const resourceCount = this.resources.length
+    for (let i = 0; i < resourceCount; i++) {
+      const maybeRef = this.resources[i]
+      if (typeof maybeRef === 'string') {
+        // Overwrite the value in `this.resources` so we only parse it once.
+        const res = this.resources[i] = new FluentResource(maybeRef)
+        resources.push(res)
+      } else if (isRef(maybeRef)) {
         if (!maybeRef.compile(bundleOpts)) {
           // When it finishes loading it should mark this as dirty, leading to recompile.
           continue

--- a/modules/cactus-i18n/src/BaseI18nController.ts
+++ b/modules/cactus-i18n/src/BaseI18nController.ts
@@ -3,279 +3,391 @@ import 'intl/locale-data/jsonp/en.js'
 import 'intl/locale-data/jsonp/es.js'
 import 'intl-pluralrules' // eslint-disable-line simple-import-sort/sort
 
-import { FluentBundle, FluentResource, FluentVariable } from '@fluent/bundle'
+import { FluentBundle, FluentFunction, FluentResource, FluentVariable } from '@fluent/bundle'
 import { negotiateLanguages } from '@fluent/langneg'
+import lodashSet from 'lodash/set'
 
-import { ResourceDefinition } from './types'
+interface HasI18nArgs {
+  section: string
+  id: string
+  lang?: string
+}
 
-interface Dictionary {
+type SplitFunc = (key: string) => string | string[]
+interface GetI18nArgs extends HasI18nArgs {
+  args?: Record<string, FluentVariable>
+  mapAttrs?: string | RegExp | SplitFunc
+}
+
+export interface I18nMessage {
+  text: string | null
+  attrs: Record<string, any>
+  found: boolean
+}
+
+export type LoadState = 'new' | 'loading' | 'loaded' | 'error'
+export type LoadEventType = 'loaded' | 'error' | 'all'
+export type LoadEventHandler = (b: BundleInfo, prevState: LoadState, error?: any) => void
+
+interface LoadEventListener {
+  listener: LoadEventHandler
+  eventType: LoadEventType
+}
+
+export type Loader = (
+  this: BaseI18nController,
+  bundleInfo: BundleInfo,
+  loadOpts: LoadOpts
+) => AsyncLoadResult
+
+export interface LoadOpts extends Record<string, any> {
+  loader?: Loader
+  /** Call this instead of running through the list of global listeners. */
+  onLoad?: LoadEventHandler
+  // This is for hard-coded defaults, mostly intended for use by 3rd party libraries.
+  defaults?: FluentResource
+}
+
+export interface LoadResult {
+  resources: Resource[]
+  version?: number
+}
+
+export type AsyncLoadResult = Promise<LoadResult | undefined>
+
+export type Resource = BundleInfo | FluentResource
+
+interface BundleOpts {
   /**
-   * Dictionary containing fluent bundles for each language with currently loaded sections
+   * Flag to disable bidi isolating unicode characters.
+   * @default = true
    */
-  [lang: string]: FluentBundle
+  useIsolating: boolean
+
+  /** Custom functions for Fluent to use during interpolation */
+  functions: Record<string, FluentFunction>
 }
 
-export interface LoadingState {
-  [langSectionKey: string]: 'loading' | 'loaded' | 'failed' | undefined
-}
-
-interface LoadingStateListener {
-  (params: LoadingState): void
-}
-
-/** matches .ftl format files for fluent parsing */
-type FTL = string
-
-interface I18nControllerOptions {
+interface I18nControllerOptions extends Partial<BundleOpts> {
   /**
    * Should be an array of locale codes
    */
   supportedLangs: string[]
 
   /**
-   * Initializes global section dictionary
-   */
-  global?: FTL
-
-  /**
    * fallback language if key does not exist
    */
-  defaultLang: string
+  defaultLang?: string
 
   /** Set the current lang explicitly or uses provided default */
   lang?: string
 
   /** Flag for displaying error messages. Default is false */
   debugMode?: boolean
-
-  /**
-   * Flag to disable bidi isolating unicode characters.
-   * @default = true
-   */
-  useIsolating?: boolean
 }
-
-const _dictionaries = new WeakMap<BaseI18nController, Dictionary>()
 
 export default abstract class BaseI18nController {
   public lang = ''
-  public defaultLang: string
+  public defaultLang: string | undefined = undefined
   private _supportedLangs: string[]
   private _languages: string[] = []
-  private _loadingState: LoadingState = {}
-  private _listeners: LoadingStateListener[] = []
+  private _listeners: LoadEventListener[] = []
+  private _bundles: Record<string, BundleInfo> = {}
   private _debugMode: boolean
+  private _bundleOpts: BundleOpts
 
-  public constructor(options: I18nControllerOptions) {
+  public constructor({ functions = {}, ...options }: I18nControllerOptions) {
     if (!Array.isArray(options.supportedLangs) || options.supportedLangs.length === 0) {
       throw new Error('You must provide supported languages')
+    } else if (options.defaultLang) {
+      if (!options.supportedLangs.includes(options.defaultLang)) {
+        throw new Error('The default language provided is not a supported language')
+      }
+      this.defaultLang = options.defaultLang
+    } else if (!options.lang) {
+      throw new Error('You must provide a `lang` or `defaultLang`')
     }
     if (this.load === undefined) {
       throw new Error('You must override the `load` method')
     }
-    if (!options.defaultLang) {
-      throw new Error('You must provide a default language')
-    }
-    if (!options.supportedLangs.includes(options.defaultLang)) {
-      throw new Error('The default language provided is not a supported language')
-    }
 
-    const useIsolating = options.hasOwnProperty('useIsolating')
-      ? Boolean(options.useIsolating)
-      : true
     this._supportedLangs = options.supportedLangs
-    this.defaultLang = options.defaultLang
-    this.setLang(options.lang || this.defaultLang)
-    const dict: Dictionary = {}
-    const bundles = this._supportedLangs.reduce((memo, lang): Dictionary => {
-      memo[lang] = new FluentBundle(lang, { useIsolating })
-      return memo
-    }, dict)
-    _dictionaries.set(this, bundles)
-    this._debugMode = Boolean(options.debugMode)
+    this.setLang(options.lang || (options.defaultLang as string))
+    this._debugMode = !!options.debugMode
+    const useIsolating = options.useIsolating === undefined ? true : !!options.useIsolating
+    this._bundleOpts = { useIsolating, functions }
+  }
 
-    if (options.global === undefined) {
-      this._load({ lang: this.defaultLang, section: 'global' })
-    } else {
-      this.setDict(this.defaultLang, 'global', options.global)
+  protected abstract load(b: BundleInfo, l: LoadOpts): AsyncLoadResult
+
+  protected _log(levelOrArg: string, ...args: any[]): void {
+    if (this._debugMode) {
+      if (console.hasOwnProperty(levelOrArg)) {
+        // @ts-ignore
+        console[levelOrArg](...args)
+      } else {
+        console.log(levelOrArg, ...args)
+      }
     }
   }
 
-  abstract load(
-    { lang, section }: { lang: string; section: string },
-    extra: { [key: string]: any }
-  ): Promise<ResourceDefinition[]>
-
-  private _getDict(): Dictionary {
-    return _dictionaries.get(this) || {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected getKey(id: string, section?: string, lang?: string): string {
+    return id
   }
 
-  public setDict(lang: string, section: string, ftl: FTL): void {
-    if (this._debugMode && !this._languages.includes(lang)) {
-      console.warn(
-        `You are loading an unrequested translation ${lang} for section: ${section} which will not be used. ` +
-          `Ignore this message if you have just updated the requested language.`
-      )
+  protected negotiateLang(lang?: string, strict = false): string[] {
+    if (lang === undefined) {
+      return this._languages
     }
-    const bundle = this._getDict()[lang]
-    if (this._debugMode && !bundle) {
-      console.error(
-        `Attempting to set dictionary for unsupported language: ${lang} and section: ${section}`
-      )
-      return
-    }
-    const errors = bundle.addResource(new FluentResource(ftl))
-    if (this._debugMode && Array.isArray(errors) && errors.length) {
-      console.error(`Errors found in resource for section ${section} ${lang}`)
-      console.log(errors)
-    }
-    this._loadingState[`${section}/${lang}`] = 'loaded'
-  }
-
-  private negotiateLang(lang: string): string[] {
-    return negotiateLanguages([lang], this._supportedLangs, {
+    const langs = negotiateLanguages([lang], this._supportedLangs, {
       defaultLocale: this.defaultLang,
       strategy: 'matching',
     })
+    if (strict && !langs.length) {
+      throw new Error(`Unsupported language: ${lang}`)
+    }
+    return langs
   }
 
   public setLang(lang: string): void {
-    this._languages = this.negotiateLang(lang)
+    this._languages = this.negotiateLang(lang, true)
     this.lang = this._languages[0]
   }
 
   public get({
     args,
-    section = 'global',
+    section,
     id,
     lang: overrideLang = this.lang,
-  }: {
-    args?: Record<string, FluentVariable>
-    section?: string
-    id: string
-    lang?: string
-  }): [string | null, { [k: string]: any }] {
-    const bundles = this._getDict()
-    const key = section === 'global' ? id : `${section}__${id}`
-    if (bundles !== undefined) {
-      let languages = this._languages
-      if (typeof overrideLang === 'string') {
-        languages = this.negotiateLang(overrideLang)
-      }
-      const lang = languages.find((l): boolean => bundles[l] && bundles[l].hasMessage(key))
-      const bundle = lang && bundles[lang]
-      if (!bundle) {
-        if (
-          this._debugMode &&
-          (section !== 'global' || this._loadingState[`global/${this.defaultLang}`] === 'loaded')
-        ) {
-          console.warn(
-            `The requested message ${key} does not exist` +
-              ` in these translations: ${this._languages.join(', ')}`
-          )
+    mapAttrs,
+  }: GetI18nArgs): I18nMessage {
+    const langs = this.negotiateLang(overrideLang, true)
+    const result: I18nMessage = { text: null, attrs: {}, found: false }
+    for (const lang of langs) {
+      const bundle = this.getBundle(section, lang)
+      if (bundle) {
+        const message = bundle.getMessage(this.getKey(id, section, lang))
+        if (message) {
+          result.found = true
+          const { value, attributes } = message
+          const errors: any[] = []
+          if (value) {
+            result.text = bundle.formatPattern(value, args, errors)
+          }
+          if (attributes) {
+            for (const [attr, val] of Object.entries(attributes)) {
+              const key =
+                typeof mapAttrs === 'function'
+                  ? mapAttrs(attr)
+                  : mapAttrs
+                  ? attr.split(mapAttrs)
+                  : attr
+              lodashSet(result.attrs, key, bundle.formatPattern(val, args, errors))
+            }
+          }
+          if (errors.length) {
+            this._log('warn', 'Errors while formatting translation', { id, section, lang, errors })
+          }
+          break
+        } else {
+          this._log('warn', 'Translation not found', { id, section, lang })
         }
-        return [null, {}]
       }
-      const message = bundle.getMessage(key)
-      let text: string | null = null
-      const attrs: { [key: string]: string } = {}
-      const errors: any[] = []
-      if (message?.attributes) {
-        Object.entries(message.attributes).forEach(([attr, value]): void => {
-          attrs[attr] = bundle.formatPattern(value, args, errors)
-        })
-      }
-      if (message?.value) {
-        text = bundle.formatPattern(message.value, args, errors)
-      }
-      if (errors.length) {
-        return [null, {}]
-      }
-      return [text, attrs]
     }
-    if (
-      this._debugMode &&
-      (section !== 'global' || this._loadingState[`global/${this.defaultLang}`] === 'loaded')
-    ) {
-      console.warn(`The requested section ${section} does not exist when requesting id ${id}`)
-    }
-    return [null, {}]
+    return result
   }
 
-  public getText({
-    args,
-    section = 'global',
-    id,
-    lang,
-  }: {
-    args?: Record<string, FluentVariable>
-    section?: string
-    id: string
-    lang?: string
-  }): string | null {
-    const [message] = this.get({ args, section, id, lang })
-    return message
+  public getText(args: GetI18nArgs): I18nMessage['text'] {
+    return this.get(args).text
+  }
+
+  public hasText({ section, id, lang }: HasI18nArgs): boolean {
+    lang = this.negotiateLang(lang)[0]
+    const bundle = lang && this.getBundle(section, lang)
+    return bundle ? bundle.hasMessage(this.getKey(id, section, lang)) : false
   }
 
   public _load(
     { lang: requestedLang, section }: { lang: string; section: string },
-    extra: { [key: string]: any } = {}
-  ): void {
-    const [lang] = this.negotiateLang(requestedLang)
-    const loadingKey = `${section}/${lang}`
-    if (this._loadingState[loadingKey] !== undefined) {
-      return
-    }
-
-    this._loadingState[loadingKey] = 'loading'
-    this.load({ lang, section }, extra)
-      .then((resourceDefs): void => {
-        resourceDefs.forEach((resDef): void => {
-          this.setDict(resDef.lang, section, resDef.ftl)
-        })
-        const updatedLoadingState = { ...this._loadingState }
-        this._listeners.forEach((l): void => l(updatedLoadingState))
-      })
-      .catch((error): void => {
-        this._loadingState[loadingKey] = 'failed'
-        if (this._debugMode) {
-          console.error(`FTL Resource ${lang}/${section} failed to load:`, error)
+    loadOpts: LoadOpts = {}
+  ): BundleInfo {
+    const lang = this.negotiateLang(requestedLang, true)[0]
+    const bundleInfo = this.getBundleInfo(section, lang, true) as BundleInfo
+    if (bundleInfo.loadState === 'new' || bundleInfo.loadState === 'error') {
+      const prevState = bundleInfo.loadState
+      bundleInfo.loadState = 'loading'
+      const loader = loadOpts.loader || this.load
+      const onLoad = loadOpts.onLoad || this.onLoad
+      loader.call(this, bundleInfo, loadOpts).then(
+        (result) => {
+          if (bundleInfo.update('loaded', loadOpts, result)) {
+            onLoad.call(this, bundleInfo, prevState)
+          }
+        },
+        (error) => {
+          this._log('error', 'FTL Resource failed to load', { section, lang, error })
+          bundleInfo.update('error', loadOpts)
+          onLoad.call(this, bundleInfo, prevState, error)
         }
-      })
-  }
-
-  public hasText({
-    section = 'global',
-    id,
-    lang,
-  }: {
-    section?: string
-    id: string
-    lang?: string
-  }): boolean {
-    const key = section === 'global' ? id : `${section}__${id}`
-    const bundles = this._getDict()
-    let languages = this._languages
-    if (typeof lang === 'string') {
-      languages = this.negotiateLang(lang)
+      )
     }
-    return languages.some((l): boolean => bundles[l] && bundles[l].hasMessage(key))
+    return bundleInfo
   }
 
   public hasLoaded(section: string, lang?: string): boolean {
-    let languages = this._languages
-    if (lang !== undefined) {
-      languages = this.negotiateLang(lang)
+    const language = this.negotiateLang(lang)[0]
+    return this.getLoadState(section, language) === 'loaded'
+  }
+
+  protected onLoad(bundleInfo: BundleInfo, prevState: LoadState, error?: unknown): void {
+    for (const { listener, eventType } of this._listeners) {
+      if (eventType === 'all' || eventType === bundleInfo.loadState) {
+        listener(bundleInfo, prevState, error)
+      }
     }
-    return languages.some((l): boolean => this._loadingState[`${section}/${l}`] === 'loaded')
   }
 
-  public addListener(listener: LoadingStateListener): void {
-    this._listeners.push(listener)
-    listener(this._loadingState)
+  public addListener(listener: LoadEventHandler, eventType: LoadEventType = 'loaded'): void {
+    this._listeners.push({ listener, eventType })
   }
 
-  public removeListener(listener: LoadingStateListener): void {
-    this._listeners = this._listeners.filter((l): boolean => l !== listener)
+  public removeListener(listener: LoadEventHandler): void {
+    const index = this._listeners.findIndex((x) => x.listener === listener)
+    if (index >= 0) {
+      this._listeners.splice(index, 1)
+    }
   }
+
+  protected loadRef(
+    referrer: BundleInfo,
+    section: string,
+    loadOpts: LoadOpts,
+    lang?: string
+  ): BundleInfo {
+    const refBundle = this._load({ section, lang: lang || referrer.lang }, loadOpts)
+    if (referrer === refBundle) {
+      throw new Error(`Self-referencing section: ${section}/${refBundle.lang}`)
+    } else if (referrer.lang !== refBundle.lang) {
+      this._log('Ref to different language:', {
+        section: referrer.section,
+        lang: referrer.lang,
+        ref: refBundle.section,
+        refLang: refBundle.lang,
+      })
+    }
+    refBundle.addDependent(referrer)
+    return refBundle
+  }
+
+  public getLoadState(section: string, lang: string): LoadState {
+    return this.getBundleInfo(section, lang)?.loadState || 'new'
+  }
+
+  protected getBundleInfo(section: string, lang: string, create = false): BundleInfo | undefined {
+    const key = `${section}/${lang}`
+    let bundleInfo = this._bundles[key]
+    if (!bundleInfo && create) {
+      this._bundles[key] = bundleInfo = new BundleInfo(section, lang)
+    }
+    return bundleInfo
+  }
+
+  protected getBundle(section: string, lang: string): FluentBundle | undefined {
+    const bundleInfo = this.getBundleInfo(section, lang)
+    if (!bundleInfo) {
+      this._log('warn', 'Attempting to use unloaded section:', { section, lang })
+      return
+    }
+    return bundleInfo.compile(this._bundleOpts)
+  }
+}
+
+export class BundleInfo {
+  public section: string
+  public lang: string
+  public loadState: LoadState = 'new'
+  public loadOpts?: LoadOpts
+  private bundle?: FluentBundle
+  private messages?: FluentResource
+  private version = 0
+  private resources: Resource[] = []
+  private dependents: Set<BundleInfo> = new Set()
+
+  public constructor(section: string, lang: string) {
+    this.section = section
+    this.lang = lang
+  }
+
+  public addDependent(d: BundleInfo): void {
+    this.dependents.add(d)
+  }
+
+  public compile(bundleOpts: BundleOpts): FluentBundle | undefined {
+    if (this.bundle || this.loadState !== 'loaded') {
+      return this.bundle
+    }
+    const resources: FluentResource[] = []
+    for (const maybeRef of this.resources) {
+      if (isRef(maybeRef)) {
+        if (!maybeRef.compile(bundleOpts)) {
+          // When it finishes loading it should mark this as dirty, leading to recompile.
+          continue
+        }
+        resources.push(maybeRef.messages as FluentResource)
+      } else {
+        resources.push(maybeRef)
+      }
+    }
+    const bundle = (this.bundle = new FluentBundle(this.lang, bundleOpts))
+    for (const resource of resources) {
+      bundle.addResource(resource, { allowOverrides: true })
+    }
+    this.messages = bundleToResource(bundle)
+    this.version += 1
+    return bundle
+  }
+
+  public update(loadState: LoadState, loadOpts: LoadOpts, result?: LoadResult): boolean {
+    this.loadState = loadState
+    this.loadOpts = loadOpts
+    if (!result || this.resources === result.resources) return false
+    else if (result.version) {
+      if (result.version <= this.version) return false
+      // We adjust here to get the right value after it's incremented on compile.
+      this.version = result.version - 1
+    }
+    this.resources = result.resources
+    this.markDirty()
+    return true
+  }
+
+  public markDirty(): void {
+    delete this.bundle
+    this.dependents.forEach($markDirty)
+  }
+}
+// I miss Python at times like this...
+const $markDirty = (x: BundleInfo) => x.markDirty()
+
+function isRef(maybeRef: Resource): maybeRef is BundleInfo
+function isRef(maybeRef: any): boolean {
+  return Array.isArray(maybeRef.resources)
+}
+
+type FluentPattern = FluentResource['body'][number]
+
+function mapToResource(
+  map: Map<string, FluentPattern>,
+  resource: FluentResource = new FluentResource('')
+) {
+  map.forEach((entry) => resource.body.push(entry))
+  return resource
+}
+
+function bundleToResource(bundle: FluentBundle) {
+  const resource = new FluentResource('')
+  mapToResource(bundle._terms, resource)
+  mapToResource(bundle._messages, resource)
+  return resource
 }

--- a/modules/cactus-i18n/src/Components.tsx
+++ b/modules/cactus-i18n/src/Components.tsx
@@ -18,6 +18,8 @@ interface I18nProviderProps {
   lang?: string
 }
 
+const flopFlip = (x: boolean) => !x
+
 const I18nProvider: React.FC<I18nProviderProps> = (props): ReactElement => {
   const controller = props.controller
   if (!(controller instanceof BaseI18nController)) {
@@ -27,26 +29,26 @@ const I18nProvider: React.FC<I18nProviderProps> = (props): ReactElement => {
     controller.setLang(props.lang)
   }
   const lang = controller.lang
-  const [loadingState, setLoading] = useState({})
-  const i18nContext: I18nContextType | null = {
-    controller: controller,
-    lang,
-    section: 'global',
-    loadingState,
+  const [flipFlop, toggle] = useState(false)
+  const i18nContext: I18nContextType = { controller, lang, section: 'global' }
+  const { current: stable } = React.useRef({ flipFlop, i18nContext })
+  if (
+    flipFlop !== stable.flipFlop ||
+    controller !== stable.i18nContext.controller ||
+    lang !== stable.i18nContext.lang
+  ) {
+    stable.flipFlop = flipFlop
+    stable.i18nContext = i18nContext
   }
-  useEffect((): (() => void) | undefined => {
+  useEffect(() => {
     if (controller instanceof BaseI18nController) {
-      controller.addListener(setLoading)
-      return (): void => controller.removeListener(setLoading)
+      const triggerUpdate = () => toggle(flopFlip)
+      controller.addListener(triggerUpdate)
+      return (): void => controller.removeListener(triggerUpdate)
     }
   }, [controller])
-  useEffect((): void => {
-    if (controller instanceof BaseI18nController) {
-      controller._load({ lang, section: 'global' })
-    }
-  }, [controller, lang])
   return (
-    <I18nContext.Provider value={i18nContext}>
+    <I18nContext.Provider value={stable.i18nContext}>
       <React.Fragment>{props.children}</React.Fragment>
     </I18nContext.Provider>
   )
@@ -172,9 +174,9 @@ const I18nElement = function <Elem extends TagNameOrReactComp>(
   props: I18nElementProps<Elem>
 ): ReactElement {
   const { get, args = {}, section, as, ...rest } = props
-  const [message, attrs] = useI18nResource(get, args, section)
+  const { text, attrs } = useI18nResource(get, args, section)
   const elemProps = { ...rest, ...attrs }
-  return React.createElement(as, elemProps, message || get)
+  return React.createElement(as, elemProps, text || get)
 }
 
 I18nElement.propTypes = {
@@ -190,7 +192,7 @@ interface I18nResourceProps extends I18nTextProps {
 }
 
 const I18nResource: React.FC<I18nResourceProps> = (props): ReactElement => {
-  const [message, attrs] = useI18nResource(props.get, props.args, props.section)
+  const { text, attrs } = useI18nResource(props.get, props.args, props.section)
   let renderer = null
   if (typeof props.children === 'function') {
     renderer = props.children
@@ -199,9 +201,7 @@ const I18nResource: React.FC<I18nResourceProps> = (props): ReactElement => {
   }
 
   return (
-    <React.Fragment>
-      {renderer !== null ? renderer(message || props.get, attrs) : null}
-    </React.Fragment>
+    <React.Fragment>{renderer !== null ? renderer(text || props.get, attrs) : null}</React.Fragment>
   )
 }
 

--- a/modules/cactus-i18n/src/hooks.ts
+++ b/modules/cactus-i18n/src/hooks.ts
@@ -1,7 +1,7 @@
 import { FluentVariable } from '@fluent/bundle'
 import { createContext, useContext } from 'react'
 
-import { I18nContextType } from './types'
+import { I18nContextType, I18nMessage } from './types'
 
 export const I18nContext = createContext<I18nContextType | null>(null)
 
@@ -22,10 +22,10 @@ export const useI18nResource = (
   id: string,
   args?: Record<string, FluentVariable>,
   sectionOverride?: string
-): [string | null, { [k: string]: any }] => {
+): I18nMessage => {
   const context = useContext(I18nContext)
   if (context === null) {
-    return [null, {}]
+    return { text: null, attrs: {}, found: false }
   }
   const { controller, section, lang } = context
   return controller.get({ args, section: sectionOverride || section, id, lang })

--- a/modules/cactus-i18n/src/types.ts
+++ b/modules/cactus-i18n/src/types.ts
@@ -1,16 +1,31 @@
-import BaseI18nController, { LoadingState } from './BaseI18nController'
+// Workaround for an issue with rollup/re-exporting types.
+import BaseI18nController, {
+  AsyncLoadResult as $AsyncLoadResult,
+  BundleInfo,
+  I18nMessage as $I18nMessage,
+  Loader as $Loader,
+  LoadEventHandler as $LoadEventHandler,
+  LoadEventType as $LoadEventType,
+  LoadOpts as $LoadOpts,
+  LoadResult as $LoadResult,
+  LoadState as $LoadState,
+  Resource as $Resource,
+} from './BaseI18nController'
 
-export interface ResourceDefinition {
-  lang: string
-  /**
-   * FTL message resource
-   */
-  ftl: string
-}
+export { BundleInfo }
 
 export interface I18nContextType {
   controller: BaseI18nController
   section: string
   lang: string
-  loadingState: LoadingState
 }
+
+export type AsyncLoadResult = $AsyncLoadResult
+export type I18nMessage = $I18nMessage
+export type LoadEventHandler = $LoadEventHandler
+export type LoadEventType = $LoadEventType
+export type LoadOpts = $LoadOpts
+export type LoadResult = $LoadResult
+export type LoadState = $LoadState
+export type Loader = $Loader
+export type Resource = $Resource

--- a/modules/cactus-i18n/tests/__snapshots__/exports.test.ts.snap
+++ b/modules/cactus-i18n/tests/__snapshots__/exports.test.ts.snap
@@ -12,5 +12,6 @@ Array [
   "useI18nResource",
   "I18nContext",
   "BaseI18nController",
+  "BundleInfo",
 ]
 `;

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -24,7 +24,7 @@ class I18nController extends BaseI18nController {
     if (opts.defaults) {
       return { resources: [opts.defaults] }
     } else if (typeof opts.content === 'string') {
-      return { resources: [new FluentResource(opts.content)] }
+      return { resources: [opts.content] }
     }
   }
 

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -511,7 +511,7 @@ override = I'm invisible
         // @ts-ignore
         const mockLoad = (controller.load = jest.fn<Loader>(() => Promise.resolve({ resources })))
         render(
-          <I18nProvider controller={controller}>
+          <I18nProvider controller={controller} section="">
             <I18nSection name="kleenex" dynamic>
               <I18nText get="runny-nose" />
             </I18nSection>
@@ -554,7 +554,7 @@ override = I'm invisible
 
       const i18nDependencies = [{ section: 'needed', extra: 'data', for: 'load function' }]
       render(
-        <I18nProvider controller={controller}>
+        <I18nProvider controller={controller} section="">
           <I18nSection name="kleenex" dependencies={i18nDependencies}>
             <I18nText get="runny-nose" section="needed" />
           </I18nSection>

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -180,28 +180,6 @@ key-for-no-people = blah blah blue stew`)
       expect(controller.getText({ section: 'local', id: 'key' })).toBe('local value')
     })
 
-    test('can customize attr nesting', async () => {
-      const section = 'attr'
-      const controller = new I18nController({ lang: 'es', supportedLangs: ['es'] })
-      const content = 'key =\n .options__one = uno\n .options__two = dos\n .label__a = lento'
-      await controller.loadAll({ section, lang: 'es', content })
-      const withString = controller.get({ section, id: 'key', mapAttrs: '__' })
-      expect(withString).toEqual({
-        text: null,
-        found: true,
-        attrs: { options: { one: 'uno', two: 'dos' }, label: { a: 'lento' } },
-      })
-      const withRegex = controller.get({ section, id: 'key', mapAttrs: /__/ })
-      expect(withRegex).toEqual(withString)
-      const mapAttrs = (attr: string) => (attr.startsWith('options') ? attr.split('__') : attr)
-      const withFunc = controller.get({ section, id: 'key', mapAttrs })
-      expect(withFunc).toEqual({
-        text: null,
-        found: true,
-        attrs: { options: { one: 'uno', two: 'dos' }, label__a: 'lento' },
-      })
-    })
-
     test('defaults to use bidi isolating', async () => {
       const global = `for-all-to-see = You can't see why this fails { $foo }`
       const controller = new I18nController({

--- a/modules/cactus-i18n/tests/i18n.test.tsx
+++ b/modules/cactus-i18n/tests/i18n.test.tsx
@@ -1,35 +1,49 @@
-import { act, fireEvent, render } from '@testing-library/react'
+import { FluentResource } from '@fluent/bundle'
+import { fireEvent, render, screen } from '@testing-library/react'
 import * as React from 'react'
 
 import I18nProvider, {
+  AsyncLoadResult,
   BaseI18nController,
+  BundleInfo,
   I18nElement,
   I18nFormatted,
   I18nResource,
   I18nSection,
   I18nText,
+  Loader,
+  LoadOpts,
   useI18nResource,
   useI18nText,
 } from '../src/index'
-import { ResourceDefinition } from '../src/types'
-import MockPromise from './helpers/MockPromise'
+
+const NOT_FOUND = { text: null, attrs: {}, found: false }
 
 class I18nController extends BaseI18nController {
-  public load(): Promise<never[]> {
-    console.error('This should not be called')
-    return Promise.resolve([])
+  protected async load(b: BundleInfo, opts: LoadOpts): AsyncLoadResult {
+    if (opts.defaults) {
+      return { resources: [opts.defaults] }
+    } else if (typeof opts.content === 'string') {
+      return { resources: [new FluentResource(opts.content)] }
+    }
+  }
+
+  public async loadAll(...loadArgs: any[]) {
+    for (const { section, lang, ...opts } of loadArgs) {
+      this._load({ section, lang }, opts)
+    }
   }
 }
 
-describe('i18n functionality', (): void => {
-  describe('<I18nProvider />', (): void => {
-    test('allows I18nText to render translations when provided', (): void => {
+describe('i18n functionality', () => {
+  describe('<I18nProvider />', () => {
+    test('allows I18nText to render translations when provided', async () => {
       const global = `this_is_the_key = This should render`
       const i18nController = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en'],
-        global,
       })
+      await i18nController.loadAll({ section: 'global', lang: 'en', content: global })
       const { container } = render(
         <I18nProvider lang="en" controller={i18nController}>
           <I18nText get="this_is_the_key">This is the default content.</I18nText>
@@ -38,83 +52,77 @@ describe('i18n functionality', (): void => {
       expect(container).toHaveTextContent('This should render')
     })
 
-    test('should load translations for requested language', (): void => {
+    test('should load translations for requested language', async () => {
       const globalEn = 'this-is-the-key = This should not render'
       const globalEs = 'this-is-the-key = Este texto debe mostrar'
-      const globalEsResDef: ResourceDefinition = { lang: 'es', ftl: globalEs }
       const i18nController = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en', 'es'],
-        global: globalEn,
       })
-      const esGlobalPromise = MockPromise.resolve([globalEsResDef])
-      // @ts-ignore
-      i18nController.load = jest.fn((): MockPromise => esGlobalPromise)
+      await i18nController.loadAll(
+        { section: 'global', lang: 'en', content: globalEn },
+        { section: 'global', lang: 'es', content: globalEs }
+      )
       const { container } = render(
         <I18nProvider lang="es" controller={i18nController}>
           <I18nText get="this-is-the-key">This is the default content.</I18nText>
         </I18nProvider>
       )
-      act((): void => {
-        esGlobalPromise._call()
-      })
-      // @ts-ignore
       expect(container).toHaveTextContent('Este texto debe mostrar')
     })
 
-    test('should render key from default language when key does not exist for requested language', (): void => {
+    test('should render key from default language when key does not exist for requested language', async () => {
       const global = `this_is_the_key = This should render`
       const i18nController = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en', 'es'],
-        global,
       })
-      const esGlobalPromise = MockPromise.resolve([{ lang: 'es', ftl: '' }])
-      //@ts-ignore
-      i18nController.load = jest.fn((): MockPromise => esGlobalPromise)
+      await i18nController.loadAll({ section: 'global', lang: 'en', content: global })
       const { container } = render(
         <I18nProvider lang="es" controller={i18nController}>
           <I18nText get="this_is_the_key">This is the default content.</I18nText>
         </I18nProvider>
       )
-      act((): void => {
-        esGlobalPromise._call()
-      })
       expect(container).toHaveTextContent('This should render')
     })
 
-    describe('with mocked console.error', (): void => {
+    describe('with mocked console.error', () => {
       let _error: any
-      beforeEach((): void => {
+      beforeEach(() => {
         _error = console.error
         console.error = jest.fn()
       })
-      afterEach((): void => {
+      afterEach(() => {
         console.error = _error
       })
 
-      test('throws when I18nProvider is rendered without a controller', (): void => {
-        expect((): void => {
+      test('throws when I18nProvider is rendered without a controller', () => {
+        expect(() => {
           render(
             // @ts-ignore
             <I18nProvider>
               <I18nText get="this_is_the_key">This is the default content.</I18nText>
             </I18nProvider>
           )
-        }).toThrowError()
+        }).toThrowError('I18nProvider must be given a controller which extends BaseI18nController')
       })
     })
   })
 
-  describe('I18nController class', (): void => {
-    test('should throw error when no supported languages are given', (): void => {
-      //@ts-ignore
-      expect((): BaseI18nController => new BaseI18nController({ defaultLang: 'en' })).toThrowError(
+  describe('I18nController class', () => {
+    test('should throw error when invalid args are given', () => {
+      expect(() => new I18nController({ supportedLangs: [] })).toThrowError(
         'You must provide supported languages'
+      )
+      expect(() => new I18nController({ supportedLangs: ['en'] })).toThrowError(
+        'You must provide a `lang` or `defaultLang`'
+      )
+      expect(() => new I18nController({ supportedLangs: ['en'], defaultLang: 'es' })).toThrowError(
+        'The default language provided is not a supported language'
       )
     })
 
-    test('load() should throw when not overridden', (): void => {
+    test('load() should throw when not overridden', () => {
       //@ts-ignore
       class BadI18nController extends BaseI18nController {}
       expect(
@@ -123,158 +131,349 @@ describe('i18n functionality', (): void => {
       ).toThrowError('You must override the `load` method')
     })
 
-    test('should load default global when none is provided', (): void => {
-      const mockLoad = jest.fn((): MockPromise => MockPromise.resolve([{ lang: 'en', ftl: '' }]))
-      class Controller extends BaseI18nController {
-        //@ts-ignore
-        public load(): MockPromise {
-          return mockLoad()
-        }
-      }
-      new Controller({ defaultLang: 'en', supportedLangs: ['en'] })
-      expect(mockLoad).toHaveBeenCalled()
-    })
-
-    test('can access translations outside React context', (): void => {
-      const global = `
+    test('can access translations outside React context', async () => {
+      const defaults = new FluentResource(`
 key_for_the_people = We are the people!
   .aria-label=anything { $value }
   .name=test
-key-for-no-people = blah blah blue stew`
+key-for-no-people = blah blah blue stew`)
       const controller = new I18nController({
-        defaultLang: 'en',
+        useIsolating: false,
+        lang: 'en',
         supportedLangs: ['en', 'es'],
-        global,
       })
-      expect(controller.getText({ id: 'key_for_the_people', args: { value: 'foo' } })).toBe(
-        'We are the people!'
-      )
-      expect(controller.getText({ id: 'key-for-no-people' })).toBe('blah blah blue stew')
+      const getArgs = { section: 'test', id: 'key_for_the_people', args: { value: 'foo' } }
+      const beforeLoad = controller.get(getArgs)
+      expect(beforeLoad).toEqual(NOT_FOUND)
+      await controller.loadAll({ section: 'test', lang: 'en', defaults })
+      const afterLoad = controller.get(getArgs)
+      expect(afterLoad).toEqual({
+        text: 'We are the people!',
+        found: true,
+        attrs: { 'aria-label': 'anything foo', name: 'test' },
+      })
+      const noPeople = controller.getText({ section: 'test', id: 'key-for-no-people' })
+      expect(noPeople).toBe('blah blah blue stew')
       const spanish = `key_for_the_people = Nosotros somos personas!`
+      await controller.loadAll({ section: 'test', lang: 'es', content: spanish })
+      const esResult = controller.get({ ...getArgs, lang: 'es' })
+      expect(esResult).toEqual({ text: 'Nosotros somos personas!', attrs: {}, found: true })
       controller.setLang('es')
-      controller.setDict('es', 'global', spanish)
-      expect(controller.getText({ id: 'key_for_the_people' })).toBe('Nosotros somos personas!')
+      // If there were a `defaultLang` set it'd fall back to that.
+      const notFound = controller.get({ section: 'test', id: 'key-for-no-people' })
+      expect(notFound).toEqual(NOT_FOUND)
     })
 
-    test('defaults to use bidi isolating', (): void => {
+    test('can customize key formatting', async () => {
+      class Controller extends I18nController {
+        protected getKey(id: string, section?: string) {
+          // This is how it used to behave by default.
+          return section === 'global' ? id : `${section}__${id}`
+        }
+      }
+      const controller = new Controller({ lang: 'en', supportedLangs: ['en'] })
+      await controller.loadAll(
+        { section: 'global', lang: 'en', content: 'key = global value' },
+        { section: 'local', lang: 'en', content: 'key=unused\nlocal__key = local value' }
+      )
+      expect(controller.getText({ section: 'global', id: 'key' })).toBe('global value')
+      expect(controller.getText({ section: 'local', id: 'key' })).toBe('local value')
+    })
+
+    test('can customize attr nesting', async () => {
+      const section = 'attr'
+      const controller = new I18nController({ lang: 'es', supportedLangs: ['es'] })
+      const content = 'key =\n .options__one = uno\n .options__two = dos\n .label__a = lento'
+      await controller.loadAll({ section, lang: 'es', content })
+      const withString = controller.get({ section, id: 'key', mapAttrs: '__' })
+      expect(withString).toEqual({
+        text: null,
+        found: true,
+        attrs: { options: { one: 'uno', two: 'dos' }, label: { a: 'lento' } },
+      })
+      const withRegex = controller.get({ section, id: 'key', mapAttrs: /__/ })
+      expect(withRegex).toEqual(withString)
+      const mapAttrs = (attr: string) => (attr.startsWith('options') ? attr.split('__') : attr)
+      const withFunc = controller.get({ section, id: 'key', mapAttrs })
+      expect(withFunc).toEqual({
+        text: null,
+        found: true,
+        attrs: { options: { one: 'uno', two: 'dos' }, label__a: 'lento' },
+      })
+    })
+
+    test('defaults to use bidi isolating', async () => {
       const global = `for-all-to-see = You can't see why this fails { $foo }`
       const controller = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en', 'es'],
-        global,
       })
-      expect(controller.getText({ id: 'for-all-to-see', args: { foo: 'bar' } })).toBe(
-        `You can't see why this fails \u2068bar\u2069`
-      )
+      await controller.loadAll({ section: 'test', lang: 'en', content: global })
+      const getArgs = { section: 'test', id: 'for-all-to-see', args: { foo: 'bar' } }
+      expect(controller.getText(getArgs)).toBe(`You can't see why this fails \u2068bar\u2069`)
     })
 
-    test('can disabled bidi isolating characters', (): void => {
+    test('can disabled bidi isolating characters', async () => {
       const global = `for-all-to-see = No hidden characters here { $foo }`
       const controller = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en', 'es'],
-        global,
         useIsolating: false,
       })
-      expect(controller.getText({ id: 'for-all-to-see', args: { foo: 'bar' } })).toBe(
-        'No hidden characters here bar'
-      )
+      await controller.loadAll({ section: 'test', lang: 'en', content: global })
+      const getArgs = { section: 'test', id: 'for-all-to-see', args: { foo: 'bar' } }
+      expect(controller.getText(getArgs)).toBe('No hidden characters here bar')
     })
 
-    test('should only attempt to load supported languages', (): void => {
-      const global = `
-key_for_the_people = We are the people!
-  .aria-label=anything { $value }
-  .name=test
-key-for-no-people = blah blah blue stew`
+    test('custom loader & onLoad in loadOpts', async () => {
+      const controller = new I18nController({ lang: 'en', supportedLangs: ['en'] })
+      // The custom onLoad will prevent this from being called.
+      const willBeUnused = jest.fn()
+      controller.addListener(willBeUnused)
+      const onLoad = jest.fn(function (bundle: any, prevState: string) {
+        // @ts-ignore
+        expect(this).toBe(controller)
+        expect(prevState).toBe('new')
+      })
+      const loader = jest.fn(function () {
+        // @ts-ignore
+        expect(this).toBe(controller)
+        return Promise.resolve({ resources: [] })
+      })
+      controller._load({ section: 'loadOpts', lang: 'en' }, { loader, onLoad })
+      await Promise.resolve()
+      expect(onLoad).toHaveBeenCalledTimes(1)
+      expect(loader).toHaveBeenCalledTimes(1)
+      expect(willBeUnused).not.toHaveBeenCalled()
+    })
+
+    test('should only attempt to load supported languages', async () => {
       const controller = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en', 'es'],
-        global,
       })
-      // @ts-ignore
-      controller.load = jest.fn(
-        (): MockPromise => MockPromise.resolve([{ lang: 'en', ftl: global }])
-      )
-      controller._load({ lang: 'de-DE', section: 'global' })
-      expect(controller.load).not.toBeCalled()
+      const mockLoad = jest.fn((() => Promise.resolve(undefined)) as Loader)
+      const loadArgs = { lang: 'de-DE', section: 'test', loader: mockLoad }
+      await controller.loadAll(loadArgs)
+      expect(mockLoad).toBeCalledTimes(1)
+      // It doesn't actually prevent load, it just falls back to the defaultLang.
+      expect(mockLoad.mock.calls[0][0]?.section).toBe('test')
+      expect(mockLoad.mock.calls[0][0]?.lang).toBe('en')
     })
 
-    describe('with mocked console.error and console.warn', (): void => {
+    test('strict language negotiation raises errors', () => {
+      const lang = 'de'
+      const section = 'test'
+      const error = 'Unsupported language: de'
+      expect(() => new I18nController({ lang, supportedLangs: ['en'] })).toThrowError(error)
+      const noDefault = new I18nController({ lang: 'en', supportedLangs: ['en'] })
+      expect(() => noDefault._load({ lang, section })).toThrowError(error)
+      expect(() => noDefault.setLang(lang)).toThrowError(error)
+      expect(() => noDefault.get({ section, lang, id: 'test' })).toThrowError(error)
+      // These two functions also indirectly use negotiation, but aren't strict.
+      expect(noDefault.hasText({ section, lang, id: 'test' })).toBe(false)
+      expect(noDefault.hasLoaded(section, lang)).toBe(false)
+    })
+
+    test('listeners run for appropriate events', async () => {
+      const step = Promise.resolve()
+      const controller = new I18nController({ lang: 'en', supportedLangs: ['en'] })
+      const listenLoad = jest.fn()
+      const listenAll = jest.fn()
+      const listenError = jest.fn()
+      controller.addListener(listenLoad)
+      controller.addListener(listenAll, 'all')
+      controller.addListener(listenError, 'error')
+      const load = { section: 'loadTest', lang: 'en' }
+      let loader: Loader = jest.fn(() => Promise.reject('oh noes!'))
+      const bundle = controller._load(load, { loader })
+      await step
+      expect(listenLoad).not.toHaveBeenCalled()
+      expect(listenAll).toHaveBeenLastCalledWith(bundle, 'new', 'oh noes!')
+      expect(listenError).toHaveBeenLastCalledWith(bundle, 'new', 'oh noes!')
+      loader = jest.fn(() => Promise.resolve({ resources: [] })) as Loader
+      controller._load(load, { loader })
+      await step
+      expect(listenLoad).toHaveBeenLastCalledWith(bundle, 'error', undefined)
+      expect(listenAll).toHaveBeenLastCalledWith(bundle, 'error', undefined)
+      expect(listenError).toHaveBeenCalledTimes(1)
+      controller.removeListener(listenLoad)
+      controller.removeListener(listenAll)
+      controller.removeListener(listenError)
+      controller._load({ section: 'one', lang: 'en' }, { loader })
+      await step
+      expect(listenLoad).toHaveBeenCalledTimes(1)
+      expect(listenAll).toHaveBeenCalledTimes(2)
+      expect(listenError).toHaveBeenCalledTimes(1)
+    })
+
+    describe('with mocked console.error and console.warn', () => {
       let _error: any
       let _warn: any
-      beforeEach((): void => {
+      beforeEach(() => {
         _error = console.error
         _warn = console.warn
         console.warn = jest.fn()
         console.error = jest.fn()
       })
-      afterEach((): void => {
+      afterEach(() => {
         console.error = _error
         console.warn = _warn
       })
 
-      test('get() should gracefully handle missing id', (): void => {
+      test('get() should gracefully handle missing id', async () => {
         const global = `this_is_the_key = This should render`
         const i18nController = new I18nController({
           defaultLang: 'en',
           lang: 'es',
           supportedLangs: ['en', 'es'],
-          global,
           debugMode: true,
         })
-        expect(i18nController.get({ id: 'bogogo' })).toEqual([null, {}])
-        expect(console.warn).toHaveBeenCalledWith(
-          `The requested message bogogo does not exist in these translations: es, en`
-        )
+        await i18nController.loadAll({ section: 'global', lang: 'es', content: global })
+        expect(i18nController.get({ section: 'global', id: 'bogogo' })).toEqual(NOT_FOUND)
+        expect(console.warn).toHaveBeenCalledWith('Translation not found', {
+          id: 'bogogo',
+          lang: 'es',
+          section: 'global',
+        })
       })
 
-      test('get() should gracefully handle missing section', (): void => {
-        const global = `this_is_the_key = This should render`
+      test('get() should gracefully handle missing section', () => {
         const i18nController = new I18nController({
           defaultLang: 'en',
           supportedLangs: ['en', 'es'],
-          global,
           debugMode: true,
         })
-        expect(i18nController.get({ section: 'foobar', id: 'bogogo' })).toEqual([null, {}])
-        expect(console.warn).toHaveBeenCalledWith(
-          `The requested message foobar__bogogo does not exist in these translations: en`
-        )
+        expect(i18nController.get({ section: 'foobar', id: 'bogogo' })).toEqual(NOT_FOUND)
+        expect(console.warn).toHaveBeenCalledWith('Attempting to use unloaded section:', {
+          lang: 'en',
+          section: 'foobar',
+        })
       })
 
-      test('can check for existing messages', (): void => {
+      test('can check for existing messages', async () => {
         const global = `this_is_the_key = This should render`
         const i18nController = new I18nController({
           defaultLang: 'en',
           supportedLangs: ['en'],
-          global,
           debugMode: true,
         })
-        expect(i18nController.hasText({ id: 'this_is_the_key' })).toEqual(true)
-        expect(i18nController.hasText({ section: 'other', id: 'not' })).toEqual(false)
-        expect(console.warn).not.toHaveBeenCalled()
+        await i18nController.loadAll({ section: 'global', lang: 'en', content: global })
+        expect(i18nController.hasText({ section: 'global', id: 'this_is_the_key' })).toEqual(true)
+        expect(i18nController.hasText({ section: 'global', id: 'not' })).toEqual(false)
+        expect(i18nController.hasText({ section: 'other', id: 'this_is_the_key' })).toEqual(false)
+        expect(console.warn).toHaveBeenCalledWith('Attempting to use unloaded section:', {
+          lang: 'en',
+          section: 'other',
+        })
       })
 
-      test('keeps track of failed resources', (): void => {
-        const globalPromise = MockPromise.reject(Error('failed to load requested resource'))
-        const mockLoad = jest.fn((): MockPromise => globalPromise)
-        class Controller extends BaseI18nController {
-          //@ts-ignore
-          public load(): MockPromise {
-            return mockLoad()
-          }
-        }
-        const controller = new Controller({ defaultLang: 'en', supportedLangs: ['en'] })
-        globalPromise._call()
+      test('keeps track of failed resources', async () => {
+        const controller = new I18nController({ defaultLang: 'en', supportedLangs: ['en'] })
         //@ts-ignore
-        expect(controller._loadingState['global/en']).toBe('failed')
+        controller.load = jest.fn(() => Promise.reject('oh noes!'))
+        expect(controller.getLoadState('global', 'en')).toBe('new')
+        await controller.loadAll({ section: 'global', lang: 'en' })
+        expect(controller.getLoadState('global', 'en')).toBe('error')
+      })
+    })
+
+    describe('with refs & dependent sections', () => {
+      const step = Promise.resolve()
+      const lang = 'en'
+
+      class Controller extends BaseI18nController {
+        constructor() {
+          super({ lang, supportedLangs: [lang], useIsolating: false })
+        }
+
+        protected async load(bi: BundleInfo, opts: LoadOpts): AsyncLoadResult {
+          const resources = []
+          if (bi.section === 'two') {
+            resources.push(this.loadRef(bi, 'one', opts))
+            resources.push(
+              new FluentResource(`
+original = The one and only
+dependent = I need a {-blank}
+override = You are group two
+            `)
+            )
+          } else if (opts.success) {
+            resources.push(
+              new FluentResource(`
+low = Can you go
+override = I'm invisible
+-blank = hero
+            `)
+            )
+          } else {
+            throw 'testing that reloading calls `markDirty`'
+          }
+          return { resources }
+        }
+      }
+
+      test('section with ref loads referred section', async () => {
+        const controller = new Controller()
+        const loader = jest.fn(function (this: Controller, bi: BundleInfo, o: LoadOpts) {
+          return this.load(bi, o)
+        })
+        controller._load({ section: 'two', lang }, { loader, success: true })
+        expect(loader).toHaveBeenCalledTimes(2)
+        expect(controller.getLoadState('one', lang)).toBe('loading')
+        expect(controller.getLoadState('two', lang)).toBe('loading')
+        await step
+        expect(controller.getLoadState('one', lang)).toBe('loaded')
+        expect(controller.getLoadState('two', lang)).toBe('loaded')
+        expect(controller.getText({ section: 'two', id: 'original' })).toEqual('The one and only')
+        expect(controller.getText({ section: 'two', id: 'dependent' })).toEqual('I need a hero')
+        expect(controller.getText({ section: 'two', id: 'low' })).toEqual('Can you go')
+        expect(controller.getText({ section: 'one', id: 'low' })).toEqual('Can you go')
+        expect(controller.getText({ section: 'one', id: 'override' })).toEqual(`I'm invisible`)
+        expect(controller.getText({ section: 'two', id: 'override' })).toEqual('You are group two')
+      })
+
+      test('reloading dependency causes section to recompile', async () => {
+        const controller = new Controller()
+        controller._load({ section: 'two', lang })
+        await step
+        expect(controller.getLoadState('one', lang)).toBe('error')
+        expect(controller.getLoadState('two', lang)).toBe('loaded')
+        expect(controller.getText({ section: 'two', id: 'original' })).toEqual('The one and only')
+        expect(controller.getText({ section: 'two', id: 'dependent' })).toEqual('I need a {-blank}')
+        expect(controller.getText({ section: 'two', id: 'override' })).toEqual('You are group two')
+        expect(controller.get({ section: 'two', id: 'low' })).toEqual(NOT_FOUND)
+
+        controller._load({ section: 'one', lang }, { success: true })
+        await step
+        expect(controller.getLoadState('one', lang)).toBe('loaded')
+        expect(controller.getText({ section: 'two', id: 'dependent' })).toEqual('I need a hero')
+        expect(controller.getText({ section: 'two', id: 'low' })).toEqual('Can you go')
+        expect(controller.getText({ section: 'one', id: 'override' })).toEqual(`I'm invisible`)
+      })
+
+      test('section with loaded ref does not reload', async () => {
+        const controller = new Controller()
+        const loader = jest.fn(function (this: Controller, bi: BundleInfo, o: LoadOpts) {
+          return this.load(bi, o)
+        })
+        controller._load({ section: 'one', lang }, { loader, success: true })
+        expect(loader).toHaveBeenCalledTimes(1)
+        await step
+        controller._load({ section: 'two', lang }, { loader })
+        expect(loader).toHaveBeenCalledTimes(2)
+        await step
+
+        expect(controller.getText({ section: 'two', id: 'dependent' })).toEqual('I need a hero')
+        expect(controller.getText({ section: 'two', id: 'low' })).toEqual('Can you go')
+        expect(controller.getText({ section: 'one', id: 'low' })).toEqual('Can you go')
+        expect(controller.getText({ section: 'one', id: 'override' })).toEqual(`I'm invisible`)
       })
     })
   })
 
-  describe('<I18nSection />', (): void => {
-    test('can be rendered without providing context', (): void => {
+  describe('<I18nSection />', () => {
+    test('can be rendered without providing context', () => {
       const { container } = render(
         <I18nSection name="blank">
           <I18nText get="this_is_the_key">This is the default content.</I18nText>
@@ -283,86 +482,54 @@ key-for-no-people = blah blah blue stew`
       expect(container).toHaveTextContent('This is the default content.')
     })
 
-    test('passed extra data to load()', (): void => {
+    test('passed extra data to load()', async () => {
       const controller = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en', 'en-US'],
-        global: `runny-nose = WRONG KEY`,
       })
-      const sectionPromise = MockPromise.resolve([
-        {
-          lang: 'en',
-          ftl: `kleenex__runny-nose = This text should render`,
-        },
-      ])
-      //@ts-ignore
-      controller.load = jest.fn((): MockPromise => sectionPromise)
-
+      expect(controller.getLoadState('kleenex', 'en')).toBe('new')
       render(
         <I18nProvider controller={controller}>
-          <I18nSection name="kleenex" dynamic>
+          <I18nSection name="kleenex" content="runny-nose = This text should render">
             <I18nText get="runny-nose" />
           </I18nSection>
         </I18nProvider>
       )
-      act((): void => {
-        sectionPromise._call()
-      })
-      expect(controller.load).toHaveBeenCalledWith(
-        { section: 'kleenex', lang: 'en' },
-        { dynamic: true }
-      )
+      expect(controller.getLoadState('kleenex', 'en')).toBe('loading')
+      const element = await screen.findByText('This text should render')
+      expect(controller.getLoadState('kleenex', 'en')).toBe('loaded')
+      expect(element).toBeInTheDocument()
     })
 
-    describe('should override', (): void => {
-      test('section name', (): void => {
+    describe('should override', () => {
+      test('section name', async () => {
         const controller = new I18nController({
           defaultLang: 'en',
           supportedLangs: ['en', 'en-US'],
-          global: `runny-nose = WRONG KEY`,
         })
-        const globalPromise = MockPromise.resolve([{ lang: 'en', ftl: `runny-nose = WRONG KEY` }])
-        const sectionPromise = MockPromise.resolve([
-          {
-            lang: 'en',
-            ftl: `kleenex__runny-nose = This text should render`,
-          },
-        ])
-        //@ts-ignore
-        controller.load = jest.fn(
-          ({ section }): MockPromise => (section === 'global' ? globalPromise : sectionPromise)
-        )
-        const { container } = render(
+        const resources = [new FluentResource('runny-nose = This text should render')]
+        // @ts-ignore
+        const mockLoad = (controller.load = jest.fn<Loader>(() => Promise.resolve({ resources })))
+        render(
           <I18nProvider controller={controller}>
-            <I18nSection name="kleenex">
+            <I18nSection name="kleenex" dynamic>
               <I18nText get="runny-nose" />
             </I18nSection>
           </I18nProvider>
         )
-        act((): void => {
-          globalPromise._call()
-          sectionPromise._call()
-        })
-        expect(container).toHaveTextContent('This text should render')
+        expect(await screen.findByText('This text should render')).toBeInTheDocument()
+        expect(mockLoad).toHaveBeenCalledTimes(1)
+        expect(mockLoad.mock.calls[0][0]?.section).toBe('kleenex')
+        expect(mockLoad.mock.calls[0][1]).toEqual({ dynamic: true })
       })
 
-      test('language selection', (): void => {
+      test('language selection', async () => {
         const controller = new I18nController({
           defaultLang: 'en',
           supportedLangs: ['en', 'es'],
-          global: `runny-nose = WRONG KEY`,
         })
-        const globalPromise = MockPromise.resolve([{ lang: 'en', ftl: `runny-nose = WRONG KEY` }])
-        const esGlobalPromise = MockPromise.resolve([
-          {
-            lang: 'es',
-            ftl: `runny-nose = This text should render`,
-          },
-        ])
-        //@ts-ignore
-        controller.load = jest.fn(
-          ({ lang }): MockPromise => (lang === 'en' ? globalPromise : esGlobalPromise)
-        )
+        const content = `runny-nose = This text should render`
+        await controller.loadAll({ section: 'global', lang: 'es', content })
         const { container } = render(
           <I18nProvider controller={controller}>
             <I18nSection name="global" lang="es">
@@ -370,113 +537,58 @@ key-for-no-people = blah blah blue stew`
             </I18nSection>
           </I18nProvider>
         )
-        act((): void => {
-          globalPromise._call()
-          esGlobalPromise._call()
-        })
         expect(container).toHaveTextContent('This text should render')
       })
     })
 
-    test('will load extra dependencies', (): void => {
+    test('will load extra dependencies with custom props', async () => {
       const controller = new I18nController({
         defaultLang: 'en',
         supportedLangs: ['en', 'en-US'],
-        global: `runny-nose = WRONG KEY`,
       })
-      const kleenexPromise = MockPromise.resolve([
-        {
-          lang: 'en',
-          ftl: `kleenex__runny-nose = { needed__runny-nose }`,
-        },
-      ])
-      const neededPromise = MockPromise.resolve([
-        {
-          lang: 'en',
-          ftl: `needed__runny-nose = This text should render`,
-        },
-      ])
+      const resources = [new FluentResource('runny-nose = This text should render')]
       //@ts-ignore
-      controller.load = jest.fn(
-        ({ section }): MockPromise => (section === 'needed' ? neededPromise : kleenexPromise)
-      )
-
-      const { container } = render(
-        <I18nProvider controller={controller}>
-          <I18nSection name="kleenex" dependencies={['needed']}>
-            <I18nText get="runny-nose" />
-          </I18nSection>
-        </I18nProvider>
-      )
-      act((): void => {
-        kleenexPromise._call()
-      })
-      // should not render until 'needed' section is also loaded
-      expect(container).toHaveTextContent('')
-      act((): void => {
-        neededPromise._call()
-      })
-      expect(container).toHaveTextContent('This text should render')
-    })
-
-    test('will load extra dependencies with custom props', (): void => {
-      const controller = new I18nController({
-        defaultLang: 'en',
-        supportedLangs: ['en', 'en-US'],
-        global: `runny-nose = WRONG KEY`,
-      })
-      const kleenexPromise = MockPromise.resolve([
-        {
-          lang: 'en',
-          ftl: `kleenex__runny-nose = { needed__runny-nose }`,
-        },
-      ])
-      const neededPromise = MockPromise.resolve([
-        {
-          lang: 'en',
-          ftl: `needed__runny-nose = This text should render`,
-        },
-      ])
-      //@ts-ignore
-      controller.load = jest.fn(
-        ({ section }): MockPromise => (section === 'needed' ? neededPromise : kleenexPromise)
-      )
+      const mockLoad = (controller.load = jest.fn<Loader>(({ section }) =>
+        Promise.resolve(section === 'needed' ? { resources } : undefined)
+      ))
 
       const i18nDependencies = [{ section: 'needed', extra: 'data', for: 'load function' }]
       render(
         <I18nProvider controller={controller}>
           <I18nSection name="kleenex" dependencies={i18nDependencies}>
-            <I18nText get="runny-nose" />
+            <I18nText get="runny-nose" section="needed" />
           </I18nSection>
         </I18nProvider>
       )
-      expect(controller.load).toHaveBeenCalledWith(
-        { section: 'needed', lang: 'en' },
-        { extra: 'data', for: 'load function' }
-      )
+      expect(await screen.findByText('This text should render')).toBeInTheDocument()
+      expect(mockLoad).toHaveBeenCalledTimes(2)
+      expect(mockLoad.mock.calls[0][0]?.section).toBe('kleenex')
+      expect(mockLoad.mock.calls[0][1]).toEqual({})
+      expect(mockLoad.mock.calls[1][0]?.section).toBe('needed')
+      expect(mockLoad.mock.calls[1][1]).toEqual({ extra: 'data', for: 'load function' })
     })
   })
 
-  describe('<I18nText />', (): void => {
-    test('can render get id', (): void => {
+  describe('<I18nText />', () => {
+    test('can render get id', () => {
       const { container } = render(<I18nText get="this_is_my_key" />)
       expect(container).toHaveTextContent('this_is_my_key')
     })
 
-    test('renders children when no dictionary is present', (): void => {
+    test('renders children when no dictionary is present', () => {
       const { container } = render(
         <I18nText get="this_is_my_key">This is the default content.</I18nText>
       )
       expect(container).toHaveTextContent('This is the default content.')
     })
 
-    test('can render variables in a translation', (): void => {
+    test('can render variables in a translation', async () => {
       const global = `key-for-the-group= We are the { $groupName }!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const { container } = render(
         <I18nProvider controller={controller}>
           <I18nText get="key-for-the-group" args={{ groupName: 'people' }} />
@@ -485,42 +597,41 @@ key-for-no-people = blah blah blue stew`
       expect(container).toHaveTextContent('We are the \u2068people\u2069!')
     })
 
-    test('can override section', (): void => {
+    test('can override section', async () => {
       const global = `key_for_the_people= We are the people!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
-      controller.setDict('en-US', 'kleenex', `kleenex__key_for_the_people = We are NOT the people!`)
-      let container
-      act((): void => {
-        const tester = render(
-          <I18nProvider controller={controller}>
-            <I18nSection name="kleenex">
-              <I18nText get="key_for_the_people" section="global" />
-            </I18nSection>
-          </I18nProvider>
-        )
-        container = tester.container
-      })
+      const content = `kleenex__key_for_the_people = We are NOT the people!`
+      await controller.loadAll(
+        { section: 'global', lang: 'en-US', content: global },
+        { lang: 'en-US', section: 'kleenex', content }
+      )
+      const { container } = render(
+        <I18nProvider controller={controller}>
+          <I18nSection name="kleenex">
+            <I18nText get="key_for_the_people" section="global" />
+          </I18nSection>
+        </I18nProvider>
+      )
       expect(container).toHaveTextContent('We are the people!')
     })
   })
 
-  describe('<I18nElement />', (): void => {
-    test('can render get id when no context present', (): void => {
+  describe('<I18nElement />', () => {
+    test('can render get id when no context present', () => {
       const { container } = render(<I18nElement get="this_is_my_key" as="div" />)
       expect(container).toHaveTextContent('this_is_my_key')
     })
 
-    test('can render variables in a translation', (): void => {
+    test('can render variables in a translation', async () => {
       const global = `key-for-the-group= We are the { $groupName }!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const { container } = render(
         <I18nProvider controller={controller}>
           <I18nElement get="key-for-the-group" as="div" args={{ groupName: 'people' }} />
@@ -529,15 +640,15 @@ key-for-no-people = blah blah blue stew`
       expect(container).toHaveTextContent('We are the \u2068people\u2069!')
     })
 
-    test('can render an element with attributes', (): void => {
+    test('can render an element with attributes', async () => {
       const global = `
 key-for-the-group= We are the { $groupName }!
   .aria-label = { $groupName} run the world`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const { getByLabelText } = render(
         <I18nProvider controller={controller}>
           <I18nElement get="key-for-the-group" as="div" args={{ groupName: 'people' }} />
@@ -546,15 +657,15 @@ key-for-the-group= We are the { $groupName }!
       expect(getByLabelText('\u2068people\u2069 run the world')).not.toBeNull()
     })
 
-    test('should pass additional props to rendered element', (): void => {
+    test('should pass additional props to rendered element', async () => {
       const global = `
 key-for-the-group= We are the people!
   .aria-label = people run the world`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const handleClick = jest.fn()
       const { getByLabelText } = render(
         <I18nProvider controller={controller}>
@@ -566,8 +677,8 @@ key-for-the-group= We are the people!
     })
   })
 
-  describe('<I18nResource />', (): void => {
-    test('renders get key when message not found', (): void => {
+  describe('<I18nResource />', () => {
+    test('renders get key when message not found', () => {
       const { container } = render(
         <I18nResource get="this_is_my_key">
           {(message): React.ReactElement => <span>{message}</span>}
@@ -576,15 +687,15 @@ key-for-the-group= We are the people!
       expect(container).toHaveTextContent('this_is_my_key')
     })
 
-    test('calls provided children as render prop', (): void => {
+    test('calls provided children as render prop', async () => {
       const global = `
 key-for-the-group = We are the { $groupName }!
   .aria-label = { $groupName} run the world`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const { getByLabelText } = render(
         <I18nProvider controller={controller}>
           <I18nResource get="key-for-the-group" args={{ groupName: 'people' }}>
@@ -597,15 +708,15 @@ key-for-the-group = We are the { $groupName }!
       expect(span).toHaveTextContent('We are the \u2068people\u2069!')
     })
 
-    test('calls provided render prop', (): void => {
+    test('calls provided render prop', async () => {
       const global = `
 key-for-the-group = We are the { $groupName }!
   .aria-label = { $groupName} run the world`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const { getByLabelText } = render(
         <I18nProvider controller={controller}>
           <I18nResource
@@ -621,14 +732,14 @@ key-for-the-group = We are the { $groupName }!
     })
   })
 
-  describe('<I18nFormatted />', (): void => {
-    test('should handle additional formatting', (): void => {
+  describe('<I18nFormatted />', () => {
+    test('should handle additional formatting', async () => {
       const global = `key-for-the-group= We are the people!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const formatter = jest.fn(
         (text: string): React.ReactElement => {
           return <div data-testid="hoobla">{text}</div>
@@ -643,14 +754,14 @@ key-for-the-group = We are the { $groupName }!
     })
   })
 
-  describe('useI18nText()', (): void => {
-    test('returns fluent text', (): void => {
+  describe('useI18nText()', () => {
+    test('returns fluent text', async () => {
       const global = `key-for-the-group= We are the people!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const TestI18nText = (): React.ReactElement => {
         const text = useI18nText('key-for-the-group')
         return <div data-testid="used-text">{text}</div>
@@ -663,13 +774,13 @@ key-for-the-group = We are the { $groupName }!
       expect(getByTestId('used-text')).toHaveTextContent('We are the people!')
     })
 
-    test('returns formatted fluent text with args', (): void => {
+    test('returns formatted fluent text with args', async () => {
       const global = `key-for-the-group= We are the { $groupName }!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const TestI18nText = (): React.ReactElement => {
         const text = useI18nText('key-for-the-group', { groupName: 'rabbits' })
         return <div data-testid="used-text">{text}</div>
@@ -682,15 +793,17 @@ key-for-the-group = We are the { $groupName }!
       expect(getByTestId('used-text')).toHaveTextContent(/We are the .rabbits.!/)
     })
 
-    test('allows overriding section for text', (): void => {
+    test('allows overriding section for text', async () => {
       const global = `key-for-the-group= We are the { $groupName }!`
-      const simple = `simple__key-for-the-group = We are the simple people!`
+      const simple = `key-for-the-group = We are the simple people!`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
-      controller.setDict('en-US', 'simple', simple)
+      await controller.loadAll(
+        { section: 'global', lang: 'en-US', content: global },
+        { section: 'simple', lang: 'en-US', content: simple }
+      )
       const TestI18nText = (): React.ReactElement => {
         const text = useI18nText('key-for-the-group', undefined, 'simple')
         return <div data-testid="used-text">{text}</div>
@@ -704,18 +817,18 @@ key-for-the-group = We are the { $groupName }!
     })
   })
 
-  describe('useI18nResource()', (): void => {
-    test('returns fluent text and attributes', (): void => {
+  describe('useI18nResource()', () => {
+    test('returns fluent text and attributes', async () => {
       const global = `
 key-for-the-group= We are the people!
   .aria-label = people run the world`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const TestI18nResource = (): React.ReactElement => {
-        const [text, attrs] = useI18nResource('key-for-the-group')
+        const { text, attrs } = useI18nResource('key-for-the-group')
         return <div {...attrs}>{text}</div>
       }
       const { getByLabelText } = render(
@@ -726,17 +839,17 @@ key-for-the-group= We are the people!
       expect(getByLabelText('people run the world')).toHaveTextContent('We are the people!')
     })
 
-    test('returns formatted text and attributes applying provided args', (): void => {
+    test('returns formatted text and attributes applying provided args', async () => {
       const global = `
 key-for-the-group= We are the { $groupName }!
   .aria-label = people run the { $place }`
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
+      await controller.loadAll({ section: 'global', lang: 'en-US', content: global })
       const TestI18nResource = (): React.ReactElement => {
-        const [text, attrs] = useI18nResource('key-for-the-group', {
+        const { text, attrs } = useI18nResource('key-for-the-group', {
           groupName: 'people',
           place: 'world',
         })
@@ -750,16 +863,19 @@ key-for-the-group= We are the { $groupName }!
       expect(getByLabelText(/people run the .world./)).toHaveTextContent(/We are the .people.!/)
     })
 
-    test('allows overriding section', (): void => {
-      const global = `key-for-the-group= We are the people!`
+    test('allows overriding section', async () => {
+      const defaults = new FluentResource(`key-for-the-group= We are the people!`)
       const controller = new I18nController({
         defaultLang: 'en-US',
         supportedLangs: ['en-US'],
-        global,
       })
-      controller.setDict('en-US', 'other', 'other__key-for-the-group = We are the OTHER people!')
+      const content = 'key-for-the-group = We are the OTHER people!'
+      await controller.loadAll(
+        { section: 'global', lang: 'en-US', defaults },
+        { section: 'other', lang: 'en-US', content }
+      )
       const TestI18nResource = (): React.ReactElement => {
-        const [text, attrs] = useI18nResource('key-for-the-group', undefined, 'other')
+        const { text, attrs } = useI18nResource('key-for-the-group', undefined, 'other')
         return (
           <div data-testid="select-me" {...attrs}>
             {text}


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-431

Quite a few breaking changes, but hopefully they should all be centered around the implementation of the controller class, rather than spread all over the place. ~I'm setting this up as a draft PR because I'd like some feedback, but I also want to double-check my work on the actual channels code base. (And I still need to update the docs/example apps.)~

Specifically, the issue I want feedback on is this: the way channels currently does their fallback is to have each section with it's own bundle; when they do a lookup, if they don't find the key in the first bundle they go on to the next, until they run out of bundles to check. The way I implemented it, each section bundle includes all keys from its dependencies, so it only needs to check the first bundle. The main advantage of this is that you can use Fluent references (`{ other-key }`) to keys in dependent sections (you can't do that in the channels implementation because the keys are stored in different bundles). The main disadvantage is that it uses more memory, because a single Fluent pattern object would be stored in multiple bundles (note that the patterns themselves aren't copied, so it's just that the `Map`s are larger).

Example (Channels):
```
section: "web"
key1 = value1

section: "web/page"
key2 = value2

// Lookup for key1 in "web/page":
for (const section of ['web/page', 'web']) {
  if (hasText(section, 'key1')) {
    return getText(section, 'key1')
  }
}
```
New Method:
```
section: "web"
key1 = value1

section: "web/page"
key1 = value1  // Copied from "web"
key2 = value2  // Originally defined in "web/page"

// Lookup for key1 in "web/page":
return getText('web/page', 'key1')
```

Non-breaking changes:
- ~Added `mapAttrs` arg to `controller.get()` for custom attr naming~
- Added support for custom load function (`loader`) and callback (`onLoad`)
- `defaultLang` is no longer a required arg to the controller (but if it's omitted, `lang` must be passed instead)
- Added `functions` arg which can be used to customize Fluent behavior
- Added `loadRef()` method; not a breaking change by itself, but is intended to be used with the change to the `load()` method

BREAKING CHANGE: Some interface changes, and the change to `load()`.
- Removed "global" section as a core concept
  - It is still the default section in `I18nProvider` so most hooks/components are unaffected
  - The `global` arg has been removed from the controller constructor, ~and I18nProvider does not automatically load it~
  - There is no longer a default section in `get()`, `getText()`, or `hasText()`
  - There is no longer a "default" key format of `[section]__[key]`; instead there is a `getKey()` method that can be used to implement any desired key pattern
- Removed `setDict` method; all section modifications should be done through `_load()`/`load()`
- `controller.get()` & `useI18nResource` now return an object instead of a tuple, and added the `found` property
- Controller listeners now get data about the specific section that was loaded, instead of the load state of all sections
- `controller.load()` return type changed
  - Instead of a single call returning multiple languages, it only returns data for the requested language
  - The data for a single section can be an array of resources or references to other sections, where the data in later array elements will override the data in earlier elements