### PR TITLE
fix(cactus-web): fix iconbutton warning

### DIFF
--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -196,7 +196,7 @@ export const IconButton = styled(IconButtonBase)<IconButtonProps>`
 
 IconButton.propTypes = {
   iconSize: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
-  variant: PropTypes.oneOf(['standard', 'action', 'danger']),
+  variant: PropTypes.oneOf(['standard', 'action', 'danger', 'warning', 'success']),
   disabled: PropTypes.bool,
   label: (props: IconButtonProps, propName: string, componentName: string): Error | null => {
     if (!props.label && !props['aria-labelledby']) {


### PR DESCRIPTION
following the suggested solution, warning and success were added to the variant's proptypes

[CACTUS-524](https://repayonline.atlassian.net/browse/CACTUS-524)
