### PR TITLE
CACTUS-470 :: SonarQube Improvements

### DIFF
--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
 import Rect, { PRect } from '@reach/rect'
 import { assignRef } from '@reach/utils'
 import { NavigationChevronDown, NavigationChevronRight } from '@repay/cactus-icons'
-import { BorderSize, Shape } from '@repay/cactus-theme'
+import { BorderSize } from '@repay/cactus-theme'
 import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, {
@@ -19,7 +19,7 @@ import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 
 
 import KeyCodes from '../helpers/keyCodes'
 import { omitMargins } from '../helpers/omit'
-import { boxShadow } from '../helpers/theme'
+import { boxShadow, radius } from '../helpers/theme'
 import useId from '../helpers/useId'
 import IconButton from '../IconButton/IconButton'
 
@@ -689,18 +689,6 @@ const AccordionBase = (props: AccordionProps): ReactElement => {
   )
 }
 
-const shapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 4px;
-  `,
-  round: css`
-    border-radius: 8px;
-  `,
-}
-
 const outlineBorderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
   thin: css`
     border: 1px solid;
@@ -725,7 +713,6 @@ const simpleBorderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
   `,
 }
 
-const getShape = (shape: Shape) => shapeMap[shape]
 const getOutlineBorder = (borderSize: BorderSize) => outlineBorderMap[borderSize]
 const getSimpleBorder = (borderSize: BorderSize) => simpleBorderMap[borderSize]
 
@@ -737,7 +724,7 @@ const accordionVariantMap: VariantMap = {
   outline: css`
     ${(p): ReturnType<typeof css> => getOutlineBorder(p.theme.border)}
     border-color: ${(p): string => p.theme.colors.lightContrast};
-    ${(p): ReturnType<typeof css> => getShape(p.theme.shape)}
+    border-radius: ${radius(8)};
     & + & {
       margin-top: 8px;
     }

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -443,7 +443,7 @@ export const AccordionProvider = (props: AccordionProviderProps): ReactElement =
   )
 
   const unregisterAccordion = useCallback((id: string) => {
-    setUncontrolledOpen((previousOpen) => previousOpen.filter((openId) => openId !== id))
+    setUncontrolledOpen((previousOpen) => previousOpen.filter((o) => o !== id))
     delete managedAccordions.current[id]
   }, [])
 

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -73,7 +73,7 @@ const decideBorderRadius = (props: ThemedStyledProps<BoxProps, DefaultTheme>) =>
   } = props
 
   if (borderRadius && borderRadius === 'themed') {
-    return `border-radius: ${radius(props)};`
+    return `border-radius: ${radius(8)(props)};`
   } else if (isInstanceOfCustomBR(borderRadius)) {
     return `border-radius: ${borderRadius[props.theme.shape]};`
   }

--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -240,7 +240,7 @@ const MenuList = styled(ReachMenuList)`
   padding: 8px 0;
   margin-top: 8px;
   outline: none;
-  border-radius: ${radius};
+  border-radius: ${radius(8)};
   ${(p) => boxShadow(p.theme, 1) || `border: ${border(p.theme, 'lightContrast')}`};
   background-color: ${(p) => p.theme.colors.white};
 

--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -1,11 +1,11 @@
-import { BorderSize, ColorStyle, Shape, TextStyle } from '@repay/cactus-theme'
+import { BorderSize, ColorStyle, TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { AsProps, GenericComponent } from '../helpers/asProps'
-import { textStyle } from '../helpers/theme'
+import { radius, textStyle } from '../helpers/theme'
 import Spinner from '../Spinner/Spinner'
 
 export type ButtonVariants = 'standard' | 'action' | 'danger' | 'warning' | 'success'
@@ -138,19 +138,6 @@ const borderMap = {
   `,
 }
 
-const shapeMap = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 8px;
-  `,
-  round: css`
-    border-radius: 20px;
-  `,
-}
-const getShape = (shape: Shape): FlattenSimpleInterpolation => shapeMap[shape]
-
 const getBorder = (size: BorderSize): FlattenSimpleInterpolation => borderMap[size]
 
 interface TransientButtonProps extends Omit<ButtonProps, 'inverse' | 'variant'> {
@@ -203,7 +190,7 @@ const StyledButton = styled.button.withConfig({
   text-decoration: none;
   ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
   ${(p): FlattenSimpleInterpolation => getBorder(p.theme.border)};
-  ${(p): FlattenSimpleInterpolation => getShape(p.theme.shape)};
+  border-radius: ${radius(20)};
 
   &::-moz-focus-inner {
     border: 0;
@@ -219,7 +206,7 @@ const StyledButton = styled.button.withConfig({
       top: -5px;
       left: -5px;
       ${(p): FlattenSimpleInterpolation => getBorder(p.theme.border)};
-      ${(p): FlattenSimpleInterpolation => getShape(p.theme.shape)};
+      border-radius: ${radius(20)};
       border-color: ${(p): string => p.theme.colors.callToAction};
       box-sizing: border-box;
     }

--- a/modules/cactus-web/src/Card/Card.tsx
+++ b/modules/cactus-web/src/Card/Card.tsx
@@ -1,9 +1,9 @@
-import { BorderSize, CactusTheme, ColorStyle, Shape } from '@repay/cactus-theme'
+import { BorderSize, CactusTheme, ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import { margin, MarginProps, padding, PaddingProps, width, WidthProps } from 'styled-system'
 
-import { boxShadow } from '../helpers/theme'
+import { boxShadow, radius } from '../helpers/theme'
 
 interface CardProps extends MarginProps, WidthProps, PaddingProps {
   useBoxShadow?: boolean
@@ -18,20 +18,7 @@ const borderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
   `,
 }
 
-const shapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 4px;
-  `,
-  round: css`
-    border-radius: 8px;
-  `,
-}
-
 const getBorder = (borderSize: BorderSize): ReturnType<typeof css> => borderMap[borderSize]
-const getShape = (shape: Shape): ReturnType<typeof css> => shapeMap[shape]
 const getBoxShadow = (theme: CactusTheme, useBoxShadow?: boolean): ReturnType<typeof css> => {
   return theme.boxShadows && useBoxShadow
     ? css`
@@ -51,7 +38,7 @@ export const Card = styled.div<CardProps>`
   ${margin}
   ${width}
   ${(p): ColorStyle => p.theme.colorStyles.standard};
-  ${(p): ReturnType<typeof css> => getShape(p.theme.shape)}
+  border-radius: ${radius(8)};
   padding: ${(p): number => p.theme.space[4]}px;
   ${padding}
   ${(p): ReturnType<typeof css> => getBoxShadow(p.theme, p.useBoxShadow)}

--- a/modules/cactus-web/src/DataGrid/DataGridTable.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGridTable.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React, { ReactElement, useContext } from 'react'
 import styled from 'styled-components'
 
-import { border } from '../helpers/theme'
+import { border, radius } from '../helpers/theme'
 import Table from '../Table/Table'
 import { DataGridContext } from './helpers'
 import { ColumnObject, DataColumnObject, SortOption } from './types'
@@ -126,12 +126,6 @@ const TextWrapper = styled.div`
   flex-grow: 1;
 `
 
-const shapeMap = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 8px;',
-  round: 'border-radius: 20px;',
-}
-
 const HeaderButton = styled.button`
   display: flex;
   align-items: center;
