### PR TITLE
fix(cactus-web): accordion IconButton Issue

### DIFF
--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -252,6 +252,7 @@ export const AccordionHeader = styled(AccordionHeaderBase)`
 
   > :not(:first-child) {
     min-width: 1px;
+    flex: 1;
   }
 
   &::-moz-focus-inner {

--- a/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/modules/cactus-web/src/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -83,6 +83,9 @@ exports[`component: Accordion Component Should render Accordion 1`] = `
 
 .c1 > :not(:first-child) {
   min-width: 1px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c1::-moz-focus-inner {
@@ -250,6 +253,9 @@ exports[`component: Accordion Component Should render outline accordion 1`] = `
 
 .c2 > :not(:first-child) {
   min-width: 1px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c2::-moz-focus-inner {
@@ -419,6 +425,9 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 .c2 > :not(:first-child) {
   min-width: 1px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c2::-moz-focus-inner {
@@ -587,6 +596,9 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 .c2 > :not(:first-child) {
   min-width: 1px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c2::-moz-focus-inner {
@@ -755,6 +767,9 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 .c2 > :not(:first-child) {
   min-width: 1px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c2::-moz-focus-inner {
@@ -923,6 +938,9 @@ exports[`component: Accordion with theme customization outline accordion should 
 
 .c2 > :not(:first-child) {
   min-width: 1px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c2::-moz-focus-inner {
@@ -1086,6 +1104,9 @@ exports[`component: Accordion with theme customization simple accordion should h
 
 .c1 > :not(:first-child) {
   min-width: 1px;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c1::-moz-focus-inner {


### PR DESCRIPTION
added a [flex:1](https://www.w3schools.com/cssref/css3_pr_flex.asp) property to the Accordion header to adjust the length of the flexible items

[CACTUS-564](https://repayonline.atlassian.net/browse/CACTUS-564)