### PR TITLE
CACTUS-472: ActionBar ARIA labels

### DIFF
--- a/modules/cactus-web/src/ActionBar/ActionBar.mdx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.mdx
@@ -77,6 +77,7 @@ const MyPage = () => (
   <>
     <ActionBar.Item
       id="page-action"
+      aria-label="do something on this page"
       icon={<ActionsKey />}
       orderHint="high"
       onClick={doSomethingPageSpecific}

--- a/modules/cactus-web/src/ActionBar/ActionBar.story.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.story.tsx
@@ -43,6 +43,7 @@ const SimpleRouter = () => {
       <ActionBar.Item
         id="refresh"
         icon={<ActionsRefresh />}
+        aria-label="Refresh"
         orderHint="high"
         onClick={() => setCount((c) => c + 1)}
       />
@@ -65,8 +66,8 @@ export const BasicUsage = (): React.ReactElement => {
     <ActionBar>
       {hasItems && (
         <>
-          <ActionBar.Item icon={<ActionsRedo />} onClick={action('redo')} />
-          <ActionBar.Item icon={<Undo />} onClick={action('undo')} />
+          <ActionBar.Item icon={<ActionsRedo />} aria-label="Redo" onClick={action('redo')} />
+          <ActionBar.Item icon={<Undo />} aria-label="Undo" onClick={action('undo')} />
         </>
       )}
     </ActionBar>

--- a/modules/cactus-web/src/ActionBar/ActionBar.test.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.test.tsx
@@ -31,11 +31,11 @@ describe('component: ActionBar', () => {
       <StyleProvider>
         <ActionProvider>
           <ActionBar aria-label="Bar of Actions">
-            <ActionBar.Item id="high" icon={<ActionsGear />} orderHint="high" />
+            <ActionBar.Item id="high" aria-label="Gear" icon={<ActionsGear />} orderHint="high" />
           </ActionBar>
           <div aria-label="Content">
-            <ActionBar.Item id="bottom" icon={<ActionsKey />} orderHint="bottom" />
-            <ActionBar.Panel id="normal" icon={<ActionsKey />} />
+            <ActionBar.Item id="bottom" aria-label="Key" icon={<ActionsKey />} orderHint="bottom" />
+            <ActionBar.Panel id="normal" aria-label="Key2" icon={<ActionsKey />} />
             <ActionBar.Item id="top" aria-label="top" icon={<ActionsKey />} orderHint="top" />
           </div>
         </ActionProvider>

--- a/modules/cactus-web/src/ActionBar/ActionBar.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.tsx
@@ -15,6 +15,7 @@ interface ItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   id?: string
   icon: React.ReactElement
   orderHint?: OrderHint
+  'aria-label': string
 }
 
 type StyleProps = LayoutStyleProps & PaddingProps
@@ -152,6 +153,7 @@ ActionBarItem.propTypes = {
     PropTypes.number,
     PropTypes.oneOf<OrderHintKey>(['top', 'high', 'center', 'low', 'bottom']),
   ]),
+  'aria-label': PropTypes.string.isRequired,
 }
 
 ActionBarPanel.propTypes = {

--- a/modules/cactus-web/src/ActionBar/ActionBar.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.tsx
@@ -30,6 +30,7 @@ interface PanelProps extends StyleProps, React.HTMLAttributes<HTMLElement> {
   popupType?: PopupType
   positionPopup?: PositionPopup
   children?: React.ReactNode | RenderFn
+  'aria-label': string
 }
 
 export const ActionBarItem = React.forwardRef<HTMLButtonElement, ItemProps>(

--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -63,7 +63,7 @@ export const BrandBarUserMenu: React.FC<UserMenuProps> = (props) => {
 export const BrandBarItem: React.FC<ItemProps> = ({ mobileIcon, ...props }) => {
   const isTiny = SIZES.tiny === useScreenSize()
   if (isTiny && mobileIcon) {
-    return <ActionBar.Panel {...props} icon={mobileIcon} />
+    return <ActionBar.Panel aria-label="" {...props} icon={mobileIcon} />
   }
   return <>{props.children}</>
 }

--- a/modules/cactus-web/src/Layout/Layout.story.tsx
+++ b/modules/cactus-web/src/Layout/Layout.story.tsx
@@ -89,6 +89,7 @@ const StoryActionBar = () => (
   <ActionBar>
     <ActionBar.Item
       id="whattime"
+      aria-label="Current Time"
       icon={<DescriptiveClock />}
       onClick={() => alert(`It is now ${new Date()}.`)}
     />


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-472

BREAKING CHANGE: aria-label prop is now required on ActionBar.Panel & ActionBar.Item

I looked at the other components where a similar change might make sense (Sidebar.Button, BrandBar.Item); for the former, I decided that if devs are springing for the lower-level components they might need greater flexibility; and for the latter, I didn't want to require a prop for an optional situation that only happens on tiny screens, if at all.