### PR TITLE
CACTUS-525: added color styles to Tag component

### DIFF
--- a/modules/cactus-web/src/SelectField/SelectField.story.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.story.tsx
@@ -29,6 +29,7 @@ export const BasicUsage = (): React.ReactElement => (
       warning={text('warning', '')}
       error={text('error', '')}
       autoTooltip={boolean('autoTooltip', true)}
+      multiple={boolean('multiple', false)}
       comboBox={boolean('comboBox', false)}
       canCreateOption={boolean('canCreateOption', true)}
       disableTooltip={select('disableTooltip', [false, true, undefined], false)}

--- a/modules/cactus-web/src/Tag/Tag.tsx
+++ b/modules/cactus-web/src/Tag/Tag.tsx
@@ -1,14 +1,11 @@
 import { NavigationClose } from '@repay/cactus-icons'
-import defaultTheme, { CactusTheme, TextStyle } from '@repay/cactus-theme'
+import { TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { CSSObject, FlattenSimpleInterpolation } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { radius, textStyle } from '../helpers/theme'
-
-type ColorStyleKey = keyof CactusTheme['colorStyles']
-const colorStyleKeys = Object.keys(defaultTheme.colorStyles) as ColorStyleKey[]
 
 interface TagProps extends MarginProps {
   id?: string
@@ -17,7 +14,6 @@ interface TagProps extends MarginProps {
   children: React.ReactNode
   hidden?: boolean
   onCloseIconClick?: () => void
-  colorStyle?: ColorStyleKey
 }
 
 const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
@@ -33,11 +29,8 @@ const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
   }
 )
 
-const validColor = (style: any): ColorStyleKey =>
-  colorStyleKeys.includes(style) ? style : 'standard'
-
 export const Tag = styled(TagBase)`
-  ${(p) => p.theme.colorStyles[validColor(p.colorStyle)]};
+  ${(p) => p.theme.colorStyles.standard};
   box-sizing: border-box;
   ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'small')};
   padding: 0 8px 0 8px;
@@ -67,7 +60,6 @@ Tag.propTypes = {
   children: PropTypes.node.isRequired,
   hidden: PropTypes.bool,
   onCloseIconClick: PropTypes.func,
-  colorStyle: PropTypes.oneOf(colorStyleKeys),
 }
 
 Tag.defaultProps = {

--- a/modules/cactus-web/src/Tag/Tag.tsx
+++ b/modules/cactus-web/src/Tag/Tag.tsx
@@ -1,11 +1,14 @@
 import { NavigationClose } from '@repay/cactus-icons'
-import { TextStyle } from '@repay/cactus-theme'
+import defaultTheme, { CactusTheme, TextStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { CSSObject, FlattenSimpleInterpolation } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { radius, textStyle } from '../helpers/theme'
+
+type ColorStyleKey = keyof CactusTheme['colorStyles']
+const colorStyleKeys = Object.keys(defaultTheme.colorStyles) as ColorStyleKey[]
 
 interface TagProps extends MarginProps {
   id?: string
@@ -14,6 +17,7 @@ interface TagProps extends MarginProps {
   children: React.ReactNode
   hidden?: boolean
   onCloseIconClick?: () => void
+  colorStyle?: ColorStyleKey
 }
 
 const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
@@ -29,7 +33,11 @@ const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
   }
 )
 
+const validColor = (style: any): ColorStyleKey =>
+  colorStyleKeys.includes(style) ? style : 'standard'
+
 export const Tag = styled(TagBase)`
+  ${(p) => p.theme.colorStyles[validColor(p.colorStyle)]};
   box-sizing: border-box;
   ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'small')};
   padding: 0 8px 0 8px;
@@ -59,6 +67,7 @@ Tag.propTypes = {
   children: PropTypes.node.isRequired,
   hidden: PropTypes.bool,
   onCloseIconClick: PropTypes.func,
+  colorStyle: PropTypes.oneOf(colorStyleKeys),
 }
 
 Tag.defaultProps = {

--- a/modules/cactus-web/src/Tag/__snapshots__/Tag.test.tsx.snap
+++ b/modules/cactus-web/src/Tag/__snapshots__/Tag.test.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`component: Tag can render content as children 1`] = `
 .c0 {
+  background-color: hsl(0,0%,100%);
+  color: hsl(200,10%,20%);
   box-sizing: border-box;
   font-size: 15px;
   line-height: 1.6;


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-525

Technically I just needed to set the default `standard` color style, but who knows what the future holds, and what other use cases may pop up? Since it was just as easy to allow any color style, I figured why not.