### PR TITLE
ColorPicker Docs Fix

### DIFF
--- a/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
+++ b/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
@@ -20,7 +20,7 @@ import IconButton from '../IconButton/IconButton'
 import TextButton from '../TextButton/TextButton'
 
 // Monkey! (fix IE11 issue in Saturation component)
-if (document && document.body && !document.contains) {
+if (typeof document !== 'undefined' && document?.body && !document.contains) {
   document.contains = document.body.contains.bind(document.body)
 }
 


### PR DESCRIPTION
There was a bit of code in the ColorPicker component that is incompatible with Gatsby's SSR, and therefore prevented the docs from publishing.  Behold...a fix.