### PR TITLE
CACTUS-480: prevent duplicate options in Select

### DIFF
--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -1172,6 +1172,24 @@ describe('component: Select', (): void => {
       expect(listbox).toHaveTextContent('superior')
       expect(listbox).toHaveTextContent('globe')
     })
+
+    test('values added should not be duplicated', async (): Promise<void> => {
+      const DelayedOptions = () => {
+        const [options, setOptions] = React.useState<string[]>([])
+        React.useEffect(() => setOptions(['phoenix', 'tucson', 'flagstaff']), [])
+        return <Select id="test-id" name="city" options={options} value="phoenix" comboBox />
+      }
+      const { getByRole, getAllByRole } = render(
+        <StyleProvider>
+          <DelayedOptions />
+        </StyleProvider>
+      )
+      const trigger = getByRole('button')
+      expect(trigger).toHaveTextContent('phoenix')
+      fireEvent.click(trigger)
+      const options = getAllByRole('option')
+      expect(options).toHaveLength(3)
+    })
   })
 
   describe('with multiple=true && comboBox=true', (): void => {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1310,7 +1310,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     this.getExtOptions().forEach((opt): void => {
       this.optionsMap[opt.value] = opt
     })
-    if (this.props.comboBox && this.props.value) {
+    if (this.props.comboBox && this.props.canCreateOption && this.props.value) {
       const newOptions: OptionType[] = []
 
       if (Array.isArray(this.props.value)) {
@@ -1358,9 +1358,11 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     ) {
       return this.memoizedExtOptions.memo
     }
+    const propValues = new Set<string | number>()
     let memo = this.props.options.map(
       (o): ExtendedOptionType => {
         const opt = asOption(o)
+        propValues.add(opt.value)
         const extendedOpt: ExtendedOptionType = {
           ...opt,
           id: getOptionId(selectId, opt),
@@ -1369,13 +1371,15 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
         return extendedOpt
       }
     )
-    const extraOpts = (this.state.extraOptions as OptionType[]).map(
-      (opt): ExtendedOptionType => ({
-        ...opt,
-        id: getOptionId(selectId, opt),
-        isSelected: this.isSelected(opt),
-      })
-    )
+    const extraOpts = (this.state.extraOptions as OptionType[])
+      .filter((opt) => !propValues.has(opt.value))
+      .map(
+        (opt): ExtendedOptionType => ({
+          ...opt,
+          id: getOptionId(selectId, opt),
+          isSelected: this.isSelected(opt),
+        })
+      )
     memo = memo.concat(extraOpts)
     this.memoizedExtOptions = {
       id: selectId,


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-480

Two parts to this:
1. Making sure values can only be added programmatically if `canCreateOption` is true.
2. Do not display duplicates from the extra options (does not prevent duplicates among passed-in options).

No stories can test this as-is, but if you want to be thorough you can the modifications in the reproduction section of the ticket to test this manually; beyond that I also added a unit test to cover it.

Mike suggested this was a breaking change; is that still the case if the previous behavior was more of a bug than a feature?