### PR TITLE
CACTUS-508 :: Update Jest Sonar Package

### DIFF
--- a/modules/cactus-fwk/package.json
+++ b/modules/cactus-fwk/package.json
@@ -41,7 +41,7 @@
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
     ],
-    "testResultsProcessor": "jest-sonar-reporter"
+    "reporters": ["default", ["jest-sonar", { "outputDirectory": ".", "outputName": "test-report.xml" }]]
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",
@@ -54,7 +54,7 @@
     "@types/react": "^17.0.2",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
-    "jest-sonar-reporter": "^2.0.0",
+    "jest-sonar": "^0.2.12",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/modules/cactus-i18n/package.json
+++ b/modules/cactus-i18n/package.json
@@ -37,7 +37,7 @@
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
     ],
-    "testResultsProcessor": "jest-sonar-reporter"
+    "reporters": ["default", ["jest-sonar", { "outputDirectory": ".", "outputName": "test-report.xml" }]]
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",
@@ -51,7 +51,7 @@
     "@types/react": "^17.0.2",
     "babel-jest": "^26.6.3",
     "jest": "^26.6.3",
-    "jest-sonar-reporter": "^2.0.0",
+    "jest-sonar": "^0.2.12",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/modules/cactus-icons/package.json
+++ b/modules/cactus-icons/package.json
@@ -48,7 +48,7 @@
       "text",
       "json-summary"
     ],
-    "testResultsProcessor": "jest-sonar-reporter"
+    "reporters": ["default", ["jest-sonar", { "outputDirectory": ".", "outputName": "test-report.xml" }]]
   },
   "peerDependencies": {
     "prop-types": ">=15.0.0",
@@ -74,7 +74,7 @@
     "babel-loader": "^8.2.2",
     "fast-glob": "^3.2.4",
     "jest": "^26.6.3",
-    "jest-sonar-reporter": "^2.0.0",
+    "jest-sonar": "^0.2.12",
     "jest-styled-components": "^7.0.3",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",

--- a/modules/cactus-theme/package.json
+++ b/modules/cactus-theme/package.json
@@ -26,7 +26,7 @@
     "@repay/scripts": "^2.0.2",
     "@types/jest": "^26.0.20",
     "babel-jest": "^26.6.3",
-    "jest-sonar-reporter": "^2.0.0",
+    "jest-sonar": "^0.2.12",
     "typescript": "^4.1.5"
   },
   "jest": {
@@ -43,6 +43,6 @@
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
     ],
-    "testResultsProcessor": "jest-sonar-reporter"
+    "reporters": ["default", ["jest-sonar", { "outputDirectory": ".", "outputName": "test-report.xml" }]]
   }
 }

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -59,7 +59,7 @@
       "!src/**/*.story.{ts,tsx}",
       "!src/storySupport/**"
     ],
-    "testResultsProcessor": "jest-sonar-reporter"
+    "reporters": ["default", ["jest-sonar", { "outputDirectory": ".", "outputName": "test-report.xml" }]]
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",
@@ -82,8 +82,8 @@
     "@types/node": "^14.14.27",
     "@types/puppeteer": "^3.0.2",
     "@types/react": "^17.0.2",
-    "@types/react-transition-group": "^4.4.0",
     "@types/react-color": "^2.17.5",
+    "@types/react-transition-group": "^4.4.0",
     "@types/storybook__react": "^5.2.1",
     "@types/styled-components": "^5.1.7",
     "@types/styled-system": "^5.1.10",
@@ -94,7 +94,7 @@
     "babel-plugin-require-context-hook": "^1.0.0",
     "csstype": "^3.0.3",
     "jest": "^26.6.3",
-    "jest-sonar-reporter": "^2.0.0",
+    "jest-sonar": "^0.2.12",
     "jest-styled-components": "^7.0.3",
     "prop-types": "^15.7.2",
     "puppeteer": "^5.3.1",
@@ -121,8 +121,8 @@
     "@repay/cactus-icons": "^2.3.0",
     "@repay/cactus-theme": "^2.0.2",
     "lodash": "^4.17.19",
-    "react-transition-group": "^4.4.1",
     "react-color": "^2.19.3",
+    "react-transition-group": "^4.4.1",
     "styled-system": "^5.1.5",
     "tinycolor2": "^1.4.2"
   }

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -59,7 +59,16 @@
       "!src/**/*.story.{ts,tsx}",
       "!src/storySupport/**"
     ],
-    "reporters": ["default", ["jest-sonar", { "outputDirectory": ".", "outputName": "test-report.xml" }]]
+    "reporters": [
+      "default",
+      [
+        "jest-sonar",
+        {
+          "outputDirectory": ".",
+          "outputName": "test-report.xml"
+        }
+      ]
+    ]
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",
@@ -120,7 +129,7 @@
     "@reach/visually-hidden": "^0.13.0",
     "@repay/cactus-icons": "^2.3.0",
     "@repay/cactus-theme": "^2.0.2",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "react-color": "^2.19.3",
     "react-transition-group": "^4.4.1",
     "styled-system": "^5.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9852,6 +9852,11 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
+entities@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 env-paths@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
@@ -14652,12 +14657,13 @@ jest-snapshot@^26.3.0, jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
-jest-sonar-reporter@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jest-sonar-reporter/-/jest-sonar-reporter-2.0.0.tgz#faa54a7d2af7198767ee246a82b78c576789cf08"
-  integrity sha512-ZervDCgEX5gdUbdtWsjdipLN3bKJwpxbvhkYNXTAYvAckCihobSLr9OT/IuyNIRT1EZMDDwR6DroWtrq+IL64w==
+jest-sonar@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/jest-sonar/-/jest-sonar-0.2.12.tgz#9843cac11f65c997b03a6c94a57571f50decc02b"
+  integrity sha512-8hZO3rhxVobJkMhyuEgsZxfj0QQucCa+dkXVJ3ckz+Gi180F2ET12GwEGP/j4z1owc08Z2JgIt2Qlgl06+3asQ==
   dependencies:
-    xml "^1.0.1"
+    entities "^2.1.0"
+    strip-ansi "^6.0.0"
 
 jest-specific-snapshot@^4.0.0:
   version "4.0.0"
@@ -24068,11 +24074,6 @@ xml2js@^0.4.5, xml2js@~0.4.4:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
-
-xml@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
-  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@~11.0.0:
   version "11.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15470,6 +15470,11 @@ lodash.without@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-update-async-hook@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/log-update-async-hook/-/log-update-async-hook-2.0.2.tgz#6eba89dbe67fa12d0b20ac47df7942947af1fcd1"


### PR DESCRIPTION
Blackduck listed `jest-sonar-reporter` as a high Operational Risk since it is now inactive.  This PR replaces it with `jest-sonar`.

There's not much to test.  Just make sure the tests still run and that `test-report.xml` is still being generated in the various module folders.