### PR TITLE
CACTUS-476: add integration tests for DateInput

### DIFF
--- a/examples/mock-ebpp/src/containers/date.tsx
+++ b/examples/mock-ebpp/src/containers/date.tsx
@@ -1,0 +1,51 @@
+import { RouteComponentProps } from '@reach/router'
+import { DateInputField, Flex, SelectField, TextInputField } from '@repay/cactus-web'
+import React from 'react'
+
+type InputType = 'date' | 'datetime' | 'time'
+
+const getDefault = (inputType: InputType) => {
+  if (inputType === 'date') {
+    return '2019-10-16'
+  } else if (inputType === 'time') {
+    return '23:57'
+  }
+  return '2019-10-16T01:02'
+}
+
+const DateTest: React.FC<RouteComponentProps> = () => {
+  const [inputType, setInputType] = React.useState<InputType>('date')
+  const [dateVal, setDateVal] = React.useState<string>('2019-10-16')
+  const onTypeChange = React.useCallback((e: any) => setInputType(e.target.value), [])
+  const onDateChange = React.useCallback((e: any) => setDateVal(e.target.value), [])
+  React.useEffect(() => setDateVal(getDefault(inputType)), [inputType])
+  return (
+    <Flex paddingX="30%" flexDirection="column">
+      <SelectField
+        label="Date Field Type"
+        name="type"
+        id="input-type"
+        value={inputType}
+        onChange={onTypeChange}
+        options={['date', 'datetime', 'time']}
+      />
+      <TextInputField
+        label="Unified Value"
+        name="value"
+        id="unified-value"
+        value={dateVal}
+        onChange={onDateChange}
+      />
+      <DateInputField
+        label="Date/Time Test Field"
+        name="test"
+        id="date-test"
+        type={inputType}
+        value={dateVal}
+        onChange={onDateChange}
+      />
+    </Flex>
+  )
+}
+
+export default DateTest