@@ -158,7 +152,7 @@ const HeaderButton = styled.button`
       bottom: -4px;
       right: -8px;
       border: ${(p) => border(p.theme, 'lightContrast')};
-      ${(p) => shapeMap[p.theme.shape]}
+      border-radius: ${radius(20)};
     }
   }
 `

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -1277,9 +1277,9 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
         this.handleUpdate(event, token, 'Key', String(optionValue))
       } else {
         this.setState(
-          (state): Pick<DateInputState, 'focusDay' | 'value'> => {
-            const { value } = state
-            const pd = PartialDate.from(value, 'YYYY-MM-dd')
+          (prevState): Pick<DateInputState, 'focusDay' | 'value'> => {
+            const { value: prevValue } = prevState
+            const pd = PartialDate.from(prevValue, 'YYYY-MM-dd')
             pd[name](optionValue)
             pd.ensureDayOfMonth()
             this.raiseChange(event, pd)
@@ -1648,8 +1648,8 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
     const hasDate = type === 'date' || type === 'datetime'
     const phrases = this.getPhrases()
 
-    const monthId = id + '-month-label'
-    const yearId = id + '-year-label'
+    const currentMonthId = id + '-month-label'
+    const currentYearId = id + '-year-label'
     const timeId = id + '-time'
     const { month: focusMonth, year: focusYear, days } = this._getMonthData()
     const selectedStr = value.format('YYYY-MM-dd')
@@ -1727,7 +1727,7 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
             popupRef={this._portal}
             isOpen={!!isOpen}
             role="dialog"
-            aria-labelledby={`${monthId} ${yearId}`}
+            aria-labelledby={`${currentMonthId} ${currentYearId}`}
             onKeyDownCapture={this.handlePortalKeydownCapture}
           >
             <div onClick={this.handleCalendarClick}>
@@ -1749,7 +1749,7 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
                     aria-label={isOpen === 'calendar' ? phrases.showMonth : phrases.showCalendar}
                     aria-roledescription="toggles between calendar and month selectors"
                   >
-                    <span id={monthId}>
+                    <span id={currentMonthId}>
                       {phrases.months[focusMonth]
                         ? phrases.months[focusMonth].long
                         : phrases.months[PartialDate.from(new Date()).getMonth()].long}
@@ -1763,7 +1763,7 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
                     aria-label={isOpen === 'calendar' ? phrases.showYear : phrases.showCalendar}
                     aria-roledescription="toggles between calendar and year selectors"
                   >
-                    <span id={yearId}>{focusYear}</span>
+                    <span id={currentYearId}>{focusYear}</span>
                     <NavigationChevronDown data-is-open={isOpen} iconSize="tiny" ml={3} />
                   </YearSelect>
                 </Flex>

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -33,7 +33,7 @@ import KeyCodes from '../helpers/keyCodes'
 import getLocale from '../helpers/locale'
 import { usePositioning } from '../helpers/positionPopover'
 import positionPortal from '../helpers/positionPortal'
-import { boxShadow, textStyle } from '../helpers/theme'
+import { boxShadow, radius, textStyle } from '../helpers/theme'
 import IconButton from '../IconButton/IconButton'
 import { Status } from '../StatusMessage/StatusMessage'
 
@@ -225,20 +225,7 @@ const borderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
   `,
 }
 
-const inputShapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 8px;
-  `,
-  round: css`
-    border-radius: 20px;
-  `,
-}
-
 const getBorder = (borderSize: BorderSize): ReturnType<typeof css> => borderMap[borderSize]
-const getInputShape = (shape: Shape): ReturnType<typeof css> => inputShapeMap[shape]
 
 const InputWrapper = styled.div`
   position: relative;
@@ -249,7 +236,7 @@ const InputWrapper = styled.div`
   align-items: center;
   ${(p): ReturnType<typeof css> => getBorder(p.theme.border)}
   border-color: ${(p): string => p.theme.colors.darkestContrast};
-  ${(p): ReturnType<typeof css> => getInputShape(p.theme.shape)}
+  border-radius: ${radius(20)};
   background-color: ${(p): string => p.theme.colors.white};
   height: 36px;
   outline: none;

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -668,7 +668,7 @@ const FileInputBase = (props: FileInputProps): React.ReactElement => {
 
 export const FileInput = styled(FileInputBase)`
   box-sizing: border-box;
-  border-radius: ${radius};
+  border-radius: ${radius(8)};
   border: ${(p): string => (p.disabled ? 'none' : '2px dotted')};
   border-color: ${(p): string => p.theme.colors.darkestContrast};
   min-width: 300px;

--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -384,7 +384,7 @@ const MenuWrapper = styled.div`
   left: 0;
   outline: none;
   border: ${(p) => border(p.theme, 'lightContrast')};
-  border-radius: ${radius};
+  border-radius: ${radius(8)};
   ${(p) => boxShadow(p.theme, 1)};
   white-space: normal;
   flex-flow: column nowrap;

--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -16,13 +16,7 @@ import { margin, MarginProps } from 'styled-system'
 
 import { extractMargins } from '../helpers/omit'
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
-import { border, boxShadow, textStyle } from '../helpers/theme'
-
-const shapeMap = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 8px;',
-  round: 'border-radius: 20px;',
-}
+import { border, boxShadow, radius, textStyle } from '../helpers/theme'
 
 const dropShapeMap = {
   square: 'border-radius: 0 0 1px 1px;',
@@ -31,8 +25,6 @@ const dropShapeMap = {
 }
 
 type ThemeProps = { theme: CactusTheme }
-
-const getShape = ({ theme }: ThemeProps) => shapeMap[theme.shape]
 
 const getDropShape = ({ theme }: ThemeProps) => dropShapeMap[theme.shape]
 
@@ -191,7 +183,7 @@ const buttonVariantMap: VariantMap = {
         top: -5px;
         left: -5px;
         box-sizing: border-box;
-        ${getShape};
+        border-radius: ${radius(20)};
         border: ${(p) => border(p.theme, 'callToAction')};
       }
     }
@@ -218,7 +210,7 @@ const StyledButton = styled.button<MenuButtonProps>`
   position: relative;
   box-sizing: border-box;
   width: 100%;
-  ${getShape};
+  border-radius: ${radius(20)};
   border: ${(p) => border(p.theme, '')};
   padding: 2px 24px 2px 14px;
   outline: none;

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -6,8 +6,8 @@ import styled, { css } from 'styled-components'
 import { height, HeightProps, maxHeight, MaxHeightProps, width, WidthProps } from 'styled-system'
 
 import Flex from '../Flex/Flex'
-import { border, boxShadow } from '../helpers/theme'
 import variant from '../helpers/variant'
+import { border, boxShadow, radius } from '../helpers/theme'
 import IconButton from '../IconButton/IconButton'
 
 export type ModalType = 'action' | 'danger' | 'warning' | 'success'
@@ -24,12 +24,6 @@ export interface ModalProps extends WidthProps {
 }
 interface ModalPopupProps extends DialogProps, WidthProps, HeightProps, MaxHeightProps {
   variant: ModalType
-}
-
-const shapeMap = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 8px;',
-  round: 'border-radius: 20px;',
 }
 
 const Modalbase: FunctionComponent<ModalProps> = (props): React.ReactElement => {
@@ -96,7 +90,7 @@ export const ModalPopUp = styled(DialogOverlay).withConfig({
     flex-basis: ${(p) => !p.width && '100%'};
     width: ${(p) => !p.width && '100%'};
     border: ${(p) => border(p.theme, '')};
-    ${(p) => shapeMap[p.theme.shape]};
+    border-radius: ${radius(20)};
     background: white;
     ${(p): string => boxShadow(p.theme, 2)};
     margin: auto;

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -6,8 +6,8 @@ import styled, { css } from 'styled-components'
 import { height, HeightProps, maxHeight, MaxHeightProps, width, WidthProps } from 'styled-system'
 
 import Flex from '../Flex/Flex'
-import variant from '../helpers/variant'
 import { border, boxShadow, radius } from '../helpers/theme'
+import cssVariant from '../helpers/variant'
 import IconButton from '../IconButton/IconButton'
 
 export type ModalType = 'action' | 'danger' | 'warning' | 'success'
@@ -111,7 +111,7 @@ export const ModalPopUp = styled(DialogOverlay).withConfig({
         max-width: 100%;
       }
     }
-    ${variant({
+    ${cssVariant({
       action: css`
         border-color: ${(p): string => p.theme.colors.callToAction};
       `,

--- a/modules/cactus-web/src/Pagination/Pagination.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.tsx
@@ -200,17 +200,17 @@ Pagination.displayName = 'Pagination'
 
 Pagination.propTypes = {
   pageCount: function (props: Record<string, any>): Error | null {
-    const pageCount = parseInt(props.pageCount as any)
-    if (pageCount < 1 || pageCount !== parseFloat(props.pageCount as any)) {
+    const pageCount = parseInt(props.pageCount)
+    if (pageCount < 1 || pageCount !== parseFloat(props.pageCount)) {
       return new Error('Prop `pageCount` must be a positive integer')
     }
 
     return null
   },
   currentPage: function (props: Record<string, any>): Error | null {
-    const pageCount = parseInt(props.pageCount as any)
-    const current = parseInt(props.currentPage as any)
-    if (current < 1 || current > pageCount || current !== parseFloat(props.currentPage as any)) {
+    const pageCount = parseInt(props.pageCount)
+    const current = parseInt(props.currentPage)
+    if (current < 1 || current > pageCount || current !== parseFloat(props.currentPage)) {
       return new Error('Prop `currentPage` must be an integer in the range [1, `pageCount`]')
     }
 

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
@@ -77,26 +77,26 @@ export const RadioGroup = React.forwardRef<HTMLFieldSetElement, RadioGroupProps>
       forwardProps.disabled = disabled
     }
     const hasOnChange = !!props.onChange
-    const cloneWithValue = (element: React.ReactElement, props: any) => {
+    const cloneWithValue = (element: React.ReactElement, cloneProps: any) => {
       if (value !== undefined) {
         if (element.props.value !== undefined) {
-          props = { ...props, checked: element.props.value === value }
+          cloneProps = { ...cloneProps, checked: element.props.value === value }
         } else {
-          props = { ...props, value }
+          cloneProps = { ...cloneProps, value }
         }
       } else if (defaultValue !== undefined) {
         if (element.props.value !== undefined) {
-          props = { ...props, defaultChecked: element.props.value === defaultValue }
+          cloneProps = { ...cloneProps, defaultChecked: element.props.value === defaultValue }
         } else {
-          props = { ...props, defaultValue }
+          cloneProps = { ...cloneProps, defaultValue }
         }
       }
       // This is to avert a PropTypes warning regarding missing onChange handler.
-      const hasChecked = props.checked !== undefined || element.props.checked !== undefined
+      const hasChecked = cloneProps.checked !== undefined || element.props.checked !== undefined
       if (hasChecked && hasOnChange && !element.props.onChange) {
-        props = { ...props, onChange: noop }
+        cloneProps = { ...cloneProps, onChange: noop }
       }
-      return React.cloneElement(element, props)
+      return React.cloneElement(element, cloneProps)
     }
     children = cloneAll(children, forwardProps, cloneWithValue)
 

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1,7 +1,7 @@
 import '../helpers/polyfills'
 
 import { ActionsAdd, NavigationChevronDown } from '@repay/cactus-icons'
-import { BorderSize, CactusTheme, ColorStyle, Shape, TextStyle } from '@repay/cactus-theme'
+import { BorderSize, CactusTheme, ColorStyle, TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { useLayoutEffect, useRef, useState } from 'react'
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
@@ -20,7 +20,7 @@ import {
 import KeyCodes from '../helpers/keyCodes'
 import { omitMargins } from '../helpers/omit'
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
-import { boxShadow, fontSize, textStyle } from '../helpers/theme'
+import { boxShadow, fontSize, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 import Tag from '../Tag/Tag'
 import TextButton from '../TextButton/TextButton'
@@ -230,20 +230,7 @@ const borderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
   `,
 }
 
-const shapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 8px;
-  `,
-  round: css`
-    border-radius: 20px;
-  `,
-}
-
 const getBorder = (borderSize: BorderSize): ReturnType<typeof css> => borderMap[borderSize]
-const getShape = (shape: Shape): ReturnType<typeof css> => shapeMap[shape]
 
 const SelectTrigger = styled.button`
   position: relative;
@@ -253,7 +240,7 @@ const SelectTrigger = styled.button`
   height: 32px;
   padding: 0 28px 0 16px;
   background-color: transparent;
-  ${(p): ReturnType<typeof css> => getShape(p.theme.shape)}
+  border-radius: ${radius(20)};
   ${(p): ReturnType<typeof css> => getBorder(p.theme.border)}
   border-style: solid;
   border-color: ${(p): string => p.theme.colors.darkContrast};
@@ -299,7 +286,7 @@ const ComboInput = styled.input`
   height: 32px;
   padding: 0 24px 0 16px;
   background-color: transparent;
-  ${(p): ReturnType<typeof css> => getShape(p.theme.shape)}
+  border-radius: ${radius(20)};
   ${(p): ReturnType<typeof css> => getBorder(p.theme.border)}
   border-style: solid;
   border-color: ${(p): string => p.theme.colors.darkContrast};
@@ -323,19 +310,6 @@ function responsiveHeight(): number {
   return (typeof window !== 'undefined' && window.innerHeight * 0.4) || 0
 }
 
-const listShapeMap: { [K in Shape]: ReturnType<typeof css> } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 4px;
-  `,
-  round: css`
-    border-radius: 8px;
-  `,
-}
-
-const getListShape = (shape: Shape): ReturnType<typeof css> => listShapeMap[shape]
 const getListBoxShadowStyles = (theme: CactusTheme): ReturnType<typeof css> => {
   return theme.boxShadows
     ? css`
@@ -358,7 +332,7 @@ const StyledList = styled.ul`
   margin-bottom: 0;
   overflow-y: auto;
   outline: none;
-  ${(p): ReturnType<typeof css> => getListShape(p.theme.shape)}
+  border-radius: ${radius(8)};
   ${(p): ReturnType<typeof css> => getListBoxShadowStyles(p.theme)}
   border-style: solid;
   ${(): string =>
@@ -444,7 +418,7 @@ const StyledListWrapper = styled.div`
   &[aria-hidden='true'] {
     display: none;
   }
-  ${(p): ReturnType<typeof css> => getListShape(p.theme.shape)}
+  border-radius: ${radius(8)};
   max-height: 400px;
   max-width: 100vw;
   ${(p): string => boxShadow(p.theme, 1)};

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React, { useLayoutEffect, useRef, useState } from 'react'
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
-import { width, WidthProps } from 'styled-system'
+import { width as styledSystemWidth, WidthProps } from 'styled-system'
 
 import CheckBox from '../CheckBox/CheckBox'
 import Flex from '../Flex/Flex'
@@ -20,6 +20,7 @@ import {
 import KeyCodes from '../helpers/keyCodes'
 import { omitMargins } from '../helpers/omit'
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
+import { textFieldStatusMap } from '../helpers/status'
 import { boxShadow, fontSize, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 import Tag from '../Tag/Tag'
@@ -67,23 +68,6 @@ export interface SelectProps
   onFocus?: React.FocusEventHandler<Target>
 }
 
-type StatusMap = { [K in Status]: ReturnType<typeof css> }
-
-const statusMap: StatusMap = {
-  success: css`
-    border-color: ${(p): string => p.theme.colors.success};
-    background: ${(p): string => p.theme.colors.transparentSuccess};
-  `,
-  warning: css`
-    border-color: ${(p): string => p.theme.colors.warning};
-    background: ${(p): string => p.theme.colors.transparentWarning};
-  `,
-  error: css`
-    border-color: ${(p): string => p.theme.colors.error};
-    background: ${(p): string => p.theme.colors.transparentError};
-  `,
-}
-
 // Thank you, Stack Overflow https://stackoverflow.com/questions/49986720/how-to-detect-internet-explorer-11-and-below-versions
 const isIE = () => {
   const ua = window.navigator.userAgent //Check the userAgent property of the window.navigator object
@@ -93,10 +77,9 @@ const isIE = () => {
   return msie > 0 || trident > 0
 }
 
-// @ts-ignore
-const displayStatus: any = (props): ReturnType<typeof css> | string => {
+const displayStatus: any = (props: SelectProps): ReturnType<typeof css> | string => {
   if (props.status && !props.disabled) {
-    return statusMap[props.status as Status]
+    return textFieldStatusMap[props.status as Status]
   } else {
     return ''
   }
@@ -611,7 +594,7 @@ class List extends React.Component<ListProps, ListState> {
     const currentTarget = event.currentTarget
     // prevent triggering by automated scrolling
     if (!this.didScroll) {
-      this.setActiveDescendant(currentTarget.id as string)
+      this.setActiveDescendant(currentTarget.id)
     }
   }
 
@@ -904,7 +887,7 @@ function asOption(opt: number | string | OptionType): OptionType {
     const option: OptionType = { label: String(opt), value: opt }
     return option
   }
-  return opt as OptionType
+  return opt
 }
 
 function getOptionId(selectId: string, option: OptionType): string {
@@ -1070,7 +1053,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     }
     if (target.getAttribute('role') === 'option') {
       event.preventDefault()
-      const activeId = target.id as string
+      const activeId = target.id
       const active = this.getExtOptions().find((o): boolean => o.id === activeId)
 
       this.raiseChange(event, active || null)
@@ -1486,7 +1469,7 @@ export const Select = styled(SelectBase)`
     border-color: ${(p) => p.disabled && p.theme.colors.lightGray};
   }
   ${margin}
-  ${width}
+  ${styledSystemWidth}
   ${SelectTrigger} {
     ${displayStatus}
   }

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import { margin, MarginProps, width, WidthProps } from 'styled-system'
+import { margin, MarginProps, width as styledSystemWidth, WidthProps } from 'styled-system'
 
 import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import { omitMargins } from '../helpers/omit'
@@ -55,12 +55,19 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
     >
-      {({ fieldId, labelId, name, ariaDescribedBy, status, disabled }): React.ReactElement => (
+      {({
+        fieldId,
+        labelId,
+        name: accessibilityName,
+        ariaDescribedBy,
+        status,
+        disabled: accessibilityDisabled,
+      }): React.ReactElement => (
         <Select
           {...rest}
-          disabled={disabled}
+          disabled={accessibilityDisabled}
           status={status}
-          name={name}
+          name={accessibilityName}
           id={fieldId}
           aria-labelledby={labelId}
           aria-describedby={ariaDescribedBy}
@@ -74,7 +81,7 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
 export const SelectField = styled(SelectFieldBase)`
   position: relative;
   ${margin}
-  ${width}
+  ${styledSystemWidth}
 
   ${Select} {
     width: 100%;

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -14,8 +14,8 @@ import styled, { createGlobalStyle, css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
-import { border, boxShadow, textStyle } from '../helpers/theme'
 import variant from '../helpers/variant'
+import { border, boxShadow, radius, textStyle } from '../helpers/theme'
 
 export type SplitButtonVariant = 'standard' | 'danger' | 'success'
 export interface IconProps {
@@ -154,16 +154,10 @@ const SplitButtonStyles = createGlobalStyle`
   }
 `
 
-const dropdownShapeMap: { [K in Shape]: string } = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 4px;',
-  round: 'border-radius: 8px;',
-}
-
 const SplitButtonList = styled(ReachMenuItems)<VariantInterface>`
   padding: 8px 0;
   outline: none;
-  ${(p) => dropdownShapeMap[p.theme.shape]}
+  border-radius: ${radius(8)};
   ${(p): string => boxShadow(p.theme, 1)};
   background-color: ${(p): string => p.theme.colors.white};
   border: ${(p) => (!p.theme.boxShadows ? border(p.theme, 'lightContrast') : '0')};

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -14,8 +14,8 @@ import styled, { createGlobalStyle, css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
-import variant from '../helpers/variant'
 import { border, boxShadow, radius, textStyle } from '../helpers/theme'
+import cssVariant from '../helpers/variant'
 
 export type SplitButtonVariant = 'standard' | 'danger' | 'success'
 export interface IconProps {
@@ -57,7 +57,7 @@ const mainShapeMap: { [K in Shape]: string } = {
   round: 'border-radius: 20px 1px 1px 20px;',
 }
 
-const getVariantDark = variant({
+const getVariantDark = cssVariant({
   standard: css`
     ${(p): ColorStyle => p.theme.colorStyles.callToAction};
   `,
@@ -105,7 +105,7 @@ const MainActionButton = styled.button<VariantInterface>`
   ${(p) => p.disabled && p.theme.colorStyles.disable}
 
     &.dd-closed {
-    ${variant({
+    ${cssVariant({
       standard: css`
         border-color: ${(p): string => p.theme.colors.darkestContrast};
       `,
@@ -119,7 +119,7 @@ const MainActionButton = styled.button<VariantInterface>`
 
     &:hover,
       &:focus {
-      ${variant({
+      ${cssVariant({
         standard: css`
           border-color: ${(p): string => p.theme.colors.callToAction};
         `,
@@ -134,7 +134,7 @@ const MainActionButton = styled.button<VariantInterface>`
   }
 
   &.dd-open {
-    ${variant({
+    ${cssVariant({
       standard: css`
         border-color: ${(p): string => p.theme.colors.callToAction};
       `,
@@ -198,16 +198,10 @@ const DropdownButton = styled(ReachMenuButton)<VariantInterface>`
   ${(p) =>
     p.disabled
       ? p.theme.colorStyles.disable
-      : variant({
-          standard: css`
-            ${(p): ColorStyle => p.theme.colorStyles.darkestContrast};
-          `,
-          danger: css`
-            ${(p): ColorStyle => p.theme.colorStyles.error};
-          `,
-          success: css`
-            ${(p): ColorStyle => p.theme.colorStyles.success};
-          `,
+      : cssVariant({
+          standard: p.theme.colorStyles.darkestContrast,
+          danger: p.theme.colorStyles.error,
+          success: p.theme.colorStyles.success,
         })};
 
   ${(p): string =>

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -1,11 +1,17 @@
-import { CactusTheme, ColorStyle, Shape, TextStyle } from '@repay/cactus-theme'
+import { CactusTheme, ColorStyle, TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { createContext, useContext, useLayoutEffect } from 'react'
-import styled, { css, FlattenSimpleInterpolation, ThemeProps } from 'styled-components'
+import styled, {
+  css,
+  DefaultTheme,
+  FlattenInterpolation,
+  FlattenSimpleInterpolation,
+  ThemeProps,
+} from 'styled-components'
 import { width, WidthProps } from 'styled-system'
 
 import { useMergedRefs } from '../helpers/react'
-import { border, boxShadow, media, textStyle } from '../helpers/theme'
+import { border, boxShadow, media, radius, textStyle } from '../helpers/theme'
 import variant from '../helpers/variant'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
 
@@ -249,14 +255,8 @@ Table.defaultProps = {
 
 export default DefaultTable
 
-const shapeMap = {
-  square: '1px',
-  intermediate: '4px',
-  round: '8px',
-}
-
-const getShape = (shape: Shape, location: BorderCorner): string =>
-  `border-${location}-radius: ${shapeMap[shape]}`
+const getShape = (location: BorderCorner): FlattenInterpolation<ThemeProps<DefaultTheme>> =>
+  css`border-${location}-radius: ${radius(8)}`
 
 const HeaderBox = styled.div.attrs({ 'aria-hidden': 'true' })`
   text-transform: uppercase;
@@ -403,10 +403,10 @@ const table = css<TableProps>`
     td {
       border-top-color: ${(p): string => p.theme.colors.lightContrast};
       :first-child {
-        ${(p): string => getShape(p.theme.shape, 'top-left')};
+        ${getShape('top-left')};
       }
       :last-child {
-        ${(p): string => getShape(p.theme.shape, 'top-right')};
+        ${getShape('top-right')};
       }
     }
   }
@@ -430,10 +430,10 @@ const table = css<TableProps>`
       td {
         border-bottom-color: ${(p): string => p.theme.colors.lightContrast};
         :first-child {
-          ${(p): string => getShape(p.theme.shape, 'bottom-left')};
+          ${getShape('bottom-left')};
         }
         :last-child {
-          ${(p): string => getShape(p.theme.shape, 'bottom-right')};
+          ${getShape('bottom-right')};
         }
       }
     }
@@ -459,7 +459,7 @@ const card = css`
     ${(p): string => boxShadow(p.theme, 1)};
     background-color: ${(p): string => p.theme.colors.white};
     border: ${(p): string => border(p.theme, 'lightContrast')};
-    border-radius: ${(p): string => shapeMap[p.theme.shape]};
+    border-radius: ${radius(8)};
     margin: 4px;
     outline: 0;
     :focus {

--- a/modules/cactus-web/src/Tabs/Tabs.story.tsx
+++ b/modules/cactus-web/src/Tabs/Tabs.story.tsx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/react/types-6-0'
 import { Page } from 'puppeteer'
 import React from 'react'
 
-import { JustifyContent, justifyOptions } from '../Flex/Flex'
+import { justifyOptions } from '../Flex/Flex'
 import { Tab, TabController, TabList, TabPanel } from './Tabs'
 
 const LABELS = [
@@ -38,7 +38,7 @@ export default {
 export const BasicUsage = (): React.ReactElement => {
   const breadth = number('Tab Count', 6)
   const fullWidth = boolean('Full Width', true)
-  const justify = select('Justify Content', justifyOptions, 'space-evenly') as JustifyContent
+  const justify = select('Justify Content', justifyOptions, 'space-evenly')
   const fillGaps = boolean('Fill Gaps', false)
   const [active, setActive] = React.useState(-1)
 
@@ -70,7 +70,7 @@ export const BasicUsage = (): React.ReactElement => {
 }
 
 export const WithController = (): React.ReactElement => {
-  const justify = select('Justify Content', justifyOptions, 'space-evenly') as JustifyContent
+  const justify = select('Justify Content', justifyOptions, 'space-evenly')
   return (
     <TabController id="the-tabs" initialTabId="the-tabs-name-tab">
       <TabList justifyContent={justify}>

--- a/modules/cactus-web/src/Tabs/Tabs.tsx
+++ b/modules/cactus-web/src/Tabs/Tabs.tsx
@@ -166,7 +166,7 @@ export const TabController: React.FC<TabControllerProps> = ({
 const generateId = (...parts: (string | undefined)[]): string => parts.filter(Boolean).join('-')
 
 const getTabs = (root: HTMLElement) =>
-  Array.from(root.querySelectorAll('[role="tab"]')) as HTMLElement[]
+  Array.from(root.querySelectorAll<HTMLElement>('[role="tab"]'))
 
 const getScrollInfo: GetScrollInfo = (list) => ({
   listWrapper: list.parentElement as HTMLElement,

--- a/modules/cactus-web/src/Tag/Tag.tsx
+++ b/modules/cactus-web/src/Tag/Tag.tsx
@@ -1,11 +1,11 @@
 import { NavigationClose } from '@repay/cactus-icons'
-import { Shape, TextStyle } from '@repay/cactus-theme'
+import { TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, CSSObject, FlattenSimpleInterpolation } from 'styled-components'
+import styled, { CSSObject, FlattenSimpleInterpolation } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { textStyle } from '../helpers/theme'
+import { radius, textStyle } from '../helpers/theme'
 
 interface TagProps extends MarginProps {
   id?: string
@@ -29,25 +29,12 @@ const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
   }
 )
 
-const valueShapeMap: { [K in Shape]: FlattenSimpleInterpolation } = {
-  square: css`
-    border-radius: 1px;
-  `,
-  intermediate: css`
-    border-radius: 4px;
-  `,
-  round: css`
-    border-radius: 8px;
-  `,
-}
-const getValueShape = (shape: Shape): FlattenSimpleInterpolation => valueShapeMap[shape]
-
 export const Tag = styled(TagBase)`
   box-sizing: border-box;
   ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'small')};
   padding: 0 8px 0 8px;
   border: 1px solid ${(p): string => p.theme.colors.lightContrast};
-  ${(p): FlattenSimpleInterpolation => getValueShape(p.theme.shape as Shape)}
+  border-radius: ${radius(8)};
   margin-right: 2px;
   display: inline-block;
   height: 24px;

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -1,11 +1,11 @@
-import { CactusTheme, Shape } from '@repay/cactus-theme'
+import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { border, textStyle } from '../helpers/theme'
+import { border, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
 export interface TextAreaProps
@@ -45,15 +45,9 @@ const displayStatus = (
   }
 }
 
-const shapeMap: { [K in Shape]: string } = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 4px;',
-  round: 'border-radius: 8px;',
-}
-
 const Area = styled.textarea<TextAreaProps>`
   border: ${(p) => border(p.theme, p.disabled ? 'lightGray' : 'darkContrast')};
-  ${(p) => shapeMap[p.theme.shape]}
+  border-radius: ${radius(8)};
   min-height: 100px;
   ${(p): string => (p.theme.mediaQueries ? p.theme.mediaQueries.small : '')} {
     min-width: 336px;

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -1,10 +1,11 @@
 import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
+import styled, { FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
+import { textFieldStatusMap } from '../helpers/status'
 import { border, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
@@ -18,28 +19,11 @@ export interface TextAreaProps
   resize?: boolean
 }
 
-type StatusMap = { [K in Status]: FlattenInterpolation<ThemeProps<CactusTheme>> }
-
-const statusMap: StatusMap = {
-  success: css`
-    border-color: ${(p): string => p.theme.colors.success};
-    background: ${(p): string => p.theme.colors.transparentSuccess};
-  `,
-  warning: css`
-    border-color: ${(p): string => p.theme.colors.warning};
-    background: ${(p): string => p.theme.colors.transparentWarning};
-  `,
-  error: css`
-    border-color: ${(p): string => p.theme.colors.error};
-    background: ${(p): string => p.theme.colors.transparentError};
-  `,
-}
-
 const displayStatus = (
   props: TextAreaProps
 ): FlattenInterpolation<ThemeProps<CactusTheme>> | string => {
   if (props.status && !props.disabled) {
-    return statusMap[props.status]
+    return textFieldStatusMap[props.status]
   } else {
     return ''
   }

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -46,9 +46,14 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
     >
-      {({ fieldId, status, ariaDescribedBy, disabled }): React.ReactElement => (
+      {({
+        fieldId,
+        status,
+        ariaDescribedBy,
+        disabled: accessibilityDisabled,
+      }): React.ReactElement => (
         <TextArea
-          disabled={disabled}
+          disabled={accessibilityDisabled}
           id={fieldId}
           width="100%"
           status={status}

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { border, textStyle } from '../helpers/theme'
+import { border, radius, textStyle } from '../helpers/theme'
 
 export type TextButtonVariants = 'standard' | 'action' | 'danger'
 
@@ -27,12 +27,6 @@ const variantMap: VariantMap = {
   danger: css`
     color: ${(p): string => p.theme.colors.error};
   `,
-}
-
-const shapeMap = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 8px;',
-  round: 'border-radius: 20px;',
 }
 
 const inverseVariantMap: VariantMap = {
@@ -90,7 +84,7 @@ export const TextButton = styled.button<TextButtonProps>`
       top: 0px;
       left: 0px;
       border: ${(p) => border(p.theme, 'callToAction')};
-      ${(p) => shapeMap[p.theme.shape]};
+      border-radius: ${radius(20)};
     }
   }
 

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -5,7 +5,7 @@ import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { border, textStyle } from '../helpers/theme'
+import { border, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
 export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
@@ -56,16 +56,10 @@ const TextInputBase = React.forwardRef<HTMLInputElement, TextInputProps>(
   }
 )
 
-const shapeMap: { [K in Shape]: string } = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 8px;',
-  round: 'border-radius: 20px;',
-}
-
 const Input = styled.input<InputProps>`
   box-sizing: border-box;
   border: ${(p) => border(p.theme, p.disabled ? 'lightGray' : 'darkContrast')};
-  ${(p) => shapeMap[p.theme.shape]};
+  border-radius: ${radius(20)};
   height: 32px;
   outline: none;
   box-sizing: border-box;

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -1,10 +1,11 @@
-import { CactusTheme, ColorStyle, Shape } from '@repay/cactus-theme'
+import { ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
+import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
+import { textFieldStatusMap } from '../helpers/status'
 import { border, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
@@ -19,26 +20,9 @@ interface InputProps {
   status?: Status | null
 }
 
-type StatusMap = { [K in Status]: FlattenInterpolation<ThemeProps<CactusTheme>> }
-
-const statusMap: StatusMap = {
-  success: css`
-    border-color: ${(p): string => p.theme.colors.success};
-    background: ${(p): string => p.theme.colors.transparentSuccess};
-  `,
-  warning: css`
-    border-color: ${(p): string => p.theme.colors.warning};
-    background: ${(p): string => p.theme.colors.transparentWarning};
-  `,
-  error: css`
-    border-color: ${(p): string => p.theme.colors.error};
-    background: ${(p): string => p.theme.colors.transparentError};
-  `,
-}
-
 const displayStatus = (props: TextInputProps) => {
   if (props.status && !props.disabled) {
-    return statusMap[props.status]
+    return textFieldStatusMap[props.status]
   } else {
     return ''
   }

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -46,10 +46,15 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
     >
-      {({ fieldId, status, ariaDescribedBy, disabled }): React.ReactElement => (
+      {({
+        fieldId,
+        status,
+        ariaDescribedBy,
+        disabled: accessibilityDisabled,
+      }): React.ReactElement => (
         <TextInput
           {...inputProps}
-          disabled={disabled}
+          disabled={accessibilityDisabled}
           id={fieldId}
           width="100%"
           status={status}

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -2,14 +2,14 @@ import { Position } from '@reach/popover'
 import { TooltipPopup as ReachTooltipPopup, useTooltip } from '@reach/tooltip'
 import VisuallyHidden from '@reach/visually-hidden'
 import { NotificationInfo } from '@repay/cactus-icons'
-import { ColorStyle, Shape } from '@repay/cactus-theme'
+import { ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { cloneElement, useEffect, useRef, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { getScrollX, getScrollY } from '../helpers/scrollOffset'
-import { border, boxShadow } from '../helpers/theme'
+import { border, boxShadow, radius } from '../helpers/theme'
 
 interface TooltipProps extends MarginProps {
   /** Text to be displayed */
@@ -173,11 +173,6 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
     </>
   )
 }
-const shapeMap: { [K in Shape]: string } = {
-  square: 'border-radius: 1px;',
-  intermediate: 'border-radius: 4px;',
-  round: 'border-radius: 8px;',
-}
 
 export const TooltipPopup = styled(ReachTooltipPopup)`
   z-index: 100;
@@ -190,7 +185,7 @@ export const TooltipPopup = styled(ReachTooltipPopup)`
   overflow-wrap: break-word;
   word-wrap: break-word;
   border: ${(p) => border(p.theme, 'callToAction')};
-  ${(p): string => shapeMap[p.theme.shape]}
+  border-radius: ${radius(8)};
 `
 
 export const Tooltip = styled(TooltipBase)`

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -582,16 +582,16 @@ export class PartialDate implements FormatTokenMap {
 
   public isValid(): boolean {
     const type = this._type
-    const isValidDate =
+    const isDateValid =
       type === 'time' ||
       ([this.year, this.month, this.day].every(isNumber) && this.isDayOfMonth(this.day || 0))
-    const isValidTime =
+    const isTimeValid =
       type === 'date' ||
       (this.hours !== undefined &&
         this.minutes !== undefined &&
         (!this._format.includes('aa') || this.period !== undefined))
 
-    return isValidDate && isValidTime
+    return isDateValid && isTimeValid
   }
 
   public isDayOfMonth(day: number): boolean {

--- a/modules/cactus-web/src/helpers/focus.ts
+++ b/modules/cactus-web/src/helpers/focus.ts
@@ -19,7 +19,7 @@ export function getFocusable(root?: Element | Document): FocusList {
   } else {
     searchFrom = document
   }
-  const result = Array.from(searchFrom.querySelectorAll(FOCUS_SELECTOR)) as HTMLElement[]
+  const result = Array.from(searchFrom.querySelectorAll<HTMLElement>(FOCUS_SELECTOR))
   return result.filter((el) => !(el.hasAttribute('tabindex') && el.tabIndex < 0))
 }
 
@@ -78,18 +78,18 @@ export function useFocusControl(focusControl: FocusControl = getFocusable, rootI
 
   const setFocus = React.useCallback<FocusSetter>(
     (focusHint, opts = {}) => {
-      const { state, focusControl } = box
-      const { shift = false, delay = false, control = focusControl } = opts
+      const { state: boxState, focusControl: boxFocusControl } = box
+      const { shift = false, delay = false, control = boxFocusControl } = opts
       // No point in delaying setting the state to null.
       if (delay && focusHint !== null) {
-        return setState({ ...state, focusHint, shift, control })
+        return setState({ ...boxState, focusHint, shift, control })
       }
       // Modify in-place to prevent re-render; in truth, we treat this more
       // like a ref than state, but `delay` is easier to implement this way.
-      state.focusHint = focusHint
-      state.shift = shift
-      state.control = control
-      applyFocusState(state, focusRootRef.current)
+      boxState.focusHint = focusHint
+      boxState.shift = shift
+      boxState.control = control
+      applyFocusState(boxState, focusRootRef.current)
     },
     [box, focusRootRef, setState]
   )
@@ -114,7 +114,7 @@ function applyFocusState(state: FocusState, focusRoot: RootHint) {
     if (focus instanceof HTMLElement) {
       focusElement = focus
     } else if (focus?.length) {
-      const nextIndex = getFocusIndex(focus as FocusList, state as SearchState)
+      const nextIndex = getFocusIndex(focus, state as SearchState)
       if (nextIndex !== undefined) {
         focusIndex = wrapIndex(nextIndex, focus.length)
         focusElement = focus[focusIndex]

--- a/modules/cactus-web/src/helpers/react.ts
+++ b/modules/cactus-web/src/helpers/react.ts
@@ -10,9 +10,9 @@ export function cloneAll(
 ): React.ReactChild[] {
   const hasKeyPrefix = cloneProps && (cloneProps.key || cloneProps.key === 0)
   const childArray = React.Children.toArray(children) as React.ReactChild[]
-  return childArray.reduce((children, child, index) => {
+  return childArray.reduce((returnVal, child, index) => {
     if (!child || typeof child === 'string' || typeof child === 'number') {
-      children.push(child)
+      returnVal.push(child)
     } else {
       const key = hasKeyPrefix ? `${cloneProps?.key}${child.key}` : child.key
       let props: Record<string, any> | undefined
@@ -23,13 +23,13 @@ export function cloneAll(
       }
       if (child.type === React.Fragment) {
         if (child.props.children) {
-          children.push(...cloneAll(child.props.children, props, makeClone))
+          returnVal.push(...cloneAll(child.props.children, props, makeClone))
         }
       } else {
-        children.push(makeClone(child, props, index))
+        returnVal.push(makeClone(child, props, index))
       }
     }
-    return children
+    return returnVal
   }, [] as React.ReactChild[])
 }
 

--- a/modules/cactus-web/src/helpers/scroll.ts
+++ b/modules/cactus-web/src/helpers/scroll.ts
@@ -57,7 +57,7 @@ export function useScroll<T extends HTMLElement>(
       const getMappedRect = isHorizontal ? getRect : getVerticalRect
       const scrollOffset = isHorizontal ? 'scrollLeft' : 'scrollTop'
 
-      const updateScrollState = (scroll: Scroll, target?: number | HTMLElement): Scroll => {
+      const updateScrollState = (scrollState: Scroll, target?: number | HTMLElement): Scroll => {
         const { listWrapper, buttonWidth, listItems } = getScrollInfo(list)
 
         const parentRect = getMappedRect(listWrapper)
@@ -66,14 +66,14 @@ export function useScroll<T extends HTMLElement>(
           return DEFAULT_SCROLL
         }
         let offset = 0
-        let nextIndex: number = scroll.currentIndex
+        let nextIndex: number = scrollState.currentIndex
         const currentOffset = list[scrollOffset]
         const visibleWidth = parentRect.width - buttonWidth * 2
         const itemRects = listItems.map(getMappedRect)
         if (typeof target === 'object') {
           nextIndex = listItems.indexOf(target)
           if (nextIndex < 0) {
-            return scroll
+            return scrollState
           } else if (nextIndex > 0) {
             const itemRect = itemRects[nextIndex]
             const visibleLeft = parentRect.left + buttonWidth
@@ -115,19 +115,19 @@ export function useScroll<T extends HTMLElement>(
           }
         } else {
           // No target, keep the offset the same.
-          offset = scroll.offset
+          offset = scrollState.offset
         }
 
         // Set the actual scroll offset on the list.
         if (!equals(offset, currentOffset)) {
           list[scrollOffset] = offset
         } else if (
-          equals(offset, scroll.offset) &&
-          scroll.showScroll &&
-          nextIndex === scroll.currentIndex
+          equals(offset, scrollState.offset) &&
+          scrollState.showScroll &&
+          nextIndex === scrollState.currentIndex
         ) {
           // If the offset/index state is unchanged, don't update the state.
-          return scroll
+          return scrollState
         }
         const result: Scroll = {
           offset,

--- a/modules/cactus-web/src/helpers/status.ts
+++ b/modules/cactus-web/src/helpers/status.ts
@@ -1,0 +1,20 @@
+import { css } from 'styled-components'
+
+import { Status } from '../StatusMessage/StatusMessage'
+
+type StatusMap = { [K in Status]: ReturnType<typeof css> }
+
+export const textFieldStatusMap: StatusMap = {
+  success: css`
+    border-color: ${(p): string => p.theme.colors.success};
+    background: ${(p): string => p.theme.colors.transparentSuccess};
+  `,
+  warning: css`
+    border-color: ${(p): string => p.theme.colors.warning};
+    background: ${(p): string => p.theme.colors.transparentWarning};
+  `,
+  error: css`
+    border-color: ${(p): string => p.theme.colors.error};
+    background: ${(p): string => p.theme.colors.transparentError};
+  `,
+}

--- a/modules/cactus-web/src/helpers/storybookActionsWorkaround.ts
+++ b/modules/cactus-web/src/helpers/storybookActionsWorkaround.ts
@@ -1,7 +1,9 @@
 import { action, HandlerFunction } from '@storybook/addon-actions'
 
 // Workaround for https://github.com/storybookjs/storybook/issues/6471
-const setUpActionsWorkaround = (...names: string[]): { [K in string[number]]: HandlerFunction } =>
+const storybookActionsWorkaround = (
+  ...names: string[]
+): { [K in string[number]]: HandlerFunction } =>
   names.reduce((modifiedActions, actionName) => {
     const beacon = action(actionName)
     const modifiedActionFn = (eventObj: Record<string, unknown>, ...args: unknown[]) => {
@@ -13,4 +15,4 @@ const setUpActionsWorkaround = (...names: string[]): { [K in string[number]]: Ha
     }
   }, {})
 
-export default setUpActionsWorkaround
+export default storybookActionsWorkaround

--- a/modules/cactus-web/src/helpers/theme.ts
+++ b/modules/cactus-web/src/helpers/theme.ts
@@ -2,6 +2,7 @@ import {
   CactusColor,
   CactusTheme,
   ColorStyle,
+  Shape,
   TextStyle,
   TextStyleCollection,
 } from '@repay/cactus-theme'
@@ -38,14 +39,23 @@ export const insetBorder = (theme: CactusTheme, color: string, direction?: Direc
   return `box-shadow: inset ${hOffset}px ${vOffset}px 0px ${spread}px ${color}`
 }
 
-const radii = {
-  square: '1px',
-  intermediate: '4px',
-  round: '8px',
+type MaxRadius = 8 | 20
+
+const radiiMap: Record<MaxRadius, Record<Shape, string>> = {
+  8: {
+    square: '1px',
+    intermediate: '4px',
+    round: '8px',
+  },
+  20: {
+    square: '1px',
+    intermediate: '8px',
+    round: '20px',
+  },
 }
 
-// There are elements with other radius patterns, but this seems like the most common.
-export const radius = ({ theme }: Props): string => radii[theme.shape]
+export const radius = (maxRadius: MaxRadius) => ({ theme }: Props): string =>
+  radiiMap[maxRadius][theme.shape]
 
 export const invertColors = (style: ColorStyle): ColorStyle => {
   return { color: style.backgroundColor, backgroundColor: style.color }


### PR DESCRIPTION
There are two parts to this:
1. Cleaning up generic SonarQube code smells
2. Removing some flagged duplications by allowing the `radius` helper to account for multiple themed border-radius configs.

### Testing

Check that the border radius properly responds to changes in the theme shape on the following components:
- Accordion
- Box (with `borderRadius` prop set to `themed`)
- BrandBar (dropdown user menu)
- Button (including focus outline)
- DataGrid (table shape and header buttons)
- DateInput
- FileInput
- MenuBar (dropdowns)
- MenuButton (including focus outline)
- Modal
- Select (input, dropdown, and combo input)
- SplitButton
- Table
- Tag
- TextArea
- TextButton (focus outline)
- TextInput
- Tooltip (the popup)

For the other changes, make sure the following components still function correctly:
- Accordion (controlled and uncontrolled outline variants)
- DateInput
- Layout (check that focusing still works as expected with menus and the action bar panel)
- MenuBar (check the scroll arrows)
- Modal (just be sure the variants work)
- RadioGroup
- SelectField (make sure the status styling with error/success/warning still works -- also ensure that the disabled styling still works)
- SplitButton (just test that the variants work)
- TextAreaField (same stuff as SelectField)
- TextInputField (ditto)