### PR TITLE
feat(cactus-web) :: Footer link props

### DIFF
--- a/modules/cactus-web/src/Footer/Footer.test.tsx
+++ b/modules/cactus-web/src/Footer/Footer.test.tsx
@@ -97,4 +97,15 @@ describe('component: Footer', () => {
     expect(changedLink).toBeInTheDocument()
     expect(changedLink).toHaveAttribute('href', 'https://microsoft.com')
   })
+  test('should be able to pass as prop', () => {
+    const { getByText } = render(
+      <StyleProvider>
+        <Footer logo={REPAY_LOGO}>
+          Custom Content
+          <Footer.Link as="a" href="https://google.com">Some Link</Footer.Link>
+        </Footer>
+      </StyleProvider>
+    )
+    expect(getByText('Some Link')).toHaveAttribute('href', 'https://google.com')
+  })
 })

--- a/modules/cactus-web/src/Footer/Footer.test.tsx
+++ b/modules/cactus-web/src/Footer/Footer.test.tsx
@@ -102,7 +102,9 @@ describe('component: Footer', () => {
       <StyleProvider>
         <Footer logo={REPAY_LOGO}>
           Custom Content
-          <Footer.Link as="a" href="https://google.com">Some Link</Footer.Link>
+          <Footer.Link as="a" href="https://google.com">
+            Some Link
+          </Footer.Link>
         </Footer>
       </StyleProvider>
     )

--- a/modules/cactus-web/src/Footer/Footer.test.tsx
+++ b/modules/cactus-web/src/Footer/Footer.test.tsx
@@ -102,6 +102,11 @@ describe('component: Footer', () => {
       <StyleProvider>
         <Footer logo={REPAY_LOGO}>
           Custom Content
+          {/* These three should all cause Typescript errors if uncommented.
+          <Footer.Link>Hey</Footer.Link>
+          <Footer.Link to="one" href="two">You</Footer.Link>
+          <Footer.Link as="a" value="">Now</Footer.Link>
+          */}
           <Footer.Link as="a" href="https://google.com">
             Some Link
           </Footer.Link>

--- a/modules/cactus-web/src/Footer/Footer.tsx
+++ b/modules/cactus-web/src/Footer/Footer.tsx
@@ -165,7 +165,7 @@ export const Footer: FooterType = (props) => {
           {dividedLinks.map((linkGroup, colIndex) => (
             <LinkCol key={colIndex} maxCols={dividedLinks.length}>
               {linkGroup.map((link, i) => (
-                <StyledLink key={i} {...(link as any)}/>
+                <StyledLink key={i} {...(link as any)} />
               ))}
             </LinkCol>
           ))}
@@ -176,7 +176,7 @@ export const Footer: FooterType = (props) => {
 }
 
 export const FLink: any = (props: any) => {
-  const {id, children, to} = props
+  const { id, children, to } = props
   const setLinks = useContext(FooterContext)
   const key = useId(id)
   useEffect(() => {

--- a/modules/cactus-web/src/Footer/Footer.tsx
+++ b/modules/cactus-web/src/Footer/Footer.tsx
@@ -8,13 +8,7 @@ import { useLayout } from '../Layout/Layout'
 import Link from '../Link/Link'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
 
-interface LinkProps {
-  children: React.ReactNode
-  to: string
-  id?: string
-}
-
-type LinkMap = Map<string, LinkProps>
+type LinkMap = Map<string, typeof Link>
 type FooterContextType = (u: (s: LinkMap) => LinkMap) => void
 
 interface LinkColProps {
@@ -120,8 +114,8 @@ const columnsMap: { [K in Size]: number } = {
 }
 
 // Divides array of links into smaller arrays of links for splitting them up in the list view
-const divideLinks = (links: LinkProps[], maxCols: number) => {
-  const divided: LinkProps[][] = []
+const divideLinks = (links: typeof Link[], maxCols: number) => {
+  const divided: typeof Link[][] = []
   const numPerCol = Math.floor(links.length / maxCols)
   const extra = links.length % maxCols
   for (let i = 0, linkIndex = 0; i < maxCols && linkIndex < links.length; i++) {
@@ -135,11 +129,11 @@ const divideLinks = (links: LinkProps[], maxCols: number) => {
   return divided
 }
 
-type FooterType = React.FC<FooterProps> & { Link: React.FC<LinkProps> }
+type FooterType = React.FC<FooterProps> & { Link: typeof Link }
 
 export const Footer: FooterType = (props) => {
   const { logo, className, children } = props
-  const [links, setLinks] = useState(new Map<string, LinkProps>())
+  const [links, setLinks] = useState(new Map<string, typeof Link>())
   const [maxCols, setMaxCols] = useState<number>(1)
   const screenSize = useContext(ScreenSizeContext)
 
@@ -171,7 +165,7 @@ export const Footer: FooterType = (props) => {
           {dividedLinks.map((linkGroup, colIndex) => (
             <LinkCol key={colIndex} maxCols={dividedLinks.length}>
               {linkGroup.map((link, i) => (
-                <StyledLink key={i} {...link} />
+                <StyledLink key={i} {...(link as any)}/>
               ))}
             </LinkCol>
           ))}
@@ -181,11 +175,12 @@ export const Footer: FooterType = (props) => {
   )
 }
 
-export const FooterLink: React.FC<LinkProps> = ({ children, id, to }) => {
+export const FLink: any = (props: any) => {
+  const {id, children, to} = props
   const setLinks = useContext(FooterContext)
   const key = useId(id)
   useEffect(() => {
-    setLinks?.((links) => new Map(links.set(key, { children, id, to })))
+    setLinks?.((links) => new Map(links.set(key, props)))
   }, [key, children, id, to, setLinks])
   useEffect(
     () => () =>
@@ -198,6 +193,8 @@ export const FooterLink: React.FC<LinkProps> = ({ children, id, to }) => {
   )
   return null
 }
+
+const FooterLink = FLink as typeof Link
 
 const StyledFooter = styled.footer.attrs({ role: 'contentinfo' as string })<{ isGrid: boolean }>`
   ${(p) => textStyle(p.theme, 'small')};

--- a/modules/cactus-web/src/Footer/Footer.tsx
+++ b/modules/cactus-web/src/Footer/Footer.tsx
@@ -5,10 +5,10 @@ import styled from 'styled-components'
 import { boxShadow, textStyle } from '../helpers/theme'
 import useId from '../helpers/useId'
 import { useLayout } from '../Layout/Layout'
-import Link from '../Link/Link'
+import Link, { LinkProps } from '../Link/Link'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
 
-type LinkMap = Map<string, typeof Link>
+type LinkMap = Map<string, LinkProps>
 type FooterContextType = (u: (s: LinkMap) => LinkMap) => void
 
 interface LinkColProps {
@@ -98,7 +98,6 @@ const LinkCol = styled('div')<LinkColProps>`
   padding: 0 16px 0 16px;
   max-width: calc(100% / ${(p) => p.maxCols});
   border-right: 1px solid ${(p) => p.theme.colors.base};
-
   &:last-of-type {
     border-right: none;
   }
@@ -114,8 +113,8 @@ const columnsMap: { [K in Size]: number } = {
 }
 
 // Divides array of links into smaller arrays of links for splitting them up in the list view
-const divideLinks = (links: typeof Link[], maxCols: number) => {
-  const divided: typeof Link[][] = []
+const divideLinks = (links: LinkProps[], maxCols: number) => {
+  const divided: LinkProps[][] = []
   const numPerCol = Math.floor(links.length / maxCols)
   const extra = links.length % maxCols
   for (let i = 0, linkIndex = 0; i < maxCols && linkIndex < links.length; i++) {
@@ -133,7 +132,7 @@ type FooterType = React.FC<FooterProps> & { Link: typeof Link }
 
 export const Footer: FooterType = (props) => {
   const { logo, className, children } = props
-  const [links, setLinks] = useState(new Map<string, typeof Link>())
+  const [links, setLinks] = useState(new Map<string, LinkProps>())
   const [maxCols, setMaxCols] = useState<number>(1)
   const screenSize = useContext(ScreenSizeContext)
 
@@ -175,13 +174,12 @@ export const Footer: FooterType = (props) => {
   )
 }
 
-export const FLink: any = (props: any) => {
-  const { id, children, to } = props
+export const FooterLink: any = (props: LinkProps) => {
   const setLinks = useContext(FooterContext)
-  const key = useId(id)
+  const key = useId(props.id)
   useEffect(() => {
     setLinks?.((links) => new Map(links.set(key, props)))
-  }, [key, children, id, to, setLinks])
+  }, [props, key, setLinks])
   useEffect(
     () => () =>
       setLinks?.((links) => {
@@ -193,8 +191,6 @@ export const FLink: any = (props: any) => {
   )
   return null
 }
-
-const FooterLink = FLink as typeof Link
 
 const StyledFooter = styled.footer.attrs({ role: 'contentinfo' as string })<{ isGrid: boolean }>`
   ${(p) => textStyle(p.theme, 'small')};
@@ -232,15 +228,10 @@ const StyledFooter = styled.footer.attrs({ role: 'contentinfo' as string })<{ is
     }`}
 `
 
-Footer.Link = FooterLink
+Footer.Link = FooterLink as typeof Link
 
 Footer.propTypes = {
   logo: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-}
-
-FooterLink.propTypes = {
-  to: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
 }
 
 export default Footer

--- a/modules/cactus-web/src/Link/Link.tsx
+++ b/modules/cactus-web/src/Link/Link.tsx
@@ -5,7 +5,9 @@ import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
 
-interface LinkProps extends MarginProps, Omit<React.LinkHTMLAttributes<HTMLAnchorElement>, 'href'> {
+export interface LinkProps
+  extends MarginProps,
+    Omit<React.LinkHTMLAttributes<HTMLAnchorElement>, 'href'> {
   to: string
   variant?: 'standard' | 'dark'
 }


### PR DESCRIPTION
Passed the same props of the Link component allowing `as`

[CACTUS-580](https://repayonline.atlassian.net/browse/CACTUS-580)


Please, let me know if there is something I can do better. 
Thanks! 