### PR TITLE
CACTUS-464: change keypress to keydown to avoid IE bug

### DIFF
--- a/modules/cactus-web/src/DataGrid/PageSizeSelect.tsx
+++ b/modules/cactus-web/src/DataGrid/PageSizeSelect.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement, useContext } from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { keyPressAsClick } from '../helpers/a11y'
+import { keyDownAsClick } from '../helpers/a11y'
 import { border, fontSize } from '../helpers/theme'
 import { DataGridContext } from './helpers'
 
@@ -41,7 +41,7 @@ const PageSizeSelect = (props: PageSizeSelectProps): ReactElement => {
                     onClick={(): void => {
                       onPageChange({ ...paginationOptions, pageSize: pageSize })
                     }}
-                    onKeyPress={keyPressAsClick}
+                    onKeyDown={keyDownAsClick}
                     tabIndex={isCurrentPageSize ? undefined : 0}
                     aria-label={makePageSizeLabel(pageSize)}
                   >

--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components'
 
 import ActionBar from '../ActionBar/ActionBar'
 import { useAction } from '../ActionBar/ActionProvider'
-import { keyPressAsClick, preventAction } from '../helpers/a11y'
+import { keyDownAsClick, preventAction } from '../helpers/a11y'
 import { AsProps, GenericComponent } from '../helpers/asProps'
 import { isIE } from '../helpers/constants'
 import { FocusSetter, useFocusControl } from '../helpers/focus'
@@ -61,8 +61,8 @@ function MenuBarItemFunc<E, C extends GenericComponent = 'button'>(
   // The `as any` here is to enable proper use of link substition,
   // e.g. <MenuBar.Item as="a" href="go/go/power/rangers" />
   const propsCopy = { ...props } as any
-  if (!propsCopy.onKeyPress) {
-    propsCopy.onKeyPress = keyPressAsClick
+  if (!propsCopy.onKeyDown) {
+    propsCopy.onKeyDown = keyDownAsClick
   }
   const original = propsCopy.onKeyUp
   propsCopy.onKeyUp = !original

--- a/modules/cactus-web/src/Pagination/Pagination.mdx
+++ b/modules/cactus-web/src/Pagination/Pagination.mdx
@@ -77,7 +77,7 @@ There are several accessibility-related props, specifically for setting `aria-la
 - The `aria-label` and `aria-current` props should be passed on as-is to the underlying HTML element.
 - If the HTML element doesn't support `disabled` directly, you should set `aria-disabled="true"` on disabled links.
 - Set `tabIndex="0"` to allow focus on elements that normally can't be focused.
-- To make keyboard-only navigation possible, consider adding an `onKeyPress` handler for elements that don't already equate clicking and pressing the &lt;Enter&gt; or &lt;space&gt; keys.
+- To make keyboard-only navigation possible, consider adding an `onKeyDown` handler for elements that don't already equate clicking and pressing the &lt;Enter&gt; or &lt;space&gt; keys.
 - If not using an anchor element with `href`, you should set `role="link"`.
 
 ## Properties

--- a/modules/cactus-web/src/Pagination/Pagination.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.tsx
@@ -10,7 +10,7 @@ import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { keyPressAsClick } from '../helpers/a11y'
+import { keyDownAsClick, preventAction } from '../helpers/a11y'
 import { border, fontSize } from '../helpers/theme'
 
 export interface PageLinkProps {
@@ -133,7 +133,8 @@ const PageLinkBase: React.FC<PageLinkProps> = (props: PageLinkProps): ReactEleme
     linkProps.tabIndex = 0
   }
   if (onClick) {
-    linkProps.onKeyPress = keyPressAsClick
+    linkProps.onKeyDown = keyDownAsClick
+    linkProps.onKeyUp = preventAction
   }
   return (
     <a role="link" onClick={onClick} {...linkProps}>

--- a/modules/cactus-web/src/PrevNext/PrevNext.tsx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { keyPressAsClick } from '../helpers/a11y'
+import { keyDownAsClick } from '../helpers/a11y'
 import { border, fontSize } from '../helpers/theme'
 
 type NavDirection = 'prev' | 'next'
@@ -35,7 +35,7 @@ const PrevNextLinkBase: React.FC<PrevNextLinkProps> = ({
     aria-disabled={disabled ? 'true' : 'false'}
     className={className}
     onClick={onClick}
-    onKeyPress={onClick && keyPressAsClick}
+    onKeyDown={onClick && keyDownAsClick}
     tabIndex={disabled ? undefined : 0}
   >
     {children}

--- a/modules/cactus-web/src/Tabs/Tabs.tsx
+++ b/modules/cactus-web/src/Tabs/Tabs.tsx
@@ -4,9 +4,9 @@ import styled from 'styled-components'
 
 import Box, { BoxProps } from '../Box/Box'
 import Flex, { JustifyContent } from '../Flex/Flex'
-import { keyPressAsClick, preventAction } from '../helpers/a11y'
+import { keyDownAsClick, preventAction } from '../helpers/a11y'
 import { AsProps, GenericComponent } from '../helpers/asProps'
-import { isIE, isResponsiveTouchDevice } from '../helpers/constants'
+import { isResponsiveTouchDevice } from '../helpers/constants'
 import { FocusSetter, useFocusControl } from '../helpers/focus'
 import { useValue } from '../helpers/react'
 import { BUTTON_WIDTH, GetScrollInfo, ScrollButton, useScroll } from '../helpers/scroll'
@@ -115,15 +115,10 @@ function TabFunc<E, C extends GenericComponent = 'div'>(
     props.id = props.id || generateId(ctx.id, name, 'tab')
     panelId = panelId || generateId(ctx.id, name, 'panel')
   }
-  const keyProps: React.DOMAttributes<HTMLElement> = { onKeyUp: preventAction }
-  if (isIE) {
-    keyProps.onKeyDown = keyPressAsClick
-  } else {
-    keyProps.onKeyPress = keyPressAsClick
-  }
   return (
     <StyledTab
-      {...keyProps}
+      onKeyDown={keyDownAsClick}
+      onKeyUp={preventAction}
       onClick={ctx?.setCurrent}
       aria-selected={!!props.id && props.id === ctx?.currentTab}
       aria-controls={panelId}

--- a/modules/cactus-web/src/helpers/a11y.ts
+++ b/modules/cactus-web/src/helpers/a11y.ts
@@ -3,13 +3,15 @@ import { KeyboardEvent } from 'react'
 export const isActionKey = (event: KeyboardEvent): boolean =>
   event.key === 'Enter' || event.key === ' '
 
+// Some elements automatically trigger a click event on `keyup` events,
+// so combine `keyDownAsClick` with `onKeyUp={preventAction}` to stop duplicate clicks.
 export const preventAction = (event: KeyboardEvent): void => {
   if (isActionKey(event)) {
     event.preventDefault()
   }
 }
 
-export const keyPressAsClick = (event: KeyboardEvent): void => {
+export const keyDownAsClick = (event: KeyboardEvent): void => {
   if (isActionKey(event)) {
     event.preventDefault()
     const target = event.target as HTMLElement


### PR DESCRIPTION
UAT note: https://repayonline.atlassian.net/browse/CACTUS-464

I don't really remember why I went with keypress in the first place, but after some testing I found that keydown worked just as well in all browsers (I tested on button, div, and anchor with and w/out href), as long as it's paired with `onKeyUp={preventAction}` to prevent duplicate click events. As such, I decided to change all the keypress events, even the ones that weren't susceptible to the IE bug, just to make it less confusing for future devs.