### PR TITLE
CACTUS-497: support complex options in Select component

### DIFF
--- a/examples/mock-ebpp/tests/date-input-integration.test.ts
+++ b/examples/mock-ebpp/tests/date-input-integration.test.ts
@@ -34,7 +34,7 @@ const scopedSelector = (container: string, selector: string) =>
 
 const selectType = async (t: TestController, itype: string) => {
   await t.click('#input-type')
-  await t.click(`#input-type-${itype}-${itype}`)
+  await t.click(`#input-type-${itype}`)
 }
 
 const dateInput = '[aria-labelledby="date-test-label"]'

--- a/modules/cactus-web/src/Select/Select.mdx
+++ b/modules/cactus-web/src/Select/Select.mdx
@@ -30,21 +30,60 @@ export const code = `<Select
 ## Best practices
 
 - For accessibility, The `Select` component should be used in coordination with a `Label` where the `id` on the `Select` is passed as `htmlFor` on the `Label`.
-- The option values should be a unique set.
+- The option values are expected be a unique set.
 
 ## Basic usage
 
-The `Select` element requires options be provided as an array. They can be either an array of strings which represent both the option value and label, or as an object where the value and label are provided separately.
+There are three ways you can pass options to the Select:
+- An array of values in the `options` prop, where the value is also used as the label.
+- An array of objects in the `options` prop, each of which has a `label` and a `value`.
+- As children, similar to a regular HTML select element.
 
 ```js
-let options = ['provide options', 'as and array', 'of strings']
+<Select options={['provide options', 'as and array', 'of strings']} />
 // OR
