### PR TITLE
CACTUS-556 :: MenuBar Sub-Menu Width

### DIFF
--- a/modules/cactus-web/src/Layout/Layout.story.tsx
+++ b/modules/cactus-web/src/Layout/Layout.story.tsx
@@ -151,6 +151,9 @@ export const BasicUsage = (): React.ReactElement => {
           <MenuBar.List title="Interlude: About Bears">
             <MenuBar.Item onClick={action('RAWR')}>Brown Bear</MenuBar.Item>
             <MenuBar.Item onClick={action('GRR')}>Polar Bear</MenuBar.Item>
+            <MenuBar.List title="Long Bears">
+              <MenuBar.Item>A very long label about bears is wider than its parent</MenuBar.Item>
+            </MenuBar.List>
           </MenuBar.List>
         </MenuBar>
       )}

--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -481,7 +481,7 @@ const MenuWrapper = styled.div`
   white-space: normal;
   flex-flow: column nowrap;
   align-items: stretch;
-  width: auto;
+  width: max-content;
   min-width: 200px;
   max-width: 320px;
   max-height: 70vh;

--- a/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
+++ b/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
@@ -661,7 +661,9 @@ exports[`component: MenuBar typechecks 1`] = `
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-  width: auto;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
   min-width: 200px;
   max-width: 320px;
   max-height: 70vh;


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-556

So if you look [here](https://caniuse.com/mdn-css_properties_width_max-content) you'll see that caniuse says that `width: max-content;` is not supported in IE11, but it's working for me now. It wasn't working at first, when I was only applying the style to sub-menus, but when I started setting it on all menus it began to work. I'd say be extra thorough when testing IE11 since it doesn't look like it should be supported.

### Testing
1. Open the Layout "Basic Usage" story
2. Open the "Interlude: About Bears" menu and then open the "Long Bears" sub-menu.
3. Verify that the width of the sub-menu is 320px wide.