### PR TITLE
Update justifyContent in Tabs docs

### DIFF
--- a/modules/cactus-web/src/Tabs/Tabs.mdx
+++ b/modules/cactus-web/src/Tabs/Tabs.mdx
@@ -26,7 +26,7 @@ There are four components:
 export const code = `
 <Box border="1px solid black" height="175px">
   <TabController id="idPrefix" initialTabId="idPrefix-rank-tab">
-    <TabList fullWidth fillGaps justifyContent="space-evenly">
+    <TabList fullWidth fillGaps justifyContent="space-between">
       <Tab name="name">Name</Tab>
       <Tab name="rank">Rank</Tab>
       <Tab name="serial">Serial #</Tab>


### PR DESCRIPTION
The space-evenly option triggers a window.navigator check.  This prevents Gatsby from building due
to SSR restrictions.