--- a/examples/mock-ebpp/src/containers/ui-config.tsx
+++ b/examples/mock-ebpp/src/containers/ui-config.tsx
@@ -58,7 +58,7 @@ const initialValues: FormData = {
   useCactusStyles: false,
   selectColor: '',
   fileInput: undefined,
-  establishedDate: '2019-10-16',
+  establishedDate: '',
 }
 
 const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {

--- a/examples/mock-ebpp/src/index.tsx
+++ b/examples/mock-ebpp/src/index.tsx
@@ -7,6 +7,7 @@ import { Helmet } from 'react-helmet'
 import MenuBar from './components/MenuBar'
 import Account from './containers/account'
 import Accounts from './containers/accounts'
+import DateTest from './containers/date'
 import Faq from './containers/faq'
 import Home from './containers/home'
 import PaymentHistoryReport from './containers/payment-history-report'
@@ -34,6 +35,7 @@ const App = (): React.ReactElement => {
             <Faq path="/faq" />
             <Rules path="/rules" />
             <Account path="/account/:accountId" />
+            <DateTest path="/date-test" />
           </MenuBar>
         </Router>
       </ScreenSizeProvider>

--- a/examples/mock-ebpp/tests/date-input-integration.test.ts
+++ b/examples/mock-ebpp/tests/date-input-integration.test.ts
@@ -1,0 +1,305 @@
+import { queryByLabelText } from '@testing-library/testcafe'
+import * as path from 'path'
+import { Selector } from 'testcafe'
+
+import makeActions, { clickWorkaround } from './helpers/actions'
+import startStaticServer from './helpers/static-server'
+
+// eslint-disable-next-line no-undef
+fixture('DateInput Integration Tests')
+  .before(
+    async (ctx): Promise<void> => {
+      ctx.server = startStaticServer({
+        directory: path.join(process.cwd(), 'dist'),
+        port: 33567,
+        singlePageApp: true,
+      })
+    }
+  )
+  .after(
+    async (ctx): Promise<void> => {
+      await ctx.server.close()
+    }
+  )
+  .page('http://localhost:33567/date-test')
+
+const scopedSelector = (container: string, selector: string) =>
+  Selector(
+    () => {
+      const c = document.querySelector(container)
+      return (c?.querySelector?.(selector) as Node) || null
+    },
+    { dependencies: { container, selector } }
+  )
+
+const selectType = async (t: TestController, itype: string) => {
+  await t.click('#input-type')
+  await t.click(`#input-type-${itype}-${itype}`)
+}
+
+const dateInput = '[aria-labelledby="date-test-label"]'
+const dateDialog = '[role="dialog"][aria-labelledby]'
+
+const textField = Selector('#unified-value')
+const monthInput = queryByLabelText('month')
+const dayInput = queryByLabelText('day of month')
+const yearInput = queryByLabelText('year')
+const hourInput = scopedSelector(dateInput, '[aria-label="hours"]')
+const minuteInput = scopedSelector(dateInput, '[aria-label="minutes"]')
+const ampmInput = scopedSelector(dateInput, '[aria-label="time period"]')
+const upButton = scopedSelector(dateInput, 'svg[data-name="ArrowUp"]')
+const downButton = scopedSelector(dateInput, 'svg[data-name="ArrowDown"]')
+
+test('enter date by typing', async (t): Promise<void> => {
+  await t.click(monthInput)
+
+  await t.expect(monthInput.focused).ok('month not focused').expect(monthInput.value).eql('10')
+
+  await t.typeText(monthInput, '9').pressKey('tab')
+  await t.expect(monthInput.value).eql('09')
+  await t.expect(dayInput.focused).ok('day not focused').expect(dayInput.value).eql('16')
+
+  await t.typeText(dayInput, '23')
+  await t.expect(dayInput.value).eql('23')
+  await t.expect(yearInput.focused).ok('year not focused').expect(yearInput.value).eql('2019')
+
+  await t.typeText(yearInput, '1999')
+  await t
+    .expect(yearInput.focused)
+    .ok('year not focused')
+    .expect(yearInput.value)
+    .eql('1999')
+    .expect(textField.value)
+    .eql('1999-09-23')
+})
+
+test('enter datetime by typing', async (t): Promise<void> => {
+  await selectType(t, 'datetime')
+  await t.click(monthInput)
+
+  await t.expect(monthInput.focused).ok('month not focused').expect(monthInput.value).eql('10')
+
+  await t.typeText(monthInput, '9').pressKey('tab')
+  await t.expect(monthInput.value).eql('09')
+  await t.expect(dayInput.focused).ok('day not focused').expect(dayInput.value).eql('16')
+
+  await t.typeText(dayInput, '23')
+  await t.expect(dayInput.value).eql('23')
+  await t.expect(yearInput.focused).ok('year not focused').expect(yearInput.value).eql('2019')
+
+  await t.typeText(yearInput, '1999')
+  await t.expect(yearInput.value).eql('1999')
+  await t.expect(hourInput.focused).ok('hour not focused')
+  // For hours, IE includes the leading 0.
+  //.expect(hourInput.value).eql('1')
+
+  await t.typeText(hourInput, '3').pressKey('tab')
+  //await t.expect(hourInput.value).eql('3')
+  await t.expect(minuteInput.focused).ok('minute not focused').expect(minuteInput.value).eql('02')
+
+  await t.typeText(minuteInput, '42')
+  await t.expect(minuteInput.value).eql('42')
+  await t.expect(ampmInput.focused).ok('ampm not focused').expect(ampmInput.value).eql('AM')
+
+  await t.typeText(ampmInput, 'p')
+  await t
+    .expect(ampmInput.focused)
+    .ok('ampm not focused')
+    .expect(ampmInput.value)
+    .eql('PM')
+    .expect(textField.value)
+    .eql('1999-09-23T15:42')
+})
+
+test('enter time by typing', async (t): Promise<void> => {
+  await selectType(t, 'time')
+  await t.click(hourInput)
+
+  await t.expect(hourInput.focused).ok('hour not focused').expect(hourInput.value).eql('11')
+
+  await t.typeText(hourInput, '3').pressKey('tab')
+  //await t.expect(hourInput.value).eql('3')
+  await t.expect(minuteInput.focused).ok('minute not focused').expect(minuteInput.value).eql('57')
+
+  await t.typeText(minuteInput, '42')
+  await t.expect(minuteInput.value).eql('42')
+  await t.expect(ampmInput.focused).ok('ampm not focused').expect(ampmInput.value).eql('PM')
+
+  await t.typeText(ampmInput, 'a')
+  await t
+    .expect(ampmInput.focused)
+    .ok('ampm not focused')
+    .expect(ampmInput.value)
+    .eql('AM')
+    .expect(textField.value)
+    .eql('03:42')
+})
+
+test('select date with popup', async (t): Promise<void> => {
+  await clickWorkaround(queryByLabelText('Open date picker'))
+
+  await clickWorkaround(queryByLabelText('Click to change month'))
+  await t.click('#date-test-February')
+  await clickWorkaround(queryByLabelText('Click to change year'))
+  await t.click('#date-test-2005')
+  await clickWorkaround(Selector('[data-date="2005-02-28"]'))
+  await t.expect(textField.value).eql('2005-02-28')
+})
+
+test('select datetime with popup', async (t): Promise<void> => {
+  await selectType(t, 'datetime')
+  await clickWorkaround(queryByLabelText('Open date picker'))
+
+  await clickWorkaround(queryByLabelText('Click to go back one month'))
+  await clickWorkaround(Selector('[data-date="2019-09-29"]'))
+  await t
+    .typeText(scopedSelector(dateDialog, '[aria-label="hours"]'), '11')
+    .pressKey('up')
+    .click(scopedSelector(dateDialog, 'svg[data-name="ArrowUp"]'))
+    .pressKey('tab')
+    .pressKey('down')
+  await t.expect(textField.value).eql('2019-09-29T23:04')
+})
+
+test('scroll months back', async (t): Promise<void> => {
+  await t.typeText(monthInput, '1').typeText(dayInput, '31')
+  await clickWorkaround(queryByLabelText('Open date picker'))
+
+  const backButton = queryByLabelText('Click to go back one month')
+  await clickWorkaround(backButton)
+  await t.expect(textField.value).eql('2018-12-31')
+  await clickWorkaround(backButton)
+  await t.expect(textField.value).eql('2018-11-30')
+})
+
+test('scroll months forward', async (t): Promise<void> => {
+  await t.typeText(monthInput, '12').typeText(dayInput, '31')
+  await clickWorkaround(queryByLabelText('Open date picker'))
+
+  const forwardButton = queryByLabelText('Click to go forward one month')
+  await clickWorkaround(forwardButton)
+  await t.expect(textField.value).eql('2020-01-31')
+  await clickWorkaround(forwardButton)
+  await t.expect(textField.value).eql('2020-02-29')
+})
+
+test('enter datetime with arrow keys/buttons', async (t): Promise<void> => {
+  await selectType(t, 'datetime')
+  await t.typeText(textField, '2020-02-29T23:58', { replace: true })
+  await t.click(monthInput)
+
+  await t
+    .expect(monthInput.focused)
+    .ok('month not focused')
+    .click(upButton)
+    .click(downButton)
+    .pressKey('down')
+    .pressKey('down')
+    .pressKey('tab')
+  await t
+    .expect(dayInput.focused)
+    .ok('day not focused')
+    .click(upButton)
+    .pressKey('up')
+    .click(downButton)
+    .click(upButton)
+    .pressKey('up')
+    .pressKey('tab')
+  await t
+    .expect(yearInput.focused)
+    .ok('year not focused')
+    .click(upButton)
+    .pressKey('up')
+    .click(downButton)
+    .pressKey('tab')
+  await t
+    .expect(hourInput.focused)
+    .ok('hour not focused')
+    .click(upButton)
+    .pressKey('up')
+    .click(downButton)
+    .pressKey('tab')
+  await t.expect(textField.value).eql('2021-12-01T00:58')
+  await t
+    .expect(minuteInput.focused)
+    .ok('minute not focused')
+    .click(upButton)
+    .pressKey('up')
+    .click(downButton)
+    .pressKey('up')
+    .pressKey('tab')
+  await t
+    .expect(ampmInput.focused)
+    .ok('ampm not focused')
+    .click(upButton)
+    .pressKey('up')
+    .click(downButton)
+    .pressKey('tab')
+  await t.expect(textField.value).eql('2021-12-01T12:00')
+})
+
+test('locks focus to date picker', async (t: TestController): Promise<void> => {
+  const { getActiveElement } = makeActions(t)
+  const datePickerTrigger = queryByLabelText('Open date picker')
+  await clickWorkaround(datePickerTrigger)
+
+  const dateButtonActiveEl = await getActiveElement()
+  await t
+    .expect(dateButtonActiveEl.attributes?.role)
+    .eql('gridcell')
+    .expect(dateButtonActiveEl.attributes?.['data-date'])
+    .eql('2019-10-16')
+    .expect(dateButtonActiveEl.focused)
+    .ok('Date button not focused')
+
+  // tab and expect focus to circle back to Month select
+  await t.pressKey('tab')
+  const monthSelectActiveEl = await getActiveElement()
+  await t
+    .expect(monthSelectActiveEl.tagName)
+    .eql('button')
+    .expect(monthSelectActiveEl.attributes?.['aria-label'])
+    .eql('Click to go back one month')
+    .expect(monthSelectActiveEl.attributes?.['aria-roledescription'])
+    .eql('moves date back one month')
+    .expect(monthSelectActiveEl.focused)
+    .ok('Date button not focused')
+})
+
+test('move and select date with keyboard', async (t: TestController): Promise<void> => {
+  const { getActiveElement } = makeActions(t)
+  const datePickerTrigger = queryByLabelText('Open date picker')
+  await clickWorkaround(datePickerTrigger)
+
+  // move right
+  await t.pressKey('right')
+  const dateButtonActiveEl = await getActiveElement()
+  await t
+    .expect(dateButtonActiveEl.attributes?.role)
+    .eql('gridcell')
+    .expect(dateButtonActiveEl.attributes?.['data-date'])
+    .eql('2019-10-17')
+    .expect(dateButtonActiveEl.focused)
+    .ok('Date button not focused')
+
+  // move up
+  await t.pressKey('up')
+  const dateButtonActiveEl2 = await getActiveElement()
+  await t
+    .expect(dateButtonActiveEl2.attributes?.role)
+    .eql('gridcell')
+    .expect(dateButtonActiveEl2.attributes?.['data-date'])
+    .eql('2019-10-10')
+    .expect(dateButtonActiveEl2.focused)
+    .ok('Date button not focused')
+
+  // select currently focused date
+  await t.pressKey('enter')
+  await t
+    .expect(queryByLabelText('year').value)
+    .eql('2019')
+    .expect(queryByLabelText('month').value)
+    .eql('10')
+    .expect(queryByLabelText('day of month').value)
+    .eql('10')
+})

--- a/examples/mock-ebpp/tests/date-input-integration.test.ts
+++ b/examples/mock-ebpp/tests/date-input-integration.test.ts
@@ -143,7 +143,11 @@ test('select date with popup', async (t): Promise<void> => {
   await clickWorkaround(queryByLabelText('Click to change year'))
   await t.click('#date-test-2005')
   await clickWorkaround(Selector('[data-date="2005-02-28"]'))
-  await t.expect(textField.value).eql('2005-02-28')
+  await t
+    .expect(textField.value)
+    .eql('2005-02-28')
+    .expect(Selector(dateDialog).filterHidden().exists)
+    .ok('Dialog is hidden')
 })
 
 test('select datetime with popup', async (t): Promise<void> => {
@@ -158,7 +162,11 @@ test('select datetime with popup', async (t): Promise<void> => {
     .click(scopedSelector(dateDialog, 'svg[data-name="ArrowUp"]'))
     .pressKey('tab')
     .pressKey('down')
-  await t.expect(textField.value).eql('2019-09-29T23:04')
+  await t
+    .expect(textField.value)
+    .eql('2019-09-29T23:04')
+    .expect(Selector(dateDialog).filterVisible().exists)
+    .ok('Dialog is visible')
 })
 
 test('scroll months back', async (t): Promise<void> => {

--- a/examples/mock-ebpp/tests/ui-config-integration.test.ts
+++ b/examples/mock-ebpp/tests/ui-config-integration.test.ts
@@ -1,4 +1,4 @@
-import { queryByLabelText, queryByText } from '@testing-library/testcafe'
+import { queryByText } from '@testing-library/testcafe'
 import * as path from 'path'
 import { ClientFunction } from 'testcafe'
 
@@ -42,6 +42,9 @@ test('should fill out and submit the entire form', async (t): Promise<void> => {
   await t.click(queryByText('Blue'))
   await t.click(queryByText('Allow Customer Login'))
   await t.click(queryByText('Use Cactus Styles'))
+  await fillTextField('month', '2')
+  await fillTextField('day of month', '28')
+  await fillTextField('year', '2019')
   await clickWorkaround(queryByText('Submit'))
 
   const apiData: UIConfigData = await getApiData()
@@ -65,87 +68,6 @@ test('should fill out and submit the entire form', async (t): Promise<void> => {
     useCactusStyles: true,
     selectColor: 'blue',
     fileInput: [{ fileName: 'test-logo.jpg', contents: fileContents, status: 'loaded' }],
-    establishedDate: '2019-10-16',
+    establishedDate: '2019-02-28',
   })
-})
-
-test('moves focus to date picker on click', async (t): Promise<void> => {
-  const { getActiveElement } = makeActions(t)
-  await clickWorkaround(queryByLabelText('Open date picker'))
-  await t.pressKey('tab')
-  const activeEl = await getActiveElement()
-
-  await t
-    .expect(activeEl.attributes?.['aria-label'])
-    .eql('Click to go back one month')
-    .expect(activeEl.attributes?.['aria-roledescription'])
-    .eql('moves date back one month')
-    .expect(activeEl.focused)
-    .ok('Date picker is not focused')
-})
-
-test('locks focus to date picker', async (t: TestController): Promise<void> => {
-  const { getActiveElement } = makeActions(t)
-  const datePickerTrigger = queryByLabelText('Open date picker')
-  await clickWorkaround(datePickerTrigger)
-
-  const dateButtonActiveEl = await getActiveElement()
-  await t
-    .expect(dateButtonActiveEl.attributes?.role)
-    .eql('gridcell')
-    .expect(dateButtonActiveEl.attributes?.['data-date'])
-    .eql('2019-10-16')
-    .expect(dateButtonActiveEl.focused)
-    .ok('Date button not focused')
-
-  // tab and expect focus to circle back to Month select
-  await t.pressKey('tab')
-  const monthSelectActiveEl = await getActiveElement()
-  await t
-    .expect(monthSelectActiveEl.tagName)
-    .eql('button')
-    .expect(monthSelectActiveEl.attributes?.['aria-label'])
-    .eql('Click to go back one month')
-    .expect(monthSelectActiveEl.attributes?.['aria-roledescription'])
-    .eql('moves date back one month')
-    .expect(monthSelectActiveEl.focused)
-    .ok('Date button not focused')
-})
-
-test('move and select date with keyboard', async (t: TestController): Promise<void> => {
-  const { getActiveElement } = makeActions(t)
-  const datePickerTrigger = queryByLabelText('Open date picker')
-  await clickWorkaround(datePickerTrigger)
-
-  // move right
-  await t.pressKey('right')
-  const dateButtonActiveEl = await getActiveElement()
-  await t
-    .expect(dateButtonActiveEl.attributes?.role)
-    .eql('gridcell')
-    .expect(dateButtonActiveEl.attributes?.['data-date'])
-    .eql('2019-10-17')
-    .expect(dateButtonActiveEl.focused)
-    .ok('Date button not focused')
-
-  // move up
-  await t.pressKey('up')
-  const dateButtonActiveEl2 = await getActiveElement()
-  await t
-    .expect(dateButtonActiveEl2.attributes?.role)
-    .eql('gridcell')
-    .expect(dateButtonActiveEl2.attributes?.['data-date'])
-    .eql('2019-10-10')
-    .expect(dateButtonActiveEl2.focused)
-    .ok('Date button not focused')
-
-  // select currently focused date
-  await t.pressKey('enter')
-  await t
-    .expect(queryByLabelText('year').value)
-    .eql('2019')
-    .expect(queryByLabelText('month').value)
-    .eql('10')
-    .expect(queryByLabelText('day of month').value)
-    .eql('10')
 })

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -1582,8 +1582,8 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
       do {
         testDate.setMonth(month)
         months.push({
-          long: monthOnlyFmt.format(testDate),
-          short: monthOnlyFmtShort.format(testDate),
+          long: monthOnlyFmt.format(testDate).replace('\u200e', ''),
+          short: monthOnlyFmtShort.format(testDate).replace('\u200e', ''),
         })
       } while (++month < 12)
       // get weekday names


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-476

Since I couldn't think of a way of working the datetime/time inputs into the example app, I made a "hidden" page specifically for the integration tests. With that done, I felt it made more sense to move the existing DateInput tests to that file as well.

Finally, I also fixed an issue where IE (I think it's actually a polyfill library) was adding an extra character to the month names.