### PR TITLE
CACTUS-634 :: Polyfills Bug

### DIFF
--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -8,8 +8,10 @@
   "repository": "https://github.com/repaygithub/cactus/tree/master/modules/cactus-web",
   "license": "MIT",
   "sideEffects": [
-    "./dist/helpers/polyfills.js",
-    "./cactus-addon/register.jsx"
+    "dist/helpers/polyfills.js",
+    "dist/index.js",
+    "src/helpers/polyfills.ts",
+    "cactus-addon/register.jsx"
   ],
   "scripts": {
     "cleanup": "rm -rf dist coverage .storybook/dist",

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1,5 +1,3 @@
-import '../helpers/polyfills'
-
 import { ActionsAdd, NavigationChevronDown } from '@repay/cactus-icons'
 import { BorderSize, CactusTheme, ColorStyle, TextStyle } from '@repay/cactus-theme'
 import isEqual from 'lodash/isEqual'

--- a/modules/cactus-web/src/index.ts
+++ b/modules/cactus-web/src/index.ts
@@ -1,3 +1,5 @@
+import './helpers/polyfills'
+
 export { AccessibleField, useAccessibleField } from './AccessibleField/AccessibleField'
 export { default as Accordion } from './Accordion/Accordion'
 export { default as ActionBar } from './ActionBar/ActionBar'


### PR DESCRIPTION
Webpack 5 is more agressive with tree shaking than Webpack 4, and it was removing our `polyfills.ts` file from the bundle.  This PR ensures that it is always included.  (The addition of `src/helpers/polyfills.ts` to the `sideEffects` field also ensures that it's included in the `cjs` bundle as well...it wasn't before since this line was missing, causing Rollup to ignore it.)

Ticket: https://repayonline.atlassian.net/browse/CACTUS-634

### Testing

1. Generate a bare-bones app with `create-repay-ui`
2. `cd` into your new application.  Upgrade `@repay/scripts` to v3.0.0.
3. Run `yarn start`, then try to load the application in IE11.
4. Confirm that it fails to load.  This is the bug.
5. Pull down this branch, and run `yarn cleanup && yarn build`.
6. `cd modules/cactus-web` and `yalc publish`.
7. Go back to the generated application.  Run `yalc add @repay/cactus-web` followed by `yarn`
8. Run `yarn start` again and go back to IE11.  Everything should work now.
9. If you want to be extra sure this will keep on working, you can upgrade `@repay/scripts` to v3.0.0 in the Cactus repo and repeat steps 5-8.