### PR TITLE
CACTUS-575 :: Fix FileInput onChange not Firing

### DIFF
--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -529,10 +529,10 @@ const FileInputBase = (props: FileInputProps): React.ReactElement => {
   }, [box, eventTarget, files])
 
   useEffect((): void => {
-    if (value) {
+    if (value && !files.some((f) => f.status === 'loading')) {
       updateFiles({ control: value })
     }
-  }, [value, updateFiles])
+  }, [value, updateFiles, files])
 
   const handleDrop = React.useCallback<React.DragEventHandler>(
     (event) => {


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-575

### Testing
1. Pull down this branch and run `yarn web cleanup && yarn web build`
2. In Channels, copy & paste this line into the `docker-compose.yml` file in the admin container under the `volumes` section: `- ../cactus/modules/cactus-web/dist:/code/node_modules/@repay/cactus-web/dist`
3. Run `make init` in the Channels repo
4. When your channels instance is up and running, open FireFox and log in to the app there. Make your way to `https://owe.channels.dev.repay.localhost/admin/#/public-assets/create`
5. Upload a file and make sure the image appears on the page and that the submit button is enabled.
6. Complete step 5 in other browsers of your choosing.