### PR TITLE
CACTUS-442: fix ie11 word wrap in tooltip

### DIFF
--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -188,6 +188,7 @@ export const TooltipPopup = styled(ReachTooltipPopup)`
   ${(p): ColorStyle => p.theme.colorStyles.standard};
   box-sizing: border-box;
   overflow-wrap: break-word;
+  word-wrap: break-word;
   border: ${(p) => border(p.theme, 'callToAction')};
   ${(p): string => shapeMap[p.theme.shape]}
 `

--- a/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/modules/cactus-web/src/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`component: Tooltip should render tooltip on hover 1`] = `
   color: hsl(200,10%,20%);
   box-sizing: border-box;
   overflow-wrap: break-word;
+  word-wrap: break-word;
   border: 1px solid hsl(200,96%,35%);
   border-radius: 4px;
 }


### PR DESCRIPTION
Check the text in the tooltip doesn't overflow on ie11
[CACTUS-442]

[CACTUS-442]: https://repayonline.atlassian.net/browse/CACTUS-442