### PR TITLE
CACTUS 536: Changing Gatsby links format. 

### DIFF
--- a/docs/Components/API Documentation.md
+++ b/docs/Components/API Documentation.md
@@ -52,4 +52,4 @@ To see an example showcasing how `Formik` and `@repay/cactus-web` form elements 
 
 You can find individual component documentation in the side navigation.
 
-For a detailed and working example using both `@repay/cactus-web` components and `@repay/cactus-theme`, see the [theme-components example](../../examples/theme-components).
+For a detailed and working example using both `@repay/cactus-web` components and `@repay/cactus-theme`, see the [theme-components example](https://github.com/repaygithub/cactus/tree/master/examples/theme-components).

--- a/docs/Components/README.md
+++ b/docs/Components/README.md
@@ -8,14 +8,14 @@ The `@repay/cactus-web` component library provides several components that can b
 
 ## Quick Links
 
-- [Theming](../Theme/README.md)
-- [API Documentation](./API%20Documentation.md)
+- <a to="/theme">Theming</a>
+- <a to="./api-documentation">API Documentation</a>
 - [Source Code](../../modules/cactus-web/)
 
 ## Theming
 
-The components in this library are designed to work with a theme that is generated using `@repay/cactus-theme` and given the `ThemeProvider` component created by [styled-components](https://www.npmjs.com/package/styled-components). This will apply a color scheme to all of the components available in this library so that the design is standardized and complies with accessibility standards. If you would like a more detailed breakdown on how to generate and use a theme, see [@repay/cactus-theme](../Theme/README.md).
+The components in this library are designed to work with a theme that is generated using `@repay/cactus-theme` and given the `ThemeProvider` component created by [styled-components](https://www.npmjs.com/package/styled-components). This will apply a color scheme to all of the components available in this library so that the design is standardized and complies with accessibility standards. If you would like a more detailed breakdown on how to generate and use a theme, see <a to="/theme">@repay/cactus-theme</a>.
 
 ## API Documentation
 
-The Cactus Web component library provides several components which can be used across different front end applications. To view the API documentation, click [here](./API%20Documentation.md).
+The Cactus Web component library provides several components which can be used across different front end applications. To view the API documentation, click <a to="./api-documentation">here</a>.

--- a/docs/Framework/API/README.md
+++ b/docs/Framework/API/README.md
@@ -6,5 +6,5 @@ title: API Docs
 
 ## Features
 
-- [Error Boundary](./Error%20Boundary.md)
-- [Feature Flags](./Feature%20Flags.md)
+- <a to='./error-boundary'>Error Boundary</a>
+- <a to='./feature-flags'>Feature Flags</a>

--- a/docs/Framework/README.md
+++ b/docs/Framework/README.md
@@ -8,9 +8,9 @@ The Cactus Framework implements a set of common front-end necessities at a top l
 
 ## Quick Links
 
-- [API Documentation](./API/README.md)
-  - [Error Boundary](./API/Error%20Boundary.md)
-  - [Feature Flags](./API/Feature%20Flags.md)
+- <a to="./api">API Documentation</a>
+- <a to="./api/error-boundary"> Error Boundary</a>
+- <a to="./api/feature-flags"> Feature Flags</a>
 - [Source Code](../../modules/cactus-fwk/)
 
 ## Getting Started
@@ -84,4 +84,4 @@ const Home: React.FC<Props> = (props) => {
 export default Home
 ```
 
-Next read the rest of the [API documentation](./API/README.md) or checkout out the [examples folder](../../examples/)
+Next read the rest of the <a to="./api">API Documentation</a> or checkout out the [examples folder](../../examples/)

--- a/docs/How-tos/End-to-End Testing.md
+++ b/docs/How-tos/End-to-End Testing.md
@@ -2,7 +2,7 @@
 
 Unit testing is great, but sometimes you need to test how your page behaves in an actual browser: that's where end-to-end testing comes in. This guide should show you how to use some of our tools to make this task a little easier.
 
-Before starting, you should have an application that you wish to test. The examples used will be based on an app like those created by the [@repay/create-ui](https://github.com/repaygithub/ui-tools/tree/master/modules/create-repay-ui) package; see [this tutorial](/tutorials/responsive-web-design/) for an example with starting a new project.
+Before starting, you should have an application that you wish to test. The examples used will be based on an app like those created by the [@repay/create-ui](https://github.com/repaygithub/ui-tools/tree/master/modules/create-repay-ui) package; see <a to='/tutorials/responsive-web-design/'>this tutorial</a> for an example with starting a new project.
 
 ## Installation & Configuration
 

--- a/docs/How-tos/Forms.md
+++ b/docs/How-tos/Forms.md
@@ -1,8 +1,8 @@
 # How to Write Cactus Forms Using Formik
 
-Collecting data using forms is one of the most basic functions of a website. [@repay/cactus-web](/components/) provides several styled form inputs, as well as a few custom inputs that emulate built-in HTML inputs. This guide will show you the basics of combining these input components with a common forms library, [Formik](https://formik.org/).
+Collecting data using forms is one of the most basic functions of a website. <a to='/components/'>@repay/cactus-web</a> provides several styled form inputs, as well as a few custom inputs that emulate built-in HTML inputs. This guide will show you the basics of combining these input components with a common forms library, [Formik](https://formik.org/).
 
-Before starting, you should have an application, and know how to add a page or component. The examples used will be based on an app like those created by the [@repay/create-ui](https://github.com/repaygithub/ui-tools/tree/master/modules/create-repay-ui) package; see [this tutorial](/tutorials/responsive-web-design/) for an example with starting a new project.
+Before starting, you should have an application, and know how to add a page or component. The examples used will be based on an app like those created by the [@repay/create-ui](https://github.com/repaygithub/ui-tools/tree/master/modules/create-repay-ui) package; see <a to='/tutorials/responsive-web-design/'>this tutorial</a> for an example with starting a new project.
 
 ### Installation
 
@@ -255,5 +255,5 @@ These fields are all custom components rather than styled HTML elements, but the
 ### Further Reading
 
 - [Formik Documentation](https://formik.org/docs/tutorial)
-- [@repay/cactus-web Documentation](/components/)
+- <a to='/components/'>@repay/cactus-web Documentation</a>
 - [Example app w/ form (UI Config page)](https://github.com/repaygithub/cactus/tree/master/examples/mock-ebpp)

--- a/docs/Icons/README.md
+++ b/docs/Icons/README.md
@@ -9,7 +9,7 @@ The Cactus Design System contains a set of icons as React components to use with
 
 ## Quick Links
 
-- [Available Icons](./Available%20Icons.md)
+- <a to='./available-icons'>Available Icons</a>
 - [Source Code](../../modules/cactus-icons)
 
 ## Getting Started
@@ -41,4 +41,4 @@ export default (props) => (
 )
 ```
 
-Next see the [Available Icons](./Available%20Icons.md) for the published icons in the set.
+Next see the <a to='./available-icons'>Available Icons</a> for the published icons in the set.

--- a/docs/Internationalization/Getting Started.md
+++ b/docs/Internationalization/Getting Started.md
@@ -133,4 +133,4 @@ const mainComponent = () => {
 } // ¡Bienvenido a la página de cuentas, CS Human!
 ```
 
-At this point, we have successfully set up a small example with the ability to render different translations for different sections. If you want to see a working example, you can check out the standard implementation [here](https://github.com/repaygithub/cactus/tree/master/examples/standard). It uses a lot of these same ideas. Additionally, we have much more detailed API docs on each tool available with internationalization [here](../API%20Documentation.md)
+At this point, we have successfully set up a small example with the ability to render different translations for different sections. If you want to see a working example, you can check out the standard implementation [here](https://github.com/repaygithub/cactus/tree/master/examples/standard). It uses a lot of these same ideas. Additionally, we have much more detailed API docs on each tool available with internationalization <a to='../api-documentation'>here</a>.

--- a/docs/Internationalization/README.md
+++ b/docs/Internationalization/README.md
@@ -9,19 +9,19 @@ The Cactus I18n library implements i18n using the core technologies developed by
 
 ## Quick Links
 
-- [Fluent Syntax](./Fluent%20Syntax.md)
-- [Getting Started](./Getting%20Started.md)
-- [API Documentation](./API%20Documentation.md)
-- [Why Project Fluent?](./Project%20Fluent.md)
+- <a to='./fluent-syntax'>Fluent Syntax</a>
+- <a to='./getting-started'>Getting Started</a>
+- <a to='./api-documentation'>API Documentation</a>
+- <a to='./project-fluent'>Why Project Fluent?</a>
 - [Source Code](../../modules/cactus-i18n/)
 
 ## Fluent Syntax
 
-Because we make use of Fluent's tools to make internationalization possible, our API uses translations written using the Fluent ftl syntax. You can find a small example of some features of Fluent's syntax [here](./Fluent%20Syntax.md).
+Because we make use of Fluent's tools to make internationalization possible, our API uses translations written using the Fluent ftl syntax. You can find a small example of some features of Fluent's syntax <a to='./fluent-syntax'>here</a>.
 
 ## Getting Started
 
-Getting started with the internationalization tools that are available with the Cactus Framework is easy, and we have a quick guide for setting up a project to achieve internationalization, along with a working example to check out. To find out more about what you need to do to get started, go [here](./Getting%20Started.md).
+Getting started with the internationalization tools that are available with the Cactus Framework is easy, and we have a quick guide for setting up a project to achieve internationalization, along with a working example to check out. To find out more about what you need to do to get started, go <a to='./getting-started'>here</a>.
 
 1. Install this library
 
@@ -54,8 +54,8 @@ module.exports = {
 
 ## API Documentation
 
-We have detailed documentation on each of the classes, functions and components you'll need to integrate internationalization into your application [here](./API%20Documentation.md).
+We have detailed documentation on each of the classes, functions and components you'll need to integrate internationalization into your application <a to='./api-documentation'>here</a>.
 
 ## Why Project Fluent?
 
-If you are interested in learning more about why we chose to use Project Fluent over other similar i18n tools, check [this](./Project%20Fluent.md) out.
+If you are interested in learning more about why we chose to use Project Fluent over other similar i18n tools, check <a to='./project-fluent'>this</a> out.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ An application framework and design system built in React at [REPAY](https://git
 
 ## Getting Started
 
-Whether you are starting a new project from scratch, or you are looking to integrate the Cactus libraries into your existing code base, we have documentation that can help. For documentation regarding our UI application generator, see the [@repay/create-ui docs](./Getting-Started/README.md). For guidance on using Cactus with an existing application, browse the module documentation and the example applications linked below. Feel free to browse our [tutorials](./tutorials) as well.
+Whether you are starting a new project from scratch, or you are looking to integrate the Cactus libraries into your existing code base, we have documentation that can help. For documentation regarding our UI application generator, see the <a to='/getting-started'>@repay/create-ui docs</a>. For guidance on using Cactus with an existing application, browse the module documentation and the example applications linked below. Feel free to browse our <a to='/tutorials'>tutorials</a> as well.
 
 ## Design System
 

--- a/docs/Theme/README.md
+++ b/docs/Theme/README.md
@@ -77,4 +77,4 @@ export default () => (
 
 ## Next Steps
 
-Seems pretty easy, right? Well, we can't stop here. To see how you can use the components available in `@repay/cactus-web` in conjunction with the theming principles we just went over in order to create a consistent and great looking front end application, click [here](../Components/README.md)
+Seems pretty easy, right? Well, we can't stop here. To see how you can use the components available in `@repay/cactus-web` in conjunction with the theming principles we just went over in order to create a consistent and great looking front end application, click <a to='/components'>here</a>

--- a/modules/cactus-web/src/DateInput/DateInput.test.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.test.tsx
@@ -1,5 +1,5 @@
 import { generateTheme } from '@repay/cactus-theme'
-import { act, fireEvent, render } from '@testing-library/react'
+import { act, fireEvent, render, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as React from 'react'
 
@@ -320,7 +320,7 @@ describe('component: DateInput', (): void => {
         async (): Promise<void> => {
           fireEvent.click(getByLabelText('Click to change month'))
           await animationRender()
-          fireEvent.click(getByText('March'))
+          fireEvent.click(within(getByLabelText('Select a month')).getByText('March'))
           fireEvent.click(getByLabelText('Click to change year'))
           await animationRender()
           fireEvent.click(getByText('2018'))


### PR DESCRIPTION
I changed only the links with relative paths. All the URLs stay using the _markdown_ way to write links. 
I discovered that it is not necessary to change the file format from `md` to `mdx` to use Gatsby's `<Link>` API, so I have decided to preserve the original file format. 

[CACTUS-536](https://repayonline.atlassian.net/browse/CACTUS-536)