### PR TITLE
CACTUS-441: fix bottom border in brandbar's user menu in safari and edge

### DIFF
--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -203,7 +203,6 @@ const LogoWrapper = styled.div`
 const MenuButton = styled(ReachMenuButton)<ProfileStyleProp>`
   ${(p) => textStyle(p.theme, 'body')};
   font-weight: 600;
-
   margin-right: 5px;
   background-color: transparent;
   border: 0;
@@ -211,7 +210,8 @@ const MenuButton = styled(ReachMenuButton)<ProfileStyleProp>`
   align-items: center;
   padding: 16px;
   cursor: pointer;
-
+  margin: 0;
+  border-radius: 0;
   ${(p) =>
     p.$isProfilePage &&
     `

--- a/modules/cactus-web/src/BrandBar/__snapshots__/BrandBar.test.tsx.snap
+++ b/modules/cactus-web/src/BrandBar/__snapshots__/BrandBar.test.tsx.snap
@@ -501,6 +501,8 @@ exports[`component: BrandBar snapshot 1`] = `
   align-items: center;
   padding: 16px;
   cursor: pointer;
+  margin: 0;
+  border-radius: 0;
 }
 
 .c4:focus {


### PR DESCRIPTION
The problem with safari was that it was adding a default margin so I had to delete it.
In edge the button had a border-radius, so I had to delete it too.

Test:
Check the Bottom border in the user menu of the Brandbar looks good in every browser

[CACTUS-441]

[CACTUS-441]: https://repayonline.atlassian.net/browse/CACTUS-441