### PR TITLE
CACTUS-468: trim spaces from hex color values

### DIFF
--- a/modules/cactus-theme/src/converters.ts
+++ b/modules/cactus-theme/src/converters.ts
@@ -43,6 +43,7 @@ export function rgbToHsl(red: number, green: number, blue: number): [number, num
 }
 
 export function hexToRgb(hex: string): [number, number, number] {
+  hex = hex?.trim?.()
   if (/^#?([a-f\d]{3}){1,2}$/i.test(hex)) {
     let result
     if (hex.length < 6) {

--- a/modules/cactus-theme/tests/converters.test.ts
+++ b/modules/cactus-theme/tests/converters.test.ts
@@ -2,6 +2,6 @@ import { hexToRgb } from '../src/converters'
 
 describe('hex to rgb conversion', (): void => {
   test('correctly converts 3 and 6 length colors', (): void => {
-    expect(hexToRgb('#00F')).toEqual(hexToRgb('#0000FF'))
+    expect(hexToRgb('#00F')).toEqual(hexToRgb('#0000FF '))
   })
 })

--- a/modules/cactus-theme/tests/theme.test.ts
+++ b/modules/cactus-theme/tests/theme.test.ts
@@ -62,12 +62,12 @@ describe('@repay/cactus-theme', (): void => {
   })
 
   test('generates a theme when primary color is provided', (): void => {
-    const theme = generateTheme({ primary: '#012537' })
+    const theme = generateTheme({ primary: '#012537 ' })
     expect(theme).toEqual(cactusTheme)
   })
 
   test('generates a theme when two colors are provided', (): void => {
-    const theme = generateTheme({ primary: '#012537', secondary: '#0000FF' })
+    const theme = generateTheme({ primary: '#012537', secondary: ' #0000FF' })
     expect(theme).toMatchObject({
       colors: {
         base: 'hsl(200, 96%, 11%)',


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-468

I think that all hex values go through that one function, so that should be the only change needed. I'm not sure if there's a place this can be manually tested, but I added some spaces randomly in a couple of the unit tests.