### PR TITLE
CACTUS-466 :: Accordion Deletion Bug

### DIFF
--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -404,7 +404,7 @@ export const AccordionProvider = (props: AccordionProviderProps): ReactElement =
   useEffect(() => {
     const closeOldestOpenAccordion = () => {
       const accordions = managedAccordions.current
-      let allOpen = [...uncontrolledOpen]
+      let allOpen = uncontrolledOpen.filter((o) => Object.keys(accordions).includes(o))
       allOpen.sort((a, b): number => {
         if (accordions[a].order < accordions[b].order) {
           return -1
@@ -443,6 +443,7 @@ export const AccordionProvider = (props: AccordionProviderProps): ReactElement =
   )
 
   const unregisterAccordion = useCallback((id: string) => {
+    setUncontrolledOpen((previousOpen) => previousOpen.filter((openId) => openId !== id))
     delete managedAccordions.current[id]
   }, [])
 


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-466

When accordions were unregistered from an un AccordionProvider, the provider would still have the deleted accordion's ID in the `uncontrolledOpen` state.  This could cause bugs in other parts of the code.