-let options = [
-  // both label and value must be
-  { label: 'Provide Options', value: 'provide-options' },
-  { label: 'As an Array', value: 'as-an-array' },
-  { label: 'of objects', value: 'of-objects' },
-]
+<Select
+  options={[
+    { label: 'Provide Options', value: 'provide-options' },
+    { label: 'As an Array', value: 'as-an-array' },
+    { label: 'of objects', value: 'of-objects' },
+  ]}
+/>
+// OR
+<Select>
+  <Select.Option value="child">Child Option Label</Select.Option>
+</Select>
+```
+
+**Important:** If you pass options-as-children, there are a few things to be aware of:
+- The label can include complex content such as images.
+  - It's up to the dev to ensure it doesn't look bad with the Select's default styles/appearance.
+  - Non-text content will only appear in the options when the Select is open; when it's closed only the text content of the selected value will be shown.
+  - If you want to override the text shown for selected values, use the `altText` prop, or the `aria-label` prop if there is one.
+- The elements you pass as children **are not directly rendered;** instead their props are extracted and used to create the real options. The recognized props are:
+  - `value` is required, can be a string or a number
+  - `children` is used as the label; if omitted, the `value` will be used for the label
+  - `id` can be used to override the default generated ID for the option
+  - `altText` is an alternative text-only label for selected options when the drop-down is closed
+  - `aria-label` can be used if a significant portion of the label is non-text or would be ambiguous to screen readers
+- The specific type of the element doesn't matter; you can use regular HTML `<option>` tags if you want. `<Select.Option>` is available for symmetry, and if you use Typescript, for the `altText` prop.
+- Because the options are not directly rendered, all options must be present in the tree. In other words, you can't do intermediate components like this:
+
+```js
+const Options = () => (
+  <>
+    <option value="option1" />
+    <option value="option2" />
+  </>
+)
+// BAD: the `Options` render func is never called so the <option> tags don't exist
+<Select>
+  <Options />
+<Select>
+
+// OKAY: the options are returned by the func and thus become part of the children tree;
+// the `React.Fragment` element is flattened out and the options are properly parsed
+<Select>{Options()}</Select>
 ```
 
 ### Minimum Required Props
@@ -106,3 +145,7 @@ export default () => {
 ## Properties
 
 <PropsTable of={Select} />
+
+### Select.Option
+
+<PropsTable of={Select} staticProp="SelectOption" />

--- a/modules/cactus-web/src/Select/Select.story.tsx
+++ b/modules/cactus-web/src/Select/Select.story.tsx
@@ -1,21 +1,16 @@
+import { DescriptiveLocation } from '@repay/cactus-icons'
 import { array, boolean, text } from '@storybook/addon-knobs'
 import { Meta } from '@storybook/react/types-6-0'
 import React, { ReactElement } from 'react'
 
 import arizonaCities from '../storySupport/arizonaCities'
-import Select, { OptionType, SelectValueType } from './Select'
+import Select, { SelectValueType } from './Select'
 
 const eventLoggers = {
   onChange: (e: any) => console.log(`onChange '${e.target.name}': ${e.target.value}`),
   onFocus: (e: any) => console.log('onFocus:', e.target.name),
   onBlur: (e: any) => console.log('onBlur:', e.target.name),
 }
-
-const longOptions: OptionType[] = [
-  { label: 'This should be the longest option available', value: 'long-option' },
-  { label: 'Here is another option', value: 'another-option' },
-  { label: 'One more option', value: 'the-last-option' },
-]
 
 const defaultMultiValue = arizonaCities.slice(6, 15)
 
@@ -86,14 +81,17 @@ export const LongOptionLabels = (): ReactElement => {
   return (
     <div style={{ width: '194px' }}>
       <Select
-        options={longOptions}
         name="random"
         id="select-input"
         disabled={boolean('disabled', false)}
         {...eventLoggers}
         onChange={(e) => setValue(e.target.value)}
         value={value}
-      />
+      >
+        <option value="long-option">This should be the longest option available</option>
+        <option value="another-option">Here is another option</option>
+        <option value="the-last-option">One more option</option>
+      </Select>
     </div>
   )
 }
@@ -104,7 +102,6 @@ export const WithMultiselect = (): ReactElement => {
   const [value, setValue] = React.useState<SelectValueType>(defaultMultiValue)
   return (
     <Select
-      options={arizonaCities}
       name="random"
       id="select-input"
       disabled={boolean('disabled', false)}
@@ -112,7 +109,13 @@ export const WithMultiselect = (): ReactElement => {
       onChange={(e) => setValue(e.target.value)}
       value={value}
       multiple
-    />
+    >
+      {arizonaCities.map((city, ix) => (
+        <option key={ix} value={city}>
+          <DescriptiveLocation /> {city}
+        </option>
+      ))}
+    </Select>
   )
 }
 
@@ -123,7 +126,6 @@ export const WithComboBox = (): ReactElement => {
   const optionsAvailable = boolean('Show options?', true)
   return (
     <Select
-      options={optionsAvailable ? arizonaCities : []}
       noOptionsText={text('No option text', 'No options available')}
       name="random"
       id="select-input"
@@ -133,7 +135,14 @@ export const WithComboBox = (): ReactElement => {
       value={value}
       comboBox
       canCreateOption={boolean('canCreateOption', true)}
-    />
+    >
+      {optionsAvailable &&
+        arizonaCities.map((city, ix) => (
+          <Select.Option key={ix} value={city} altText={city.toLowerCase()}>
+            <DescriptiveLocation iconSize="medium" /> {city}
+          </Select.Option>
+        ))}
+    </Select>
   )
 }
 

--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -41,6 +41,28 @@ describe('component: Select', (): void => {
     expect(getByText('Who?')).not.toBeNull()
   })
 
+  test('can receive options as children, with altText', (): void => {
+    const { queryByText } = render(
+      <StyleProvider>
+        <Select id="options-children" name="test-options" value="second">
+          <Select.Option value="first" altText="Locke">
+            Peter
+          </Select.Option>
+          <Select.Option value="second" altText="Demosthenes">
+            Valentine
+          </Select.Option>
+          <Select.Option value="third">Ender</Select.Option>
+        </Select>
+      </StyleProvider>
+    )
+
+    expect(queryByText('Peter')).not.toBeNull()
+    expect(queryByText('Valentine')).not.toBeNull()
+    expect(queryByText('Ender')).not.toBeNull()
+    expect(queryByText('Locke')).toBeNull()
+    expect(document.querySelector('#options-children')).toHaveTextContent('Demosthenes')
+  })
+
   test('should set placeholder when options are empty', async (): Promise<void> => {
     const { getByRole } = render(
       <StyleProvider>
@@ -1028,12 +1050,12 @@ describe('component: Select', (): void => {
       await animationRender()
       const searchBox: HTMLElement = document.activeElement as HTMLElement
       fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-phoenix-phoenix')
+      expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-phoenix')
       fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
       fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-flagstaff-flagstaff')
+      expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-flagstaff')
       fireEvent.keyDown(searchBox, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
-      expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-tucson-tucson')
+      expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-tucson')
     })
 
     test('RETURN should select an option and focus on the trigger', async (): Promise<void> => {

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1322,7 +1322,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
   private extendedOptions: ExtendedOptionType[] | null = null
   private optionsMap: OptMap = new Map()
 
-  private getOptsFromChildren(children: React.ReactNode, prevOpts: OptMap) {
+  private buildOptsFromChildren(children: React.ReactNode, prevOpts: OptMap) {
     const childArray = React.Children.toArray(children) as React.ReactChild[]
     if (!childArray?.length) return
 
@@ -1332,7 +1332,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
       if (typeof child === 'string' || typeof child === 'number') {
         optList.push(this.asExtOpt(child))
       } else if (child?.type === React.Fragment) {
-        this.getOptsFromChildren(child.props.children, prevOpts)
+        this.buildOptsFromChildren(child.props.children, prevOpts)
       } else if (child?.props) {
         const value = child.props.value
         if (typeof value === 'string' || typeof value === 'number') {
@@ -1400,7 +1400,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     }
     const optList: ExtendedOptionType[] = (this.extendedOptions = [])
     if (this.props.children) {
-      this.getOptsFromChildren(this.props.children, prevOpts)
+      this.buildOptsFromChildren(this.props.children, prevOpts)
     } else if (this.props.options?.length) {
       for (const o of this.props.options) {
         optList.push(this.asExtOpt(o))

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -10,7 +10,7 @@ import { width as styledSystemWidth, WidthProps } from 'styled-system'
 
 import CheckBox from '../CheckBox/CheckBox'
 import Flex from '../Flex/Flex'
-import { isResponsiveTouchDevice } from '../helpers/constants'
+import { isIE, isResponsiveTouchDevice } from '../helpers/constants'
 import {
   CactusChangeEvent,
   CactusEventTarget,
@@ -20,6 +20,7 @@ import {
 import KeyCodes from '../helpers/keyCodes'
 import { omitMargins } from '../helpers/omit'
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
+import { isPurelyEqual } from '../helpers/react'
 import { textFieldStatusMap } from '../helpers/status'
 import { boxShadow, fontSize, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
@@ -27,12 +28,35 @@ import Tag from '../Tag/Tag'
 import TextButton from '../TextButton/TextButton'
 
 export type SelectValueType = string | number | (string | number)[] | null
-export interface OptionType {
-  label: string
+
+interface WithValue {
   value: string | number
 }
 
-type ExtendedOptionType = OptionType & { id: string; isSelected: boolean }
+export interface OptionType extends WithValue {
+  label: string
+}
+
+interface OptionProps extends WithValue {
+  children?: React.ReactNode
+  id?: string
+  'aria-label'?: string
+  altText?: string
+}
+
+interface ExtendedOptionType extends WithValue {
+  label: React.ReactNode
+  isSelected: boolean
+  id: string
+  ariaLabel?: string
+  altText?: string
+}
+
+type OptMap = Map<string | number, ExtendedOptionType>
+
+interface InternalOptionProps extends React.LiHTMLAttributes<HTMLLIElement> {
+  option: ExtendedOptionType
+}
 
 type Target = CactusEventTarget<SelectValueType>
 
@@ -43,7 +67,7 @@ export interface SelectProps
       React.DetailedHTMLProps<React.HTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
       'ref' | 'onChange' | 'onBlur' | 'onFocus'
     > {
-  options: (OptionType | string | number)[]
+  options?: (OptionType | string | number)[]
   id: string
   name: string
   value?: string | number | (string | number)[] | null
@@ -66,15 +90,6 @@ export interface SelectProps
   onChange?: React.ChangeEventHandler<Target>
   onBlur?: React.FocusEventHandler<Target>
   onFocus?: React.FocusEventHandler<Target>
-}
-
-// Thank you, Stack Overflow https://stackoverflow.com/questions/49986720/how-to-detect-internet-explorer-11-and-below-versions
-const isIE = () => {
-  const ua = window.navigator.userAgent //Check the userAgent property of the window.navigator object
-  const msie = ua.indexOf('MSIE ') // IE 10 or older
-  const trident = ua.indexOf('Trident/') //IE 11
-
-  return msie > 0 || trident > 0
 }
 
 const displayStatus: any = (props: SelectProps): ReturnType<typeof css> | string => {
@@ -113,7 +128,7 @@ const ValueSwitch = (props: {
   const moreRef = useRef<HTMLSpanElement | null>(null)
   const [numToRender, setNum] = useState(numSelected)
   const [prevValue, setPrevValue] = useState<string>('')
-  const valueString = selected.reduce((m, o): string => m + o.label, '')
+  const valueString = selected.reduce((m, o): string => m + getLabel(o), '')
   const shouldRenderAll = prevValue !== valueString
   /**
    * finds the maximum number of values it can display
@@ -164,8 +179,8 @@ const ValueSwitch = (props: {
         <ValueSpan ref={spanRef}>
           {selected.slice(0, shouldRenderAll ? undefined : numToRender).map(
             (opt): React.ReactElement => (
-              <Tag id={`value-tag::${opt.id}`} closeOption key={opt.value + opt.label}>
-                {opt.label}
+              <Tag id={`value-tag::${opt.id}`} closeOption key={opt.id}>
+                {opt.altText || opt.value}
               </Tag>
             )
           )}
@@ -179,13 +194,13 @@ const ValueSwitch = (props: {
       return (
         <ValueSpan>
           <Tag id={`value-tag::${value.id}`} closeOption>
-            {value.label}
+            {value.altText || value.value}
           </Tag>
         </ValueSpan>
       )
     }
   } else {
-    return <ValueSpan>{selected[0].label}</ValueSpan>
+    return <ValueSpan>{selected[0].altText || selected[0].value}</ValueSpan>
   }
 }
 
@@ -338,7 +353,7 @@ const NoMatch = styled.li`
   overflow-wrap: break-word;
 `
 
-const Option = styled.li`
+const StyledOption = styled.li`
   cursor: pointer;
   display: list-item;
   border: none;
@@ -369,6 +384,30 @@ const Option = styled.li`
     vertical-align: -2px;
   }
 `
+
+export const SelectOption: React.FC<OptionProps> = ({ children }) => <>{children}</>
+
+const InternalOption: React.FC<InternalOptionProps> = ({ option, ...props }) => {
+  const ref = React.useRef<HTMLLIElement>(null)
+  React.useEffect(() => {
+    if (option.altText === undefined && ref.current) {
+      option.altText = ref.current.textContent || ''
+    }
+  }, [option])
+  return (
+    <StyledOption
+      ref={ref}
+      role="option"
+      data-value={option.value}
+      id={option.id}
+      aria-label={option.ariaLabel}
+      {...props}
+    />
+  )
+}
+
+const getLabel = ({ label, altText, value }: ExtendedOptionType): string =>
+  typeof label === 'string' ? label : altText || value.toString()
 
 interface ListWrapperProps {
   isOpen: boolean
@@ -452,7 +491,7 @@ interface ListProps {
   searchValue: string
   onBlur: (event: React.FocusEvent<HTMLUListElement>) => void
   onClick: (event: React.MouseEvent<HTMLUListElement>) => void
-  raiseChange: (event: React.SyntheticEvent, active: OptionType | null, noToggle?: boolean) => void
+  raiseChange: (event: React.SyntheticEvent, active: WithValue | null, noToggle?: boolean) => void
   onClose: () => void
   anchorRef: React.RefObject<HTMLDivElement>
   activeDescendant: string
@@ -461,18 +500,20 @@ interface ListProps {
   handleComboInputBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
-function getSelectedIndex(options: (string | OptionType)[], value: string | number): number {
+function getSelectedIndex(options: WithValue[], value: string | number): number {
   for (let i = 0; i < options.length; ++i) {
-    const opt = options[i]
-    if (
-      (typeof opt === 'string' && opt === value) ||
-      (typeof opt !== 'string' && opt.value === value)
-    ) {
+    if (options[i].value === value) {
       return i
     }
   }
 
   return 0
+}
+
+function getIsSelected(selectedValues: SelectValueType, value: string | number) {
+  return (
+    (Array.isArray(selectedValues) && selectedValues.includes(value)) || selectedValues === value
+  )
 }
 
 function findMatchInRange(
@@ -483,7 +524,7 @@ function findMatchInRange(
 ): ExtendedOptionType | null {
   for (let i = startIndex; i < endIndex; ++i) {
     const opt = options[i]
-    if (opt.label.toLowerCase().startsWith(pendingChars.toLowerCase())) {
+    if (getLabel(opt).toLowerCase().startsWith(pendingChars.toLowerCase())) {
       return opt
     }
   }
@@ -668,16 +709,16 @@ class List extends React.Component<ListProps, ListState> {
     options: ExtendedOptionType[],
     searchValue: string
   ): [ExtendedOptionType[], boolean] => {
-    let addOption = true
+    let addOption = searchValue !== ''
+    searchValue = searchValue.toLowerCase()
     options = options.filter((opt: ExtendedOptionType): boolean => {
-      if (opt.label.toLowerCase() === searchValue.toLowerCase() || searchValue === '') {
+      const label = getLabel(opt).toLowerCase()
+      const includesSearch = label.includes(searchValue)
+      if (includesSearch && label.length === searchValue.length) {
         addOption = false
       }
-      return opt.label.toLowerCase().includes(searchValue.toLowerCase())
+      return includesSearch
     })
-    if (searchValue === '') {
-      addOption = false
-    }
     return [options, addOption]
   }
 
@@ -707,6 +748,7 @@ class List extends React.Component<ListProps, ListState> {
           label: `Create "${props.searchValue}"`,
           id: `create-${props.searchValue}`,
           isSelected: false,
+          altText: props.searchValue,
         }
         filteredOptions.unshift(addOpt)
       }
@@ -826,12 +868,10 @@ class List extends React.Component<ListProps, ListState> {
                   ariaSelected = isSelected ? 'true' : 'false'
                 }
                 return (
-                  <Option
-                    id={optId}
+                  <InternalOption
                     key={optId}
+                    option={opt}
                     className={activeDescendant === optId ? 'highlighted-option' : undefined}
-                    data-value={opt.value}
-                    role="option"
                     data-role={isCreateNewOption ? 'create' : 'option'}
                     aria-selected={ariaSelected}
                     onMouseEnter={this.handleOptionMouseEnter}
@@ -848,7 +888,7 @@ class List extends React.Component<ListProps, ListState> {
                       />
                     ) : null}
                     {opt.label}
-                  </Option>
+                  </InternalOption>
                 )
               }
             )
@@ -890,8 +930,8 @@ function asOption(opt: number | string | OptionType): OptionType {
   return opt
 }
 
-function getOptionId(selectId: string, option: OptionType): string {
-  return `${selectId}-${option.label}-${option.value}`.replace(/\s/g, '-')
+function getOptionId(selectId: string, value: string | number): string {
+  return `${selectId}-${value}`.replace(/\s/g, '-')
 }
 
 interface SelectState {
@@ -904,6 +944,8 @@ interface SelectState {
 }
 
 class SelectBase extends React.Component<SelectProps, SelectState> {
+  public static Option = SelectOption
+
   public state = {
     isOpen: false,
     value: this.props.value || null,
@@ -927,6 +969,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     if (this.triggerRef.current !== null) {
       this.setState({ currentTriggerWidth: this.triggerRef.current.getBoundingClientRect().width })
     }
+    this.resetMemo()
     this.detectOptionsFromValue()
     this.eventTarget.id = this.props.id
     this.eventTarget.name = this.props.name
@@ -941,6 +984,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
         })
       }
     }
+    this.resetMemo()
     if (JSON.stringify(this.props.value) !== JSON.stringify(prevProps.value)) {
       this.detectOptionsFromValue()
     }
@@ -1081,7 +1125,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
 
     // In IE, there's no relatedTarget on blur with React versions lower than v17...it's already moved on to activeElement
     const isReact17 = event.nativeEvent.type === 'focusout'
-    if (isIE() && !isReact17) {
+    if (isIE && !isReact17) {
       setTimeout(() => {
         const focusTarget = document.activeElement
         this.closeListIfNotFocused(focusTarget)
@@ -1172,7 +1216,7 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
 
   private raiseChange = (
     event: React.SyntheticEvent,
-    option: OptionType | null,
+    option: WithValue | null,
     onlyAdd = false
   ): void => {
     if (option === null) {
@@ -1196,7 +1240,12 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     } else {
       value = option.value
     }
-    this.resetMemo()
+    const extOpt = this.optionsMap.get(option.value)
+    if (extOpt) {
+      extOpt.isSelected = getIsSelected(value, option.value)
+    } else {
+      this.resetMemo()
+    }
     this.setState({ value })
     this.eventTarget.value = value
     const { onChange } = this.props
@@ -1244,40 +1293,18 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     }
   }
 
-  private isSelected = (option: OptionType): boolean => {
-    return (
-      (Array.isArray(this.state.value) && this.state.value.includes(option.value)) ||
-      this.state.value === option.value
-    )
-  }
-
-  private getOptByValue(value: string | number): OptionType | null {
-    for (const o of this.props.options) {
-      const option = asOption(o)
-      if (String(option.value) === String(value)) {
-        return option
-      }
-    }
-    return null
-  }
-
-  private optionsMap: { [key: string]: ExtendedOptionType } = {}
-
   private detectOptionsFromValue(): void {
-    this.getExtOptions().forEach((opt): void => {
-      this.optionsMap[opt.value] = opt
-    })
     if (this.props.comboBox && this.props.canCreateOption && this.props.value) {
       const newOptions: OptionType[] = []
 
       if (Array.isArray(this.props.value)) {
         this.props.value.forEach((val): void => {
-          if (!this.optionsMap[val]) {
+          if (!this.optionsMap.has(val)) {
             newOptions.push(asOption(val))
           }
         })
       } else {
-        if (!this.optionsMap[this.props.value]) {
+        if (!this.optionsMap.has(this.props.value)) {
           newOptions.push(asOption(this.props.value))
         }
       }
@@ -1292,63 +1319,103 @@ class SelectBase extends React.Component<SelectProps, SelectState> {
     }
   }
 
-  /** used to reduce rerenders of List and ValueSpan */
-  private memoizedExtOptions: {
-    id: string | undefined
-    options: (string | number | OptionType)[]
-    memo: ExtendedOptionType[]
-    value: SelectValueType
-  } = {
-    id: undefined,
-    options: [],
-    memo: [],
-    value: null,
+  private extendedOptions: ExtendedOptionType[] | null = null
+  private optionsMap: OptMap = new Map()
+
+  private getOptsFromChildren(children: React.ReactNode, prevOpts: OptMap) {
+    const childArray = React.Children.toArray(children) as React.ReactChild[]
+    if (!childArray?.length) return
+
+    const selectId = this.props.id
+    const optList = this.getExtOptions()
+    for (const child of childArray) {
+      if (typeof child === 'string' || typeof child === 'number') {
+        optList.push(this.asExtOpt(child))
+      } else if (child?.type === React.Fragment) {
+        this.getOptsFromChildren(child.props.children, prevOpts)
+      } else if (child?.props) {
+        const value = child.props.value
+        if (typeof value === 'string' || typeof value === 'number') {
+          const { altText: altProp, children, id, 'aria-label': ariaLabel } = child.props
+          const rawLabel = children || children === 0 ? children : value
+          const label = typeof rawLabel === 'number' ? rawLabel.toString() : rawLabel
+          let altText: string | undefined = altProp || ariaLabel
+          if (altText === undefined) {
+            let prevOpt: ExtendedOptionType | undefined
+            if (typeof label === 'string') {
+              altText = label
+            } else if ((prevOpt = prevOpts.get(value))) {
+              // Try to minimize how often we have to pull from textContent;
+              // this is to avoid the delay from `useEffect`, rather than performance reasons.
+              if (prevOpt.altText !== undefined && isPurelyEqual(prevOpt.label, label)) {
+                altText = prevOpt.altText
+              }
+            }
+          }
+          const opt: ExtendedOptionType = {
+            value,
+            label,
+            altText,
+            ariaLabel,
+            id: id || getOptionId(selectId, value),
+            isSelected: getIsSelected(this.state.value, value),
+          }
+          optList.push(opt)
+          this.optionsMap.set(opt.value, opt)
+        }
+      }
+    }
+  }
+
+  private asExtOpt(value: number | string | OptionType): ExtendedOptionType {
+    let opt: ExtendedOptionType
+    if (typeof value === 'number' || typeof value === 'string') {
+      const label = value.toString()
+      opt = {
+        value,
+        label,
+        altText: label,
+        id: getOptionId(this.props.id, value),
+        isSelected: getIsSelected(this.state.value, value),
+      }
+    } else {
+      opt = {
+        ...value,
+        altText: value.label,
+        id: getOptionId(this.props.id, value.value),
+        isSelected: getIsSelected(this.state.value, value.value),
+      }
+    }
+    this.optionsMap.set(opt.value, opt)
+    return opt
   }
 
   private getExtOptions(): ExtendedOptionType[] {
-    const selectId = this.props.id
-    if (
-      this.memoizedExtOptions.memo.length !== 0 &&
-      this.memoizedExtOptions.id === selectId &&
-      this.props.options === this.memoizedExtOptions.options &&
-      this.props.value === this.memoizedExtOptions.value
-    ) {
-      return this.memoizedExtOptions.memo
+    if (this.extendedOptions !== null) {
+      return this.extendedOptions
     }
-    const propValues = new Set<string | number>()
-    let memo = this.props.options.map(
-      (o): ExtendedOptionType => {
-        const opt = asOption(o)
-        propValues.add(opt.value)
-        const extendedOpt: ExtendedOptionType = {
-          ...opt,
-          id: getOptionId(selectId, opt),
-          isSelected: this.isSelected(opt),
-        }
-        return extendedOpt
+    const prevOpts = this.optionsMap
+    if (prevOpts.size > 0) {
+      this.optionsMap = new Map()
+    }
+    const optList: ExtendedOptionType[] = (this.extendedOptions = [])
+    if (this.props.children) {
+      this.getOptsFromChildren(this.props.children, prevOpts)
+    } else if (this.props.options?.length) {
+      for (const o of this.props.options) {
+        optList.push(this.asExtOpt(o))
       }
-    )
-    const extraOpts = (this.state.extraOptions as OptionType[])
-      .filter((opt) => !propValues.has(opt.value))
-      .map(
-        (opt): ExtendedOptionType => ({
-          ...opt,
-          id: getOptionId(selectId, opt),
-          isSelected: this.isSelected(opt),
-        })
-      )
-    memo = memo.concat(extraOpts)
-    this.memoizedExtOptions = {
-      id: selectId,
-      options: this.props.options,
-      value: this.state.value,
-      memo: memo,
     }
-    return this.memoizedExtOptions.memo
+    for (const opt of this.state.extraOptions as OptionType[]) {
+      if (!this.optionsMap.has(opt.value)) {
+        optList.push(this.asExtOpt(opt))
+      }
+    }
+    return optList
   }
 
   private resetMemo = (): void => {
-    this.memoizedExtOptions.memo = []
+    this.extendedOptions = null
   }
 
   private setActiveDescendant = (activeDescendant: string): void => {
@@ -1486,7 +1553,7 @@ Select.propTypes = {
     ),
     PropTypes.arrayOf(PropTypes.string.isRequired),
     PropTypes.arrayOf(PropTypes.number.isRequired),
-  ]).isRequired,
+  ]),
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   // @ts-ignore
@@ -1508,6 +1575,12 @@ Select.propTypes = {
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
   noOptionsText: PropTypes.string,
+  children: function (props: Record<string, any>): Error | null {
+    if (props.children && props.options) {
+      return new Error('Should use `options` prop OR pass children, not both')
+    }
+    return null
+  },
 }
 
 Select.defaultProps = {

--- a/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
+++ b/modules/cactus-web/src/Select/__snapshots__/Select.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`component: Select snapshot 1`] = `
             class="c8"
             data-role="option"
             data-value="phoenix"
-            id="test-id-phoenix-phoenix"
+            id="test-id-phoenix"
             role="option"
           >
             phoenix
@@ -210,7 +210,7 @@ exports[`component: Select snapshot 1`] = `
             class="c8"
             data-role="option"
             data-value="tucson"
-            id="test-id-tucson-tucson"
+            id="test-id-tucson"
             role="option"
           >
             tucson
@@ -219,7 +219,7 @@ exports[`component: Select snapshot 1`] = `
             class="c8"
             data-role="option"
             data-value="flagstaff"
-            id="test-id-flagstaff-flagstaff"
+            id="test-id-flagstaff"
             role="option"
           >
             flagstaff
@@ -432,7 +432,7 @@ exports[`component: Select with theme customization should have 2px border 1`] =
             class="c8"
             data-role="option"
             data-value="thin"
-            id="test-id-thin-thin"
+            id="test-id-thin"
             role="option"
           >
             thin
@@ -441,7 +441,7 @@ exports[`component: Select with theme customization should have 2px border 1`] =
             class="c8"
             data-role="option"
             data-value="thick"
-            id="test-id-thick-thick"
+            id="test-id-thick"
             role="option"
           >
             thick
@@ -654,7 +654,7 @@ exports[`component: Select with theme customization should match intermediate sh
             class="c8"
             data-role="option"
             data-value="shape"
-            id="test-id-shape-shape"
+            id="test-id-shape"
             role="option"
           >
             shape
@@ -663,7 +663,7 @@ exports[`component: Select with theme customization should match intermediate sh
             class="c8"
             data-role="option"
             data-value="border"
-            id="test-id-border-border"
+            id="test-id-border"
             role="option"
           >
             border
@@ -876,7 +876,7 @@ exports[`component: Select with theme customization should match square shape st
             class="c8"
             data-role="option"
             data-value="shape"
-            id="test-id-shape-shape"
+            id="test-id-shape"
             role="option"
           >
             shape
@@ -885,7 +885,7 @@ exports[`component: Select with theme customization should match square shape st
             class="c8"
             data-role="option"
             data-value="border"
-            id="test-id-border-border"
+            id="test-id-border"
             role="option"
           >
             border
@@ -1098,7 +1098,7 @@ exports[`component: Select with theme customization should not have box shadows 
             class="c8"
             data-role="option"
             data-value="shape"
-            id="test-id-shape-shape"
+            id="test-id-shape"
             role="option"
           >
             shape
@@ -1107,7 +1107,7 @@ exports[`component: Select with theme customization should not have box shadows 
             class="c8"
             data-role="option"
             data-value="border"
-            id="test-id-border-border"
+            id="test-id-border"
             role="option"
           >
             border

--- a/modules/cactus-web/src/SelectField/SelectField.mdx
+++ b/modules/cactus-web/src/SelectField/SelectField.mdx
@@ -33,7 +33,7 @@ Shorter text is prefered for option labels to keep the output from assistive tec
 
 ## Basic usage
 
-`options` can be provided as an array of strings or as an array of objects in the shape of `{ label: string, value: string }`.
+Basically the same as `Select`, just with the addition of some status & field-related props.
 
 ```jsx
 import React, { useState, useCallback } from 'react'

--- a/modules/cactus-web/src/SelectField/SelectField.story.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.story.tsx
@@ -57,11 +57,11 @@ CustomStyles.parameters = { storyshots: false }
 
 export const ControlledForm = (): React.ReactElement => {
   const [value, setValue] = React.useState<SelectValueType>(null)
+  const opts = array('options', ['bird', 'plane', 'superman'])
   return (
     <SelectField
       label={text('label', `What's that in the sky?`)}
       name={text('name', 'ufo')}
-      options={array('options', ['bird', 'plane', 'superman'])}
       disabled={boolean('disabled', false)}
       tooltip={text('tooltip', 'Select what you think you see in the sky.')}
       success={text('success', '')}
@@ -69,7 +69,11 @@ export const ControlledForm = (): React.ReactElement => {
       error={text('error', '')}
       onChange={(e) => setValue(e.target.value)}
       value={value}
-    />
+    >
+      {opts.map((val) => (
+        <option value={val} key={val} />
+      ))}
+    </SelectField>
   )
 }
 

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -5,20 +5,21 @@ import { margin, MarginProps, width as styledSystemWidth, WidthProps } from 'sty
 
 import AccessibleField, { FieldProps } from '../AccessibleField/AccessibleField'
 import { omitMargins } from '../helpers/omit'
-import Select, { OptionType, SelectProps } from '../Select/Select'
+import Select, { SelectProps } from '../Select/Select'
 
 interface SelectFieldProps
   extends MarginProps,
     WidthProps,
     FieldProps,
     Omit<SelectProps, 'id' | keyof MarginProps | keyof WidthProps> {
-  options: (OptionType | string | number)[]
   className?: string
   id?: string
   multiple?: boolean
 }
 
-const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement => {
+type SelectFieldType = React.FC<SelectFieldProps> & { Option: typeof Select.Option }
+
+const SelectFieldBase: SelectFieldType = (props): React.ReactElement => {
   const {
     className,
     id,
@@ -77,6 +78,8 @@ const SelectFieldBase: React.FC<SelectFieldProps> = (props): React.ReactElement 
     </AccessibleField>
   )
 }
+
+SelectFieldBase.Option = Select.Option
 
 export const SelectField = styled(SelectFieldBase)`
   position: relative;

--- a/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
+++ b/modules/cactus-web/src/SelectField/__snapshots__/SelectField.test.tsx.snap
@@ -292,7 +292,7 @@ exports[`component: SelectField minimal snapshot 1`] = `
               class="c17"
               data-role="option"
               data-value="basic"
-              id="prevent-random-id-basic-basic"
+              id="prevent-random-id-basic"
               role="option"
             >
               basic
@@ -301,7 +301,7 @@ exports[`component: SelectField minimal snapshot 1`] = `
               class="c17"
               data-role="option"
               data-value="options"
-              id="prevent-random-id-options-options"
+              id="prevent-random-id-options"
               role="option"
             >
               options

--- a/modules/cactus-web/src/helpers/react.ts
+++ b/modules/cactus-web/src/helpers/react.ts
@@ -1,3 +1,4 @@
+import isEqual from 'lodash/isEqual'
 import React, { SetStateAction } from 'react'
 
 type CloneFunc = (e: React.ReactElement, p?: Record<string, any>, ix?: number) => React.ReactElement
@@ -31,6 +32,31 @@ export function cloneAll(
     }
     return returnVal
   }, [] as React.ReactChild[])
+}
+
+// A pure component is one whose output depends solely on props.
+export function isPurelyEqual(left: React.ReactNode, right: React.ReactNode): boolean {
+  const leftArray = React.Children.toArray(left) as React.ReactChild[]
+  const rightArray = React.Children.toArray(right) as React.ReactChild[]
+  if (leftArray.length === rightArray.length) {
+    for (let i = 0; i < leftArray.length; i++) {
+      if (!compareElements(leftArray[i], rightArray[i])) return false
+    }
+    return true
+  }
+  return false
+}
+
+function compareElements(left: React.ReactChild, right: React.ReactChild) {
+  if (left === right) {
+    return true
+  } else if (typeof left === 'object' && typeof right === 'object') {
+    if (left.type !== right.type || left.key !== right.key) return false
+    const { children: lnodes, ...lprops } = left.props
+    const { children: rnodes, ...rprops } = right.props
+    return isEqual(lprops, rprops) && isPurelyEqual(lnodes, rnodes)
+  }
+  return false
 }
 
 type Ref<T> = React.RefCallback<T> | React.MutableRefObject<T> | null | undefined


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-497

The updated docs should have everything you need to know about how to use it.

Also changed IDs from using both label & value to just value, which is still supposed to be unique and should be less mutable (e.g. from translations and the like). Not sure if that would could as a breaking change or not, since it could be used in scripts.