### PR TITLE
CACTUS-609 :: Safari MenuBar Fix

### DIFF
--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -245,6 +245,7 @@ const MenuList = styled(ReachMenuList)`
   background-color: ${(p) => p.theme.colors.white};
 
   [data-reach-menu-item] {
+    z-index: 110;
     box-sizing: border-box;
     position: relative;
     display: block;

--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -372,6 +372,7 @@ const Nav = styled.nav<MenuBarProps>`
   align-items: stretch;
   position: relative;
   outline: none;
+  z-index: 100;
   [role='menubar'] > li > [role='menuitem'] {
     white-space: nowrap;
     padding: 24px 16px;

--- a/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
+++ b/modules/cactus-web/src/MenuBar/__snapshots__/MenuBar.test.tsx.snap
@@ -605,6 +605,7 @@ exports[`component: MenuBar typechecks 1`] = `
   align-items: stretch;
   position: relative;
   outline: none;
+  z-index: 100;
   box-shadow: inset 0px -2px 0px 0px hsl(200,29%,90%);
 }
 


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-609

Honestly, I still don't really know exactly what was causing this. I think it was something to do with `AceEditor`, because it was only happening on pages that use it, but that's about all I could figure out. John seemed to think it was related to `transform: translateZ(0);` in the `ace_cursor` class, but I didn't see evidence of that. I do know, however, that this fixes it. 🤷‍♂️ 

Also, I had to increase the z-index on the user menu dropdown in `BrandBar`, so that it renders above the `MenuBar`.

### Testing
1. Check out this branch and run `yarn web cleanup && yarn web build`.
2. Open up the `docker-compose.yml` file in `repay-api` and add this line to the `volumes` section under `admin-ui`:
`- ../cactus/modules/cactus-web/dist:/code/node_modules/@repay/cactus-web/dist`
3. Run `make init` to build & run Channels locally.
4. When that's done building, open Safari and go to `https://owe.channels.dev.repay.localhost/admin`.
5. Log in and navigate to the UI Config page under "Merchant Config".
6. Make sure the MenuBar dropdowns open when you click them.
7. Make sure you can log out using the user menu dropdown.
8. Repeat steps 4-7 for other browsers like Chrome or FireFox. Testing Channels locally in IE11 is a pain because you get a ridiculous amount of cert errors that pop up and get in the way, but if you want to test there too, be my guest. Or you can just take my word for it when I say it works there.