### PR TITLE
CACTUS-613 :: Flex Item Props

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
@@ -50,6 +50,30 @@ describe('component: AccessibleField', (): void => {
     )
   })
 
+  test('supports flex item props', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <AccessibleField
+          label="Accessible Label"
+          name="text_field"
+          data-testid="flex-field"
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        >
+          <input name="text_field" data-is="accessible" />
+        </AccessibleField>
+      </StyleProvider>
+    )
+
+    const field = getByTestId('flex-field')
+    expect(field).toHaveStyle('flex: 1')
+    expect(field).toHaveStyle('flex-grow: 1')
+    expect(field).toHaveStyle('flex-shrink: 0')
+    expect(field).toHaveStyle('flex-basis: 0')
+  })
+
   test('alternate prop types', (): void => {
     const { container, getByText } = render(
       <StyleProvider>

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -5,6 +5,7 @@ import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { FieldWrapper } from '../FieldWrapper/FieldWrapper'
 import { Flex } from '../Flex/Flex'
+import { FlexItemProps } from '../helpers/flexItem'
 import { omitProps } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
@@ -28,7 +29,7 @@ interface AccessibleProps {
 type RenderFunc = (props: AccessibleProps) => React.ReactNode
 
 // These are the props commonly used by components that wrap AccessibleField.
-export interface FieldProps {
+export interface FieldProps extends FlexItemProps {
   name: string
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor' | 'id'>

--- a/modules/cactus-web/src/Accordion/Accordion.test.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.test.tsx
@@ -829,4 +829,23 @@ describe('component: Accordion', (): void => {
       expect(styles.borderRadius).toBe('1px')
     })
   })
+
+  test('should support flex item props', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <Accordion data-testid="flex-accordion" flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+          <Accordion.Header>
+            <Text as="h3">I Have Flex Item Props</Text>
+          </Accordion.Header>
+          <Accordion.Body>La dee da</Accordion.Body>
+        </Accordion>
+      </StyleProvider>
+    )
+
+    const accordion = getByTestId('flex-accordion')
+    expect(accordion).toHaveStyle('flex: 1')
+    expect(accordion).toHaveStyle('flex-grow: 1')
+    expect(accordion).toHaveStyle('flex-shrink: 0')
+    expect(accordion).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -15,17 +15,9 @@ import React, {
   useState,
 } from 'react'
 import styled, { css, StyledComponentBase } from 'styled-components'
-import {
-  flexbox,
-  margin,
-  MarginProps,
-  maxWidth,
-  MaxWidthProps,
-  width,
-  WidthProps,
-} from 'styled-system'
+import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 'styled-system'
 
-import { FlexItemProps } from '../helpers/flexItem'
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import KeyCodes from '../helpers/keyCodes'
 import { omitMargins, omitProps } from '../helpers/omit'
 import { boxShadow, radius } from '../helpers/theme'
@@ -775,7 +767,7 @@ export const Accordion = styled(AccordionBase).withConfig(
   ${margin}
   ${width}
   ${maxWidth}
-  ${flexbox}
+  ${flexItem}
 ` as any
 
 Accordion.defaultProps = {

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -678,14 +678,13 @@ const AccordionBase = (props: AccordionProps): ReactElement => {
     }
   }
 
-  const rest = omitMargins(restProps, 'width', 'maxWidth')
   const open = isManaged ? getManagedOpen() : unmanagedState.isOpen
 
   return (
     <div
       id={id}
       className={`${className} ${open && variant === 'outline' ? 'box-shadow' : ''}`}
-      {...rest}
+      {...restProps}
     >
       <AccordionContext.Provider
         value={{
@@ -754,7 +753,7 @@ const variantStyles = (props: AccordionProps): ReturnType<typeof css> | undefine
 }
 
 export const Accordion = styled(AccordionBase).withConfig(
-  omitProps<AccordionProps>('flex', 'flexBasis', 'flexGrow', 'flexShrink')
+  omitProps<AccordionProps>(flexItem, margin, 'width', 'maxWidth')
 )`
   box-sizing: border-box;
   width: 100%;

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -15,10 +15,19 @@ import React, {
   useState,
 } from 'react'
 import styled, { css, StyledComponentBase } from 'styled-components'
-import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 'styled-system'
+import {
+  flexbox,
+  margin,
+  MarginProps,
+  maxWidth,
+  MaxWidthProps,
+  width,
+  WidthProps,
+} from 'styled-system'
 
+import { FlexItemProps } from '../helpers/flexItem'
 import KeyCodes from '../helpers/keyCodes'
-import { omitMargins } from '../helpers/omit'
+import { omitMargins, omitProps } from '../helpers/omit'
 import { boxShadow, radius } from '../helpers/theme'
 import useId from '../helpers/useId'
 import IconButton from '../IconButton/IconButton'
@@ -31,6 +40,7 @@ interface AccordionProps
   extends MarginProps,
     MaxWidthProps,
     WidthProps,
+    FlexItemProps,
     React.HTMLAttributes<HTMLDivElement> {
   /** Does not apply when Accordion descends from a controlled Provider.  If true, the
    * Accordion will begin in the open state when first rendered.
@@ -751,7 +761,9 @@ const variantStyles = (props: AccordionProps): ReturnType<typeof css> | undefine
   }
 }
 
-export const Accordion = styled(AccordionBase)`
+export const Accordion = styled(AccordionBase).withConfig(
+  omitProps<AccordionProps>('flex', 'flexBasis', 'flexGrow', 'flexShrink')
+)`
   box-sizing: border-box;
   width: 100%;
 
@@ -763,6 +775,7 @@ export const Accordion = styled(AccordionBase)`
   ${margin}
   ${width}
   ${maxWidth}
+  ${flexbox}
 ` as any
 
 Accordion.defaultProps = {

--- a/modules/cactus-web/src/Alert/Alert.test.tsx
+++ b/modules/cactus-web/src/Alert/Alert.test.tsx
@@ -13,4 +13,19 @@ describe('component: Alert', (): void => {
     )
     expect(getByText('Message')).toBeInTheDocument()
   })
+  test('should support flex item props', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <Alert data-testid="flex-alert" flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+          I have flex props
+        </Alert>
+      </StyleProvider>
+    )
+
+    const alert = getByTestId('flex-alert')
+    expect(alert).toHaveStyle('flex: 1')
+    expect(alert).toHaveStyle('flex-grow: 1')
+    expect(alert).toHaveStyle('flex-shrink: 0')
+    expect(alert).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -3,9 +3,10 @@ import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css, ThemeProps } from 'styled-components'
-import { margin, MarginProps, width, WidthProps } from 'styled-system'
+import { flexbox, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import Avatar from '../Avatar/Avatar'
+import { FlexItemProps } from '../helpers/flexItem'
 import { omitProps } from '../helpers/omit'
 import { boxShadow } from '../helpers/theme'
 import IconButton from '../IconButton/IconButton'
@@ -13,7 +14,7 @@ import IconButton from '../IconButton/IconButton'
 export type Status = 'error' | 'warning' | 'info' | 'success'
 export type Type = 'general' | 'push'
 
-interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+interface AlertProps extends FlexItemProps, React.HTMLAttributes<HTMLDivElement> {
   status?: Status
   onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void
   closeLabel?: string
@@ -101,7 +102,16 @@ const AlertBase = (props: AlertProps): React.ReactElement => {
 }
 
 export const Alert = styled(AlertBase).withConfig(
-  omitProps<AlertStyleProps>(margin, width, 'type', 'shadow')
+  omitProps<AlertStyleProps>(
+    margin,
+    width,
+    'type',
+    'shadow',
+    'flex',
+    'flexBasis',
+    'flexGrow',
+    'flexShrink'
+  )
 )`
   box-sizing: border-box;
   display: flex;
@@ -115,6 +125,7 @@ export const Alert = styled(AlertBase).withConfig(
   border-radius: 8px;
   ${margin}
   ${width}
+  ${flexbox}
 
   div:first-child {
     flex: 0 0 auto;

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -3,10 +3,10 @@ import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css, ThemeProps } from 'styled-components'
-import { flexbox, margin, MarginProps, width, WidthProps } from 'styled-system'
+import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import Avatar from '../Avatar/Avatar'
-import { FlexItemProps } from '../helpers/flexItem'
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { omitProps } from '../helpers/omit'
 import { boxShadow } from '../helpers/theme'
 import IconButton from '../IconButton/IconButton'
@@ -125,7 +125,7 @@ export const Alert = styled(AlertBase).withConfig(
   border-radius: 8px;
   ${margin}
   ${width}
-  ${flexbox}
+  ${flexItem}
 
   div:first-child {
     flex: 0 0 auto;

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -14,13 +14,13 @@ import IconButton from '../IconButton/IconButton'
 export type Status = 'error' | 'warning' | 'info' | 'success'
 export type Type = 'general' | 'push'
 
-interface AlertProps extends FlexItemProps, React.HTMLAttributes<HTMLDivElement> {
+interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   status?: Status
   onClose?: (event: React.MouseEvent<HTMLButtonElement>) => void
   closeLabel?: string
 }
 
-interface AlertStyleProps extends AlertProps, MarginProps, WidthProps {
+interface AlertStyleProps extends AlertProps, MarginProps, WidthProps, FlexItemProps {
   type?: Type
   shadow?: boolean
 }
@@ -102,16 +102,7 @@ const AlertBase = (props: AlertProps): React.ReactElement => {
 }
 
 export const Alert = styled(AlertBase).withConfig(
-  omitProps<AlertStyleProps>(
-    margin,
-    width,
-    'type',
-    'shadow',
-    'flex',
-    'flexBasis',
-    'flexGrow',
-    'flexShrink'
-  )
+  omitProps<AlertStyleProps>(margin, width, flexItem, 'type', 'shadow')
 )`
   box-sizing: border-box;
   display: flex;

--- a/modules/cactus-web/src/Box/Box.test.tsx
+++ b/modules/cactus-web/src/Box/Box.test.tsx
@@ -115,4 +115,21 @@ describe('component: Box', (): void => {
     expect(boxStyles.borderBottomRightRadius).toBe('1px')
     expect(boxStyles.borderBottomLeftRadius).toBe('20px')
   })
+
+  test('should accept flex item props', () => {
+    const { getByText } = render(
+      <StyleProvider>
+        <Box flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+          Flex Item Box
+        </Box>
+      </StyleProvider>
+    )
+
+    const box = getByText('Flex Item Box')
+    const boxStyles = window.getComputedStyle(box)
+    expect(boxStyles.flex).toBe('1')
+    expect(boxStyles.flexBasis).toBe('0px')
+    expect(boxStyles.flexGrow).toBe('1')
+    expect(boxStyles.flexShrink).toBe('0')
+  })
 })

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -10,7 +10,6 @@ import {
   compose,
   display,
   DisplayProps,
-  flexbox,
   layout,
   LayoutProps,
   overflow,
@@ -23,7 +22,7 @@ import {
   TypographyProps,
 } from 'styled-system'
 
-import { FlexItemProps } from '../helpers/flexItem'
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { radius, textStyle } from '../helpers/theme'
 
 interface CustomBR {
@@ -112,7 +111,7 @@ export const Box = styled('div')<BoxProps>`
     typography,
     border,
     overflow,
-    flexbox
+    flexItem
   )}
   ${(p) => p.textStyle && textStyle(p.theme, p.textStyle)}
   ${decideBorderRadius}

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -10,6 +10,7 @@ import {
   compose,
   display,
   DisplayProps,
+  flexbox,
   layout,
   LayoutProps,
   overflow,
@@ -22,6 +23,7 @@ import {
   TypographyProps,
 } from 'styled-system'
 
+import { FlexItemProps } from '../helpers/flexItem'
 import { radius, textStyle } from '../helpers/theme'
 
 interface CustomBR {
@@ -55,7 +57,8 @@ export interface BoxProps
     DisplayProps,
     TypographyProps,
     CustomBorderProps,
-    OverflowProps {
+    OverflowProps,
+    FlexItemProps {
   textStyle?: keyof TextStyleCollection
 }
 
@@ -99,7 +102,18 @@ const decideBorderRadius = (props: ThemedStyledProps<BoxProps, DefaultTheme>) =>
 
 export const Box = styled('div')<BoxProps>`
   box-sizing: border-box;
-  ${compose(position, display, layout, space, colorStyle, color, typography, border, overflow)}
+  ${compose(
+    position,
+    display,
+    layout,
+    space,
+    colorStyle,
+    color,
+    typography,
+    border,
+    overflow,
+    flexbox
+  )}
   ${(p) => p.textStyle && textStyle(p.theme, p.textStyle)}
   ${decideBorderRadius}
 `

--- a/modules/cactus-web/src/Card/Card.test.tsx
+++ b/modules/cactus-web/src/Card/Card.test.tsx
@@ -96,4 +96,20 @@ describe('component: Card', (): void => {
       expect(cardSyles.borderRadius).toBe('4px')
     })
   })
+
+  test('should support flex item props', () => {
+    const { getByText } = render(
+      <StyleProvider>
+        <Card flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+          Flex Card
+        </Card>
+      </StyleProvider>
+    )
+
+    const card = getByText('Flex Card')
+    expect(card).toHaveStyle('flex: 1')
+    expect(card).toHaveStyle('flex-grow: 1')
+    expect(card).toHaveStyle('flex-shrink: 0')
+    expect(card).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/Card/Card.tsx
+++ b/modules/cactus-web/src/Card/Card.tsx
@@ -1,11 +1,20 @@
 import { BorderSize, CactusTheme, ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { margin, MarginProps, padding, PaddingProps, width, WidthProps } from 'styled-system'
+import {
+  flexbox,
+  margin,
+  MarginProps,
+  padding,
+  PaddingProps,
+  width,
+  WidthProps,
+} from 'styled-system'
 
+import { FlexItemProps } from '../helpers/flexItem'
 import { boxShadow, radius } from '../helpers/theme'
 
-interface CardProps extends MarginProps, WidthProps, PaddingProps {
+interface CardProps extends MarginProps, WidthProps, PaddingProps, FlexItemProps {
   useBoxShadow?: boolean
 }
 
@@ -37,6 +46,7 @@ export const Card = styled.div<CardProps>`
   box-sizing: border-box;
   ${margin}
   ${width}
+  ${flexbox}
   ${(p): ColorStyle => p.theme.colorStyles.standard};
   border-radius: ${radius(8)};
   padding: ${(p): number => p.theme.space[4]}px;

--- a/modules/cactus-web/src/Card/Card.tsx
+++ b/modules/cactus-web/src/Card/Card.tsx
@@ -1,17 +1,9 @@
 import { BorderSize, CactusTheme, ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import {
-  flexbox,
-  margin,
-  MarginProps,
-  padding,
-  PaddingProps,
-  width,
-  WidthProps,
-} from 'styled-system'
+import { margin, MarginProps, padding, PaddingProps, width, WidthProps } from 'styled-system'
 
-import { FlexItemProps } from '../helpers/flexItem'
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { boxShadow, radius } from '../helpers/theme'
 
 interface CardProps extends MarginProps, WidthProps, PaddingProps, FlexItemProps {
@@ -46,7 +38,7 @@ export const Card = styled.div<CardProps>`
   box-sizing: border-box;
   ${margin}
   ${width}
-  ${flexbox}
+  ${flexItem}
   ${(p): ColorStyle => p.theme.colorStyles.standard};
   border-radius: ${radius(8)};
   padding: ${(p): number => p.theme.space[4]}px;

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
@@ -39,6 +39,29 @@ describe('component: CheckBoxField', (): void => {
     expect(styles.marginRight).toBe('8px')
   })
 
+  test('should support flex item props', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <CheckBoxField
+          label="space props"
+          name="space_props"
+          id="not-random"
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+          data-testid="flex-checkbox"
+        />
+      </StyleProvider>
+    )
+
+    const checkField = getByTestId('flex-checkbox').parentElement?.parentElement as HTMLElement
+    expect(checkField).toHaveStyle('flex: 1')
+    expect(checkField).toHaveStyle('flex-grow: 1')
+    expect(checkField).toHaveStyle('flex-shrink: 0')
+    expect(checkField).toHaveStyle('flex-basis: 0')
+  })
+
   test('should trigger onChange event', (): void => {
     const box: any = {}
     const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['name', 'checked'])))

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
@@ -5,11 +5,15 @@ import { margin, MarginProps } from 'styled-system'
 
 import CheckBox, { CheckBoxProps } from '../CheckBox/CheckBox'
 import FieldWrapper from '../FieldWrapper/FieldWrapper'
+import { FlexItemProps } from '../helpers/flexItem'
 import { omitMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 
-export interface CheckBoxFieldProps extends Omit<CheckBoxProps, 'id' | 'disabled'>, MarginProps {
+export interface CheckBoxFieldProps
+  extends Omit<CheckBoxProps, 'id' | 'disabled'>,
+    MarginProps,
+    FlexItemProps {
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
@@ -19,11 +23,28 @@ export interface CheckBoxFieldProps extends Omit<CheckBoxProps, 'id' | 'disabled
 
 const CheckBoxFieldBase = React.forwardRef<HTMLInputElement, CheckBoxFieldProps>((props, ref) => {
   const componentProps = omitMargins(props) as Omit<CheckBoxFieldProps, keyof MarginProps>
-  const { label, labelProps, id, name, className, ...checkboxProps } = componentProps
+  const {
+    label,
+    labelProps,
+    id,
+    name,
+    className,
+    flex,
+    flexGrow,
+    flexShrink,
+    flexBasis,
+    ...checkboxProps
+  } = componentProps
   const checkboxId = useId(id, name)
 
   return (
-    <FieldWrapper className={className}>
+    <FieldWrapper
+      className={className}
+      flex={flex}
+      flexGrow={flexGrow}
+      flexShrink={flexShrink}
+      flexBasis={flexBasis}
+    >
       <CheckBox {...checkboxProps} ref={ref} id={checkboxId} name={name} />
       <Label {...labelProps} htmlFor={checkboxId}>
         {label}

--- a/modules/cactus-web/src/ConfirmModal/ConfirmModal.test.tsx
+++ b/modules/cactus-web/src/ConfirmModal/ConfirmModal.test.tsx
@@ -7,9 +7,9 @@ import Text from '../Text/Text'
 import TextInput from '../TextInput/TextInput'
 import ConfirmModal from './ConfirmModal'
 
-describe('Confirm modal renders different variants', () => {
+describe('component: ConfirmModal', () => {
   const theme = generateTheme()
-  test('Warning variant', () => {
+  test('should render warning variant', () => {
     const { getByTestId } = render(
       <StyleProvider theme={theme}>
         <ConfirmModal
@@ -31,7 +31,7 @@ describe('Confirm modal renders different variants', () => {
     expect(styles.borderColor.trim()).toBe(theme.colors.warning.replace(/ /g, ''))
   })
 
-  test('Success variant', () => {
+  test('should render success variant', () => {
     const { getByTestId } = render(
       <StyleProvider theme={theme}>
         <ConfirmModal
@@ -52,7 +52,8 @@ describe('Confirm modal renders different variants', () => {
 
     expect(styles.borderColor.trim()).toBe(theme.colors.success.replace(/ /g, ''))
   })
-  test('Danger variant', () => {
+
+  test('should render danger variant', () => {
     const { getByTestId } = render(
       <StyleProvider theme={theme}>
         <ConfirmModal
@@ -73,9 +74,7 @@ describe('Confirm modal renders different variants', () => {
 
     expect(styles.borderColor.trim()).toBe(theme.colors.error.replace(/ /g, ''))
   })
-})
 
-describe('Modal renders TextInput and Description', (): void => {
   test('Should render child elements', (): void => {
     const { getByTestId } = render(
       <StyleProvider>
@@ -100,5 +99,29 @@ describe('Modal renders TextInput and Description', (): void => {
     const description = getByTestId('description')
     expect(input).toBeTruthy()
     expect(description).toBeTruthy()
+  })
+
+  test('should support flex item props', () => {
+    const { getByText } = render(
+      <StyleProvider>
+        <ConfirmModal
+          isOpen={true}
+          onConfirm={jest.fn()}
+          onClose={jest.fn()}
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        >
+          Flex Confirm Modal
+        </ConfirmModal>
+      </StyleProvider>
+    )
+
+    const confirmModal = getByText('Flex Confirm Modal').parentElement?.parentElement
+    expect(confirmModal).toHaveStyle('flex: 1')
+    expect(confirmModal).toHaveStyle('flex-grow: 1')
+    expect(confirmModal).toHaveStyle('flex-shrink: 0')
+    expect(confirmModal).toHaveStyle('flex-basis: 0')
   })
 })

--- a/modules/cactus-web/src/DateInputField/DateInputField.test.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.test.tsx
@@ -42,4 +42,24 @@ describe('component: DateInputField', (): void => {
     expect(field.getAttribute('aria-describedby')).toContain(alert.id)
     expect(alert).toHaveTextContent('an error message')
   })
+
+  test('supports flex item props', () => {
+    const { container } = render(
+      <StyleProvider>
+        <DateInputField
+          name="date_field"
+          label="Date Field"
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        />
+      </StyleProvider>
+    )
+
+    expect(container.firstElementChild).toHaveStyle('flex: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-grow: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-shrink: 0')
+    expect(container.firstElementChild).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/DateInputField/DateInputField.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.tsx
@@ -30,6 +30,10 @@ function DateInputFieldBase(props: DateInputFieldProps): React.ReactElement {
     disableTooltip,
     alignTooltip,
     invalidDateLabel = 'The date you have selected is invalid. Please pick another date.',
+    flex,
+    flexGrow,
+    flexShrink,
+    flexBasis,
     ...rest
   } = omitMargins(props) as Omit<DateInputFieldProps, keyof MarginProps>
 
@@ -54,6 +58,10 @@ function DateInputFieldBase(props: DateInputFieldProps): React.ReactElement {
       autoTooltip={autoTooltip}
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
+      flex={flex}
+      flexGrow={flexGrow}
+      flexShrink={flexShrink}
+      flexBasis={flexBasis}
     >
       {({
         fieldId,

--- a/modules/cactus-web/src/Dimmer/Dimmer.story.tsx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.story.tsx
@@ -12,7 +12,7 @@ export const ActivePageDimmer = (): React.ReactElement => {
 
   return (
     <>
-      <Flex mx={15} justifyContent="start" alignItems="flex-start" flexDirection="column">
+      <Flex mx={15} justifyContent="flex-start" alignItems="flex-start" flexDirection="column">
         <h1>Page Dimmer</h1>
         <p>
           Mauris eu felis fringilla tortor scelerisque tincidunt et quis risus. Proin dui arcu,

--- a/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
+++ b/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
@@ -1,12 +1,15 @@
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-export const FieldWrapper = styled.div<MarginProps>`
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
+
+export const FieldWrapper = styled.div<MarginProps & FlexItemProps>`
   & + & {
     margin-top: ${(p): number => p.theme.space[4]}px;
   }
 
   ${margin}
+  ${flexItem}
 `
 
 export default FieldWrapper

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -504,8 +504,8 @@ exports[`component: FileInput should render a file with an error 1`] = `
 }
 
 .c12 .c5,
-.c12 .SvgComponent-bevlva,
-.c12 .SvgComponent-fCAhFS {
+.c12 .sc-dacFzL,
+.c12 .sc-dWdcrH {
   margin-right: 4px;
   vertical-align: -2px;
 }
@@ -598,12 +598,12 @@ exports[`component: FileInput should render a file with an error 1`] = `
   width: 16px;
 }
 
-.c2 .c3 .SvgComponent-fCAhFS {
+.c2 .c3 .sc-dWdcrH {
   height: 18px;
   width: 18px;
 }
 
-.c2 .sc-eCssSg {
+.c2 .sc-gkdzZj {
   height: 12px;
   width: 12px;
 }
@@ -824,7 +824,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c4 .SvgComponent-iZpKnr {
+.c4 .sc-jUEnpm {
   padding-bottom: 4px;
 }
 
@@ -956,7 +956,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 24px;
 }
 
-.c2 .c3 .SvgComponent-iZpKnr {
+.c2 .c3 .sc-jUEnpm {
   height: 16px;
   width: 16px;
 }
@@ -966,7 +966,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 18px;
 }
 
-.c2 .sc-eCssSg {
+.c2 .sc-gkdzZj {
   height: 12px;
   width: 12px;
 }
@@ -984,7 +984,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 100%;
 }
 
-.c1 .sc-jSgupP {
+.c1 .sc-flMoUE {
   position: relative;
   margin-top: 4px;
 }
@@ -1216,17 +1216,17 @@ exports[`component: FileInput should render a loading file 1`] = `
   padding: 0;
 }
 
-.c2 .sc-bdfBwQ {
+.c2 .sc-gVgnHT {
   height: 24px;
   width: 24px;
 }
 
-.c2 .sc-bdfBwQ .SvgComponent-iZpKnr {
+.c2 .sc-gVgnHT .sc-jUEnpm {
   height: 16px;
   width: 16px;
 }
 
-.c2 .sc-bdfBwQ .SvgComponent-fCAhFS {
+.c2 .sc-gVgnHT .sc-dWdcrH {
   height: 18px;
   width: 18px;
 }
@@ -1236,11 +1236,11 @@ exports[`component: FileInput should render a loading file 1`] = `
   width: 12px;
 }
 
-.c2 .sc-hKgILt {
+.c2 .sc-gyUeRy {
   margin-left: auto;
 }
 
-.c2 .SvgComponent-eJMnHx {
+.c2 .sc-TmcTc {
   height: 12px;
   width: 12px;
 }
@@ -1249,7 +1249,7 @@ exports[`component: FileInput should render a loading file 1`] = `
   width: 100%;
 }
 
-.c1 .sc-jSgupP {
+.c1 .sc-flMoUE {
   position: relative;
   margin-top: 4px;
 }

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -13,17 +13,7 @@ exports[`component: FileInput should render a disabled file input 1`] = `
 
 .c4 {
   box-sizing: border-box;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   margin: 8px;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
 }
 
 .c5 {
@@ -224,17 +214,7 @@ exports[`component: FileInput should render a file input 1`] = `
 
 .c4 {
   box-sizing: border-box;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   margin: 8px;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
 }
 
 .c5 {
@@ -524,8 +504,8 @@ exports[`component: FileInput should render a file with an error 1`] = `
 }
 
 .c12 .c5,
-.c12 .sc-dacFzL,
-.c12 .sc-dWdcrH {
+.c12 .SvgComponent-bevlva,
+.c12 .SvgComponent-fCAhFS {
   margin-right: 4px;
   vertical-align: -2px;
 }
@@ -618,12 +598,12 @@ exports[`component: FileInput should render a file with an error 1`] = `
   width: 16px;
 }
 
-.c2 .c3 .sc-dWdcrH {
+.c2 .c3 .SvgComponent-fCAhFS {
   height: 18px;
   width: 18px;
 }
 
-.c2 .sc-gkdzZj {
+.c2 .sc-eCssSg {
   height: 12px;
   width: 12px;
 }
@@ -844,7 +824,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c4 .sc-jUEnpm {
+.c4 .SvgComponent-iZpKnr {
   padding-bottom: 4px;
 }
 
@@ -976,7 +956,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 24px;
 }
 
-.c2 .c3 .sc-jUEnpm {
+.c2 .c3 .SvgComponent-iZpKnr {
   height: 16px;
   width: 16px;
 }
@@ -986,7 +966,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 18px;
 }
 
-.c2 .sc-gkdzZj {
+.c2 .sc-eCssSg {
   height: 12px;
   width: 12px;
 }
@@ -1004,7 +984,7 @@ exports[`component: FileInput should render a loaded file 1`] = `
   width: 100%;
 }
 
-.c1 .sc-flMoUE {
+.c1 .sc-jSgupP {
   position: relative;
   margin-top: 4px;
 }
@@ -1236,17 +1216,17 @@ exports[`component: FileInput should render a loading file 1`] = `
   padding: 0;
 }
 
-.c2 .sc-gVgnHT {
+.c2 .sc-bdfBwQ {
   height: 24px;
   width: 24px;
 }
 
-.c2 .sc-gVgnHT .sc-jUEnpm {
+.c2 .sc-bdfBwQ .SvgComponent-iZpKnr {
   height: 16px;
   width: 16px;
 }
 
-.c2 .sc-gVgnHT .sc-dWdcrH {
+.c2 .sc-bdfBwQ .SvgComponent-fCAhFS {
   height: 18px;
   width: 18px;
 }
@@ -1256,11 +1236,11 @@ exports[`component: FileInput should render a loading file 1`] = `
   width: 12px;
 }
 
-.c2 .sc-gyUeRy {
+.c2 .sc-hKgILt {
   margin-left: auto;
 }
 
-.c2 .sc-TmcTc {
+.c2 .SvgComponent-eJMnHx {
   height: 12px;
   width: 12px;
 }
@@ -1269,7 +1249,7 @@ exports[`component: FileInput should render a loading file 1`] = `
   width: 100%;
 }
 
-.c1 .sc-flMoUE {
+.c1 .sc-jSgupP {
   position: relative;
   margin-top: 4px;
 }

--- a/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
+++ b/modules/cactus-web/src/FileInput/__snapshots__/FileInput.test.tsx.snap
@@ -13,7 +13,17 @@ exports[`component: FileInput should render a disabled file input 1`] = `
 
 .c4 {
   box-sizing: border-box;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   margin: 8px;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c5 {
@@ -214,7 +224,17 @@ exports[`component: FileInput should render a file input 1`] = `
 
 .c4 {
   box-sizing: border-box;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   margin: 8px;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c5 {

--- a/modules/cactus-web/src/FileInputField/FileInputField.test.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.test.tsx
@@ -109,4 +109,27 @@ describe('component: FileInputField', (): void => {
     const errorMsg = getByText("My boy's the boolest of them all")
     expect(errorMsg).toBeInTheDocument()
   })
+
+  test('should support flex item props', () => {
+    const { container } = render(
+      <StyleProvider>
+        <FileInputField
+          name="dabears"
+          id="free-fallin"
+          label="Bickin Back"
+          accept={['.txt']}
+          data-testid="flex-fileinput"
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        />
+      </StyleProvider>
+    )
+
+    expect(container.firstElementChild).toHaveStyle('flex: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-grow: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-shrink: 0')
+    expect(container.firstElementChild).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -29,6 +29,10 @@ const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
     autoTooltip = false,
     disableTooltip,
     alignTooltip,
+    flex,
+    flexGrow,
+    flexShrink,
+    flexBasis,
     ...rest
   } = omitMargins(props) as Omit<FileInputFieldProps, keyof MarginProps>
 
@@ -48,6 +52,10 @@ const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
       autoTooltip={autoTooltip}
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
+      flex={flex}
+      flexGrow={flexGrow}
+      flexShrink={flexShrink}
+      flexBasis={flexBasis}
     >
       {({
         fieldId,

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -68,8 +68,8 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 }
 
 .c22 .c15,
-.c22 .SvgComponent-bevlva,
-.c22 .SvgComponent-fCAhFS {
+.c22 .sc-fbNXWD,
+.c22 .sc-Fyfyc {
   margin-right: 4px;
   vertical-align: -2px;
 }
@@ -269,12 +269,12 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   width: 16px;
 }
 
-.c12 .c13 .SvgComponent-fCAhFS {
+.c12 .c13 .sc-Fyfyc {
   height: 18px;
   width: 18px;
 }
 
-.c12 .sc-kEjbxe {
+.c12 .sc-dwcuIR {
   height: 12px;
   width: 12px;
 }
@@ -611,7 +611,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   padding-right: 8px;
 }
 
-.c1 .sc-eCssSg {
+.c1 .sc-gkdzZj {
   margin-top: 4px;
 }
 
@@ -636,7 +636,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c14 .SvgComponent-iZpKnr {
+.c14 .sc-GTWni {
   padding-bottom: 4px;
 }
 
@@ -768,7 +768,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 24px;
 }
 
-.c12 .c13 .SvgComponent-iZpKnr {
+.c12 .c13 .sc-GTWni {
   height: 16px;
   width: 16px;
 }
@@ -778,7 +778,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 18px;
 }
 
-.c12 .sc-kEjbxe {
+.c12 .sc-dwcuIR {
   height: 12px;
   width: 12px;
 }
@@ -796,7 +796,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 100%;
 }
 
-.c11 .sc-eCssSg {
+.c11 .sc-gkdzZj {
   position: relative;
   margin-top: 4px;
 }
@@ -1083,7 +1083,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
   padding-right: 8px;
 }
 
-.c1 .sc-eCssSg {
+.c1 .sc-gkdzZj {
   margin-top: 4px;
 }
 
@@ -1169,17 +1169,17 @@ exports[`component: FileInputField should render a loading file 1`] = `
   padding: 0;
 }
 
-.c12 .sc-pFZIQ {
+.c12 .sc-eWvPJL {
   height: 24px;
   width: 24px;
 }
 
-.c12 .sc-pFZIQ .SvgComponent-iZpKnr {
+.c12 .sc-eWvPJL .sc-GTWni {
   height: 16px;
   width: 16px;
 }
 
-.c12 .sc-pFZIQ .SvgComponent-fCAhFS {
+.c12 .sc-eWvPJL .sc-Fyfyc {
   height: 18px;
   width: 18px;
 }
@@ -1189,11 +1189,11 @@ exports[`component: FileInputField should render a loading file 1`] = `
   width: 12px;
 }
 
-.c12 .sc-jrAGrp {
+.c12 .sc-kUbhmq {
   margin-left: auto;
 }
 
-.c12 .SvgComponent-eJMnHx {
+.c12 .sc-hlTvYk {
   height: 12px;
   width: 12px;
 }
@@ -1202,7 +1202,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
   width: 100%;
 }
 
-.c11 .sc-eCssSg {
+.c11 .sc-gkdzZj {
   position: relative;
   margin-top: 4px;
 }

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -7,17 +7,6 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 
 .c3 {
   box-sizing: border-box;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
 }
 
 .c4 {
@@ -79,8 +68,8 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 }
 
 .c22 .c15,
-.c22 .sc-fbNXWD,
-.c22 .sc-Fyfyc {
+.c22 .SvgComponent-bevlva,
+.c22 .SvgComponent-fCAhFS {
   margin-right: 4px;
   vertical-align: -2px;
 }
@@ -280,12 +269,12 @@ exports[`component: FileInputField should render a file with an error 1`] = `
   width: 16px;
 }
 
-.c12 .c13 .sc-Fyfyc {
+.c12 .c13 .SvgComponent-fCAhFS {
   height: 18px;
   width: 18px;
 }
 
-.c12 .sc-dwcuIR {
+.c12 .sc-kEjbxe {
   height: 12px;
   width: 12px;
 }
@@ -544,17 +533,6 @@ exports[`component: FileInputField should render a loaded file 1`] = `
 
 .c3 {
   box-sizing: border-box;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
 }
 
 .c4 {
@@ -633,7 +611,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   padding-right: 8px;
 }
 
-.c1 .sc-gkdzZj {
+.c1 .sc-eCssSg {
   margin-top: 4px;
 }
 
@@ -658,7 +636,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   background-color: hsla(145,89%,28%,0.3);
 }
 
-.c14 .sc-GTWni {
+.c14 .SvgComponent-iZpKnr {
   padding-bottom: 4px;
 }
 
@@ -790,7 +768,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 24px;
 }
 
-.c12 .c13 .sc-GTWni {
+.c12 .c13 .SvgComponent-iZpKnr {
   height: 16px;
   width: 16px;
 }
@@ -800,7 +778,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 18px;
 }
 
-.c12 .sc-dwcuIR {
+.c12 .sc-kEjbxe {
   height: 12px;
   width: 12px;
 }
@@ -818,7 +796,7 @@ exports[`component: FileInputField should render a loaded file 1`] = `
   width: 100%;
 }
 
-.c11 .sc-gkdzZj {
+.c11 .sc-eCssSg {
   position: relative;
   margin-top: 4px;
 }
@@ -1031,17 +1009,6 @@ exports[`component: FileInputField should render a loading file 1`] = `
 
 .c3 {
   box-sizing: border-box;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
 }
 
 .c4 {
@@ -1116,7 +1083,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
   padding-right: 8px;
 }
 
-.c1 .sc-gkdzZj {
+.c1 .sc-eCssSg {
   margin-top: 4px;
 }
 
@@ -1202,17 +1169,17 @@ exports[`component: FileInputField should render a loading file 1`] = `
   padding: 0;
 }
 
-.c12 .sc-eWvPJL {
+.c12 .sc-pFZIQ {
   height: 24px;
   width: 24px;
 }
 
-.c12 .sc-eWvPJL .sc-GTWni {
+.c12 .sc-pFZIQ .SvgComponent-iZpKnr {
   height: 16px;
   width: 16px;
 }
 
-.c12 .sc-eWvPJL .sc-Fyfyc {
+.c12 .sc-pFZIQ .SvgComponent-fCAhFS {
   height: 18px;
   width: 18px;
 }
@@ -1222,11 +1189,11 @@ exports[`component: FileInputField should render a loading file 1`] = `
   width: 12px;
 }
 
-.c12 .sc-kUbhmq {
+.c12 .sc-jrAGrp {
   margin-left: auto;
 }
 
-.c12 .sc-hlTvYk {
+.c12 .SvgComponent-eJMnHx {
   height: 12px;
   width: 12px;
 }
@@ -1235,7 +1202,7 @@ exports[`component: FileInputField should render a loading file 1`] = `
   width: 100%;
 }
 
-.c11 .sc-gkdzZj {
+.c11 .sc-eCssSg {
   position: relative;
   margin-top: 4px;
 }

--- a/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
+++ b/modules/cactus-web/src/FileInputField/__snapshots__/FileInputField.test.tsx.snap
@@ -7,6 +7,17 @@ exports[`component: FileInputField should render a file with an error 1`] = `
 
 .c3 {
   box-sizing: border-box;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c4 {
@@ -533,6 +544,17 @@ exports[`component: FileInputField should render a loaded file 1`] = `
 
 .c3 {
   box-sizing: border-box;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c4 {
@@ -1009,6 +1031,17 @@ exports[`component: FileInputField should render a loading file 1`] = `
 
 .c3 {
   box-sizing: border-box;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
 .c4 {

--- a/modules/cactus-web/src/List/List.test.tsx
+++ b/modules/cactus-web/src/List/List.test.tsx
@@ -73,4 +73,22 @@ describe('component: List', () => {
 
     expect(header.tagName).toBe('H3')
   })
+
+  test('should support flex item props', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <List data-testid="flex-list" flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+          <List.Item>List Item 1</List.Item>
+          <List.Item>List Item 2</List.Item>
+          <List.Item>List Item 3</List.Item>
+        </List>
+      </StyleProvider>
+    )
+
+    const list = getByTestId('flex-list')
+    expect(list).toHaveStyle('flex: 1')
+    expect(list).toHaveStyle('flex-grow: 1')
+    expect(list).toHaveStyle('flex-shrink: 0')
+    expect(list).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/List/List.tsx
+++ b/modules/cactus-web/src/List/List.tsx
@@ -5,10 +5,11 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import Flex from '../Flex/Flex'
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { border } from '../helpers/theme'
 import Text, { TextProps } from '../Text/Text'
 
-interface ListProps extends MarginProps, React.HTMLAttributes<HTMLUListElement> {
+interface ListProps extends MarginProps, FlexItemProps, React.HTMLAttributes<HTMLUListElement> {
   dividers?: boolean
 }
 
@@ -26,6 +27,7 @@ const UL = styled.ul<{ $dividers: boolean }>`
   margin: 0;
   list-style-type: none;
   ${margin}
+  ${flexItem}
 
   & & {
     margin-top: 8px;

--- a/modules/cactus-web/src/Modal/Modal.test.tsx
+++ b/modules/cactus-web/src/Modal/Modal.test.tsx
@@ -5,8 +5,8 @@ import { StyleProvider } from '../StyleProvider/StyleProvider'
 import TextInput from '../TextInput/TextInput'
 import Modal from './Modal'
 
-describe('Modal is open when isOpen=true', (): void => {
-  test('Modal is open', (): void => {
+describe('component: Modal', () => {
+  test('Modal is open when isOpen=true', (): void => {
     const { baseElement } = render(
       <StyleProvider>
         <Modal
@@ -22,10 +22,8 @@ describe('Modal is open when isOpen=true', (): void => {
     )
     expect(baseElement).toContainHTML('<reach-portal>')
   })
-})
 
-describe('Modal is closed when isOpen=false', (): void => {
-  test('Modal is closed', (): void => {
+  test('Modal is closed when isOpen=false', () => {
     const { baseElement } = render(
       <StyleProvider>
         <Modal
@@ -39,10 +37,8 @@ describe('Modal is closed when isOpen=false', (): void => {
 
     expect(baseElement).not.toContainHTML('<reach-portal>')
   })
-})
 
-describe('Aria-labels applied correctly', (): void => {
-  test('snapshot', (): void => {
+  test('Aria-labels applied correctly', () => {
     const { baseElement } = render(
       <StyleProvider>
         <Modal
@@ -59,10 +55,8 @@ describe('Aria-labels applied correctly', (): void => {
     expect(baseElement.querySelector('div[aria-label="Modal Label"]')).toBeInTheDocument()
     expect(baseElement.querySelector('div[aria-modal="true"]')).toBeInTheDocument()
   })
-})
 
-describe('Can render content as children', (): void => {
-  test('snapshot', (): void => {
+  test('Can render content as children', () => {
     const { getByTestId } = render(
       <StyleProvider>
         <Modal
@@ -80,5 +74,21 @@ describe('Can render content as children', (): void => {
     )
     const child = getByTestId('child')
     expect(child).toBeInTheDocument()
+  })
+
+  test('should support flex item props', () => {
+    const { getByText } = render(
+      <StyleProvider>
+        <Modal isOpen={true} onClose={jest.fn()} flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+          Flex Modal
+        </Modal>
+      </StyleProvider>
+    )
+
+    const modal = getByText('Flex Modal').parentElement
+    expect(modal).toHaveStyle('flex: 1')
+    expect(modal).toHaveStyle('flex-grow: 1')
+    expect(modal).toHaveStyle('flex-shrink: 0')
+    expect(modal).toHaveStyle('flex-basis: 0')
   })
 })

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -3,19 +3,11 @@ import { NavigationClose } from '@repay/cactus-icons'
 import PropTypes from 'prop-types'
 import React, { FunctionComponent } from 'react'
 import styled, { css } from 'styled-components'
-import {
-  flexbox,
-  height,
-  HeightProps,
-  maxHeight,
-  MaxHeightProps,
-  width,
-  WidthProps,
-} from 'styled-system'
+import { height, HeightProps, maxHeight, MaxHeightProps, width, WidthProps } from 'styled-system'
 
 import { DimmerStyled } from '../Dimmer/Dimmer'
 import Flex from '../Flex/Flex'
-import { FlexItemProps } from '../helpers/flexItem'
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { omitProps } from '../helpers/omit'
 import { border, boxShadow, radius } from '../helpers/theme'
 import cssVariant from '../helpers/variant'
@@ -109,7 +101,7 @@ export const ModalPopUp = styled(DimmerStyled).withConfig(
     ${(p): string => boxShadow(p.theme, 2)};
     max-width: ${(p) => !p.width && '80%'};
     ${width}
-    ${flexbox}
+    ${flexItem}
     outline: none;
     padding: 64px 24px 40px 24px;
     position: relative;

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -79,7 +79,7 @@ const ModalBase: FunctionComponent<ModalProps> = (props): React.ReactElement => 
 }
 
 export const ModalPopUp = styled(DimmerStyled).withConfig(
-  omitProps<ModalPopupProps>('maxHeight', 'flex', 'flexBasis', 'flexGrow', 'flexShrink')
+  omitProps<ModalPopupProps>(flexItem, 'maxHeight')
 )`
   bottom: 0;
   display: flex;

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -3,17 +3,27 @@ import { NavigationClose } from '@repay/cactus-icons'
 import PropTypes from 'prop-types'
 import React, { FunctionComponent } from 'react'
 import styled, { css } from 'styled-components'
-import { height, HeightProps, maxHeight, MaxHeightProps, width, WidthProps } from 'styled-system'
+import {
+  flexbox,
+  height,
+  HeightProps,
+  maxHeight,
+  MaxHeightProps,
+  width,
+  WidthProps,
+} from 'styled-system'
 
 import { DimmerStyled } from '../Dimmer/Dimmer'
 import Flex from '../Flex/Flex'
+import { FlexItemProps } from '../helpers/flexItem'
+import { omitProps } from '../helpers/omit'
 import { border, boxShadow, radius } from '../helpers/theme'
 import cssVariant from '../helpers/variant'
 import IconButton from '../IconButton/IconButton'
 
 export type ModalType = 'action' | 'danger' | 'warning' | 'success'
 
-export interface ModalProps extends WidthProps {
+export interface ModalProps extends WidthProps, FlexItemProps {
   className?: string
   closeLabel?: string
   isOpen: boolean
@@ -23,11 +33,16 @@ export interface ModalProps extends WidthProps {
   innerHeight?: HeightProps['height']
   innerMaxHeight?: MaxHeightProps['maxHeight']
 }
-interface ModalPopupProps extends DialogProps, WidthProps, HeightProps, MaxHeightProps {
+interface ModalPopupProps
+  extends DialogProps,
+    WidthProps,
+    HeightProps,
+    MaxHeightProps,
+    FlexItemProps {
   variant: ModalType
 }
 
-const Modalbase: FunctionComponent<ModalProps> = (props): React.ReactElement => {
+const ModalBase: FunctionComponent<ModalProps> = (props): React.ReactElement => {
   const {
     variant = 'action',
     children,
@@ -71,12 +86,9 @@ const Modalbase: FunctionComponent<ModalProps> = (props): React.ReactElement => 
   )
 }
 
-export const ModalPopUp = styled(DimmerStyled).withConfig({
-  shouldForwardProp: (prop) => {
-    // @ts-ignore
-    return prop !== 'maxHeight'
-  },
-})<ModalPopupProps>`
+export const ModalPopUp = styled(DimmerStyled).withConfig(
+  omitProps<ModalPopupProps>('maxHeight', 'flex', 'flexBasis', 'flexGrow', 'flexShrink')
+)`
   bottom: 0;
   display: flex;
   left: 0;
@@ -89,7 +101,7 @@ export const ModalPopUp = styled(DimmerStyled).withConfig({
   z-index: 101;
   > [data-reach-dialog-content] {
     ${(p) => p.width && 'box-sizing: border-box;'}
-    flex-basis: ${(p) => !p.width && '100%'};
+    flex-basis: ${(p) => !p.width && p.flexBasis === undefined && '100%'};
     width: ${(p) => !p.width && '100%'};
     border: ${(p) => border(p.theme, '')};
     border-radius: ${radius(20)};
@@ -97,6 +109,7 @@ export const ModalPopUp = styled(DimmerStyled).withConfig({
     ${(p): string => boxShadow(p.theme, 2)};
     max-width: ${(p) => !p.width && '80%'};
     ${width}
+    ${flexbox}
     outline: none;
     padding: 64px 24px 40px 24px;
     position: relative;
@@ -147,7 +160,7 @@ export const ModalPopUp = styled(DimmerStyled).withConfig({
     }
   }
 `
-export const Modal = styled(Modalbase)``
+export const Modal = styled(ModalBase)``
 
 Modal.propTypes = {
   className: PropTypes.string,

--- a/modules/cactus-web/src/Preview/Preview.test.tsx
+++ b/modules/cactus-web/src/Preview/Preview.test.tsx
@@ -119,4 +119,22 @@ describe('component: Preview', () => {
       expect(getAllByAltText('Cute kitten number 1').length).toBe(1)
     })
   })
+
+  test('should support flex item props', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <Preview data-testid="flex-preview" flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+          {IMAGES.map((src, ix) => (
+            <img src={src} alt={`Cute kitten number ${ix + 1}`} key={ix} />
+          ))}
+        </Preview>
+      </StyleProvider>
+    )
+
+    const previewBox = getByTestId('flex-preview')
+    expect(previewBox).toHaveStyle('flex: 1')
+    expect(previewBox).toHaveStyle('flex-grow: 1')
+    expect(previewBox).toHaveStyle('flex-shrink: 0')
+    expect(previewBox).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/Preview/Preview.tsx
+++ b/modules/cactus-web/src/Preview/Preview.tsx
@@ -2,11 +2,12 @@ import { NavigationChevronLeft, NavigationChevronRight, NavigationClose } from '
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import { height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system'
+import { flexbox, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import Dimmer from '../Dimmer/Dimmer'
 import Flex from '../Flex/Flex'
 import { keyDownAsClick, preventAction } from '../helpers/a11y'
+import { FlexItemProps } from '../helpers/flexItem'
 import { boxShadow, radius } from '../helpers/theme'
 import IconButton from '../IconButton/IconButton'
 
@@ -14,6 +15,7 @@ interface PreviewProps
   extends MarginProps,
     WidthProps,
     HeightProps,
+    FlexItemProps,
     React.HTMLAttributes<HTMLDivElement> {
   images?: string[]
   phrases?: Phrases
@@ -168,6 +170,7 @@ const PreviewBox = styled.div<{ justify: 'space-between' | 'center' }>`
   justify-content: ${(p) => p.justify};
   align-items: center;
   ${margin}
+  ${flexbox}
 
   img {
     display: inline;

--- a/modules/cactus-web/src/Preview/Preview.tsx
+++ b/modules/cactus-web/src/Preview/Preview.tsx
@@ -2,12 +2,12 @@ import { NavigationChevronLeft, NavigationChevronRight, NavigationClose } from '
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import { flexbox, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system'
+import { height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import Dimmer from '../Dimmer/Dimmer'
 import Flex from '../Flex/Flex'
 import { keyDownAsClick, preventAction } from '../helpers/a11y'
-import { FlexItemProps } from '../helpers/flexItem'
+import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { boxShadow, radius } from '../helpers/theme'
 import IconButton from '../IconButton/IconButton'
 
@@ -170,7 +170,7 @@ const PreviewBox = styled.div<{ justify: 'space-between' | 'center' }>`
   justify-content: ${(p) => p.justify};
   align-items: center;
   ${margin}
-  ${flexbox}
+  ${flexItem}
 
   img {
     display: inline;

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.test.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.test.tsx
@@ -57,4 +57,27 @@ describe('component: RadioButtonField', (): void => {
     fireEvent.blur(getByLabelText('Aegon'))
     expect(onBlur).toHaveBeenCalled()
   })
+
+  test('should support flex item props', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <RadioButtonField
+          id="Targaryen"
+          name="rbf"
+          label="Aegon"
+          data-testid="flex-rbf"
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        />
+      </StyleProvider>
+    )
+
+    const radioField = getByTestId('flex-rbf').parentElement?.parentElement
+    expect(radioField).toHaveStyle('flex: 1')
+    expect(radioField).toHaveStyle('flex-grow: 1')
+    expect(radioField).toHaveStyle('flex-shrink: 0')
+    expect(radioField).toHaveStyle('flex-basis: 0')
+  })
 })

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
@@ -4,12 +4,16 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import FieldWrapper from '../FieldWrapper/FieldWrapper'
+import { FlexItemProps } from '../helpers/flexItem'
 import { omitMargins } from '../helpers/omit'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import RadioButton, { RadioButtonProps } from '../RadioButton/RadioButton'
 
-export interface RadioButtonFieldProps extends Omit<RadioButtonProps, 'id'>, MarginProps {
+export interface RadioButtonFieldProps
+  extends Omit<RadioButtonProps, 'id'>,
+    MarginProps,
+    FlexItemProps {
   label: React.ReactNode
   name: string
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
@@ -18,13 +22,28 @@ export interface RadioButtonFieldProps extends Omit<RadioButtonProps, 'id'>, Mar
 
 const RadioButtonFieldBase = React.forwardRef<HTMLInputElement, RadioButtonFieldProps>(
   (props, ref) => {
-    const { label, labelProps, id, className, name, ...radioButtonProps } = omitMargins(
-      props
-    ) as Omit<RadioButtonFieldProps, keyof MarginProps>
+    const {
+      label,
+      labelProps,
+      id,
+      className,
+      name,
+      flex,
+      flexGrow,
+      flexShrink,
+      flexBasis,
+      ...radioButtonProps
+    } = omitMargins(props) as Omit<RadioButtonFieldProps, keyof MarginProps>
     const radioButtonId = useId(id, name)
 
     return (
-      <FieldWrapper className={className}>
+      <FieldWrapper
+        className={className}
+        flex={flex}
+        flexGrow={flexGrow}
+        flexShrink={flexShrink}
+        flexBasis={flexBasis}
+      >
         <RadioButton ref={ref} id={radioButtonId} name={name} {...radioButtonProps} />
         <Label {...labelProps} htmlFor={radioButtonId}>
           {label}

--- a/modules/cactus-web/src/SelectField/SelectField.test.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.test.tsx
@@ -172,7 +172,32 @@ describe('component: SelectField', (): void => {
       </StyleProvider>
     )
 
-    expect(container).not.toBeNull()
+    expect(container.firstElementChild).toHaveStyle('margin-left: 8px')
+    expect(container.firstElementChild).toHaveStyle('margin-right: 8px')
+    expect(container.firstElementChild).toHaveStyle('margin-top: 8px')
+    expect(container.firstElementChild).toHaveStyle('margin-bottom: 8px')
+  })
+
+  test('should support flex item props', () => {
+    const { container } = render(
+      <StyleProvider>
+        <SelectField
+          label="Requires a label"
+          name="the-test-select-field"
+          id="for-the-snap"
+          options={['basic', 'options']}
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        />
+      </StyleProvider>
+    )
+
+    expect(container.firstElementChild).toHaveStyle('flex: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-grow: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-shrink: 0')
+    expect(container.firstElementChild).toHaveStyle('flex-basis: 0')
   })
 
   describe('should accept form event', (): void => {

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -35,6 +35,10 @@ const SelectFieldBase: SelectFieldType = (props): React.ReactElement => {
     autoTooltip,
     disableTooltip,
     alignTooltip,
+    flex,
+    flexGrow,
+    flexShrink,
+    flexBasis,
     ...rest
   } = omitMargins(props) as Omit<SelectFieldProps, keyof MarginProps>
   const [isOpen, setIsOpen] = React.useState(false)
@@ -55,6 +59,10 @@ const SelectFieldBase: SelectFieldType = (props): React.ReactElement => {
       isOpen={isOpen}
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
+      flex={flex}
+      flexGrow={flexGrow}
+      flexShrink={flexShrink}
+      flexBasis={flexBasis}
     >
       {({
         fieldId,

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.test.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.test.tsx
@@ -106,6 +106,29 @@ describe('component: TextAreaField', (): void => {
     )
 
     expect(container.firstElementChild).toHaveStyle('margin-left: 8px')
+    expect(container.firstElementChild).toHaveStyle('margin-right: 8px')
+  })
+
+  test('should support flex item props', () => {
+    const { container } = render(
+      <StyleProvider>
+        <TextAreaField
+          id="missing"
+          name="missing"
+          label="missing a comma"
+          tooltip="you are missing a comma, sir"
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        />
+      </StyleProvider>
+    )
+
+    expect(container.firstElementChild).toHaveStyle('flex: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-grow: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-shrink: 0')
+    expect(container.firstElementChild).toHaveStyle('flex-basis: 0')
   })
 
   test('should trigger onChange handler', (): void => {

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -27,6 +27,10 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
     autoTooltip,
     disableTooltip,
     alignTooltip,
+    flex,
+    flexGrow,
+    flexShrink,
+    flexBasis,
     ...textAreaProps
   } = omitMargins(props) as Omit<TextAreaFieldProps, keyof MarginProps>
 
@@ -45,6 +49,10 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
       autoTooltip={autoTooltip}
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
+      flex={flex}
+      flexGrow={flexGrow}
+      flexShrink={flexShrink}
+      flexBasis={flexBasis}
     >
       {({
         fieldId,

--- a/modules/cactus-web/src/TextInputField/TextInputField.test.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.test.tsx
@@ -103,6 +103,27 @@ describe('component: TextInputField', (): void => {
     expect(container.firstElementChild).toHaveStyle('margin: 8px')
   })
 
+  test('should support flex item props', () => {
+    const { container } = render(
+      <StyleProvider>
+        <TextInputField
+          id="margins"
+          name="margins"
+          label="Check out all these sick margins"
+          flex={1}
+          flexGrow={1}
+          flexShrink={0}
+          flexBasis={0}
+        />
+      </StyleProvider>
+    )
+
+    expect(container.firstElementChild).toHaveStyle('flex: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-grow: 1')
+    expect(container.firstElementChild).toHaveStyle('flex-shrink: 0')
+    expect(container.firstElementChild).toHaveStyle('flex-basis: 0')
+  })
+
   test('should trigger onChange handler', (): void => {
     const onChange = jest.fn()
     const { getByPlaceholderText } = render(

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -27,6 +27,10 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
     autoTooltip,
     disableTooltip,
     alignTooltip,
+    flex,
+    flexGrow,
+    flexShrink,
+    flexBasis,
     ...inputProps
   } = omitMargins(props) as Omit<TextInputFieldProps, keyof MarginProps>
 
@@ -45,6 +49,10 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
       autoTooltip={autoTooltip}
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
+      flex={flex}
+      flexGrow={flexGrow}
+      flexShrink={flexShrink}
+      flexBasis={flexBasis}
     >
       {({
         fieldId,

--- a/modules/cactus-web/src/helpers/flexItem.ts
+++ b/modules/cactus-web/src/helpers/flexItem.ts
@@ -1,0 +1,3 @@
+import { FlexboxProps } from 'styled-system'
+
+export type FlexItemProps = Pick<FlexboxProps, 'flex' | 'flexBasis' | 'flexGrow' | 'flexShrink'>

--- a/modules/cactus-web/src/helpers/flexItem.ts
+++ b/modules/cactus-web/src/helpers/flexItem.ts
@@ -1,3 +1,5 @@
-import { FlexboxProps } from 'styled-system'
+import { FlexboxProps, system } from 'styled-system'
 
 export type FlexItemProps = Pick<FlexboxProps, 'flex' | 'flexBasis' | 'flexGrow' | 'flexShrink'>
+
+export const flexItem = system({ flex: true, flexBasis: true, flexGrow: true, flexShrink: true })


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-613

A couple of points of discussion:

I didn't allow the props on `Table` or `DataGrid`. My thinking was that these components are typically meant to take up the majority of the screen's width. I couldn't really think of any use-cases for them to be rendered inside a `Flex` and their width to be adjusted, but I'm open to adding the props on them if you guys can see a reason to do so.

I went back and forth a lot when deciding whether or not we should add the props to the form field components (things like `TextInputField`, `TextAreaField`, `SelectField`, `DateInputField`, etc.). Ultimately I decided not to, since most use-cases I've seen either involve the fields taking up the entire width of the form or the form being sectioned off into a couple of columns. In either of those cases, though, I feel that they'd probably always be rendered inside block-level components like `Card` or `Box`, which _do_ now support the flex item props and therefore shouldn't really need them. However, I would like some opinions on this. If you guys think it'd be worth the effort, I can go back through and add them there too.

Also, for some reason it looked like the snapshots for the `FileInput`/`FileInputField` needed to be updated...no idea why that is since this branch is up-to-date with master.

### Testing
I didn't add or update any stories for these props. To be honest, I don't think it'd be worth it to do that for each of the components I updated. If you want to test them out you can render the components with updates inside a `Flex` and play around with the props that were added.