### PR TITLE
CACTUS-578 :: Mini Table

### DIFF
--- a/modules/cactus-web/src/DataGrid/BottomSection.tsx
+++ b/modules/cactus-web/src/DataGrid/BottomSection.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react'
 import styled, { useTheme } from 'styled-components'
 
 import { cloneAll } from '../helpers/react'
+import { textStyle } from '../helpers/theme'
 import { ScreenSizeContext } from '../ScreenSizeProvider/ScreenSizeProvider'
 import { DataGridContext, getMediaQuery } from './helpers'
 import { JustifyContent, TransientProps } from './types'
@@ -15,7 +16,7 @@ export interface BottomSectionProps {
 
 const BottomSection = (props: BottomSectionProps): React.ReactElement | null => {
   const { children, justifyContent = 'space-between', spacing = 4 } = props
-  const { isCardView, cardBreakpoint } = useContext(DataGridContext)
+  const { isCardView, cardBreakpoint, variant } = useContext(DataGridContext)
   const screenSize = useContext(ScreenSizeContext)
   const { space } = useTheme()
 
@@ -27,6 +28,7 @@ const BottomSection = (props: BottomSectionProps): React.ReactElement | null => 
       $isCardView={isCardView}
       $cardBreakpoint={cardBreakpoint}
       $justifyContent={justifyContent}
+      $variant={variant}
     >
       {cloneAll(
         children,
@@ -49,8 +51,9 @@ const StyledBottomSection = styled.div<TransientProps & { $justifyContent: Justi
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 40px;
+  margin-top: ${(p) => (p.$variant === 'mini' ? `${p.theme.space[3]}px` : `${p.theme.space[7]}px`)};
   padding: 0 16px;
+  ${(p) => textStyle(p.theme, p.$variant === 'mini' ? 'small' : 'body')}}
 
   // Non-card view styles
   ${getMediaQuery} {

--- a/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
@@ -69,6 +69,14 @@ const INITIAL_DATA = [
   },
 ]
 
+type Variant = 'table' | 'card' | 'mini'
+const varOptions = {
+  undefined: '',
+  table: 'table',
+  card: 'card',
+  mini: 'mini',
+}
+
 const BoolComponent = ({ value }: { value: boolean }): ReactElement => {
   return <div>{value ? 'YES' : 'NO'}</div>
 }
@@ -85,6 +93,7 @@ const DataGridContainer = ({
     ['tiny', 'small', 'medium', 'large', 'extraLarge'],
     'tiny'
   )
+  const variant = select('variant', varOptions, undefined) as Variant
   const size = useContext(ScreenSizeContext)
   const isCardView = cardBreakpoint && size <= SIZES[cardBreakpoint]
   const showResultsCount = includePaginationAndSort
@@ -222,6 +231,7 @@ const DataGridContainer = ({
       onPageChange={onPageChange}
       fullWidth={boolean('fullWidth', false)}
       cardBreakpoint={cardBreakpoint}
+      variant={variant}
     >
       {topSection && (
         <DataGrid.TopSection

--- a/modules/cactus-web/src/DataGrid/DataGrid.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.tsx
@@ -8,6 +8,7 @@ import useId from '../helpers/useId'
 import Pagination, { PaginationProps } from '../Pagination/Pagination'
 import PrevNext, { PrevNextProps } from '../PrevNext/PrevNext'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
+import { TableVariant } from '../Table/Table'
 import BottomSection, { BottomSectionProps } from './BottomSection'
 import DataGridTable, { DataGridTableProps } from './DataGridTable'
 import { DataGridContext, getMediaQuery } from './helpers'
@@ -31,6 +32,7 @@ interface DataGridProps extends MarginProps {
   children: React.ReactNode
   fullWidth?: boolean
   cardBreakpoint?: Size
+  variant?: TableVariant
 }
 
 export const DataGrid = (props: DataGridProps): ReactElement => {
@@ -42,6 +44,7 @@ export const DataGrid = (props: DataGridProps): ReactElement => {
     paginationOptions,
     onPageChange = () => undefined,
     cardBreakpoint = 'tiny',
+    variant,
     ...rest
   } = props
   const [columns, setColumns] = useState(new Map<string, DataColumnObject | ColumnObject>())
@@ -98,6 +101,7 @@ export const DataGrid = (props: DataGridProps): ReactElement => {
           fullWidth,
           cardBreakpoint,
           isCardView,
+          variant,
         }}
       >
         {!topSectionRendered && <TopSection />}

--- a/modules/cactus-web/src/DataGrid/DataGridTable.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGridTable.tsx
@@ -24,9 +24,15 @@ const isColumn = (col: any): col is ColumnObject => {
 const DataGridTable: React.FC<DataGridTableProps> = (props) => {
   const { children, data, ...rest } = props
 
-  const { columns, isCardView, cardBreakpoint, fullWidth, sortOptions, onSort } = useContext(
-    DataGridContext
-  )
+  const {
+    columns,
+    isCardView,
+    cardBreakpoint,
+    fullWidth,
+    sortOptions,
+    onSort,
+    variant,
+  } = useContext(DataGridContext)
 
   const handleSort = (id: string, exists: boolean) => {
     if (sortOptions) {
@@ -39,7 +45,7 @@ const DataGridTable: React.FC<DataGridTableProps> = (props) => {
   return (
     <>
       {children}
-      <Table fullWidth={fullWidth} cardBreakpoint={cardBreakpoint} {...rest}>
+      <Table fullWidth={fullWidth} cardBreakpoint={cardBreakpoint} variant={variant} {...rest}>
         <Table.Header>
           {[...columns.keys()].map((key) => {
             const column = columns.get(key)

--- a/modules/cactus-web/src/DataGrid/TopSection.tsx
+++ b/modules/cactus-web/src/DataGrid/TopSection.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement, useContext, useEffect, useMemo, useState } from 'r
 import styled, { useTheme } from 'styled-components'
 
 import { cloneAll } from '../helpers/react'
+import { textStyle } from '../helpers/theme'
 import MenuButton from '../MenuButton/MenuButton'
 import { ScreenSizeContext } from '../ScreenSizeProvider/ScreenSizeProvider'
 import { DataGridContext, getMediaQuery } from './helpers'
@@ -25,7 +26,9 @@ interface SortLabels {
 const TopSection = (props: TopSectionProps): ReactElement | null => {
   const [hasChildren, setHasChildren] = useState<boolean>(false)
   const { sortLabels = {}, children, justifyContent = 'space-between', spacing = 4 } = props
-  const { columns, sortOptions, onSort, isCardView, cardBreakpoint } = useContext(DataGridContext)
+  const { columns, sortOptions, onSort, isCardView, cardBreakpoint, variant } = useContext(
+    DataGridContext
+  )
   const screenSize = useContext(ScreenSizeContext)
   const { space } = useTheme()
   const sortableColumns = useMemo(() => {
@@ -78,6 +81,7 @@ const TopSection = (props: TopSectionProps): ReactElement | null => {
       $isCardView={isCardView}
       $cardBreakpoint={cardBreakpoint}
       $justifyContent={justifyContent}
+      $variant={variant}
     >
       {isCardView && sortableColumns.size > 0 && (
         <div className="sort-buttons">
@@ -125,9 +129,11 @@ const StyledTopSection = styled.div<TransientProps & { $justifyContent: JustifyC
   flex-direction: column;
   align-items: center;
   padding: 0 16px;
+  ${(p) => textStyle(p.theme, p.$variant === 'mini' ? 'small' : 'body')}}
 
   &.has-content {
-    margin-bottom: 40px;
+    margin-bottom: ${(p) =>
+      p.$variant === 'mini' ? `${p.theme.space[3]}px` : `${p.theme.space[7]}px`};
   }
 
   // Non-card view styles

--- a/modules/cactus-web/src/DataGrid/helpers.ts
+++ b/modules/cactus-web/src/DataGrid/helpers.ts
@@ -48,4 +48,5 @@ export const DataGridContext = createContext<DataGridContextType>({
   fullWidth: false,
   cardBreakpoint: 'tiny',
   isCardView: false,
+  variant: undefined,
 })

--- a/modules/cactus-web/src/DataGrid/types.ts
+++ b/modules/cactus-web/src/DataGrid/types.ts
@@ -1,5 +1,5 @@
 import { Size } from '../ScreenSizeProvider/ScreenSizeProvider'
-import { TableCellProps } from '../Table/Table'
+import { TableCellProps, TableVariant } from '../Table/Table'
 
 export type ColumnFn = (rowData: { [key: string]: any }) => React.ReactNode
 export type JustifyContent =
@@ -14,6 +14,7 @@ export type JustifyContent =
 export interface TransientProps {
   $isCardView: boolean
   $cardBreakpoint: Size
+  $variant?: TableVariant
 }
 
 export interface DataColumnObject {
@@ -63,4 +64,5 @@ export interface DataGridContextType {
   fullWidth: boolean
   cardBreakpoint: Size
   isCardView: boolean
+  variant: TableVariant | undefined
 }

--- a/modules/cactus-web/src/Table/Table.story.tsx
+++ b/modules/cactus-web/src/Table/Table.story.tsx
@@ -12,11 +12,12 @@ const alignOptions = {
   undefined: '',
 }
 
-type Variant = 'table' | 'card'
+type Variant = 'table' | 'card' | 'mini'
 const varOptions = {
   undefined: '',
   table: 'table',
   card: 'card',
+  mini: 'mini',
 }
 
 const createAlignKnob = (): CellAlignment =>

--- a/modules/cactus-web/src/Table/Table.test.tsx
+++ b/modules/cactus-web/src/Table/Table.test.tsx
@@ -31,4 +31,31 @@ describe('component: Table', (): void => {
     const singleCell = getByTestId('cell')
     expect(singleCell).toHaveStyle('width: 240px')
   })
+
+  test('renders mini table styles', () => {
+    const { getByTestId } = render(
+      <StyleProvider>
+        <Table variant="mini">
+          <Table.Header>
+            <Table.Cell data-testid="header-cell">Header Cell</Table.Cell>
+          </Table.Header>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell data-testid="data-cell">Data cell</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Data cell</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Data cell</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </StyleProvider>
+    )
+    const headerCell = getByTestId('header-cell')
+    const dataCell = getByTestId('data-cell')
+    expect(headerCell).toHaveStyle('padding: 8px')
+    expect(dataCell).toHaveStyle('padding: 8px')
+  })
 })

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -18,7 +18,7 @@ import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSize
 type CellAlignment = 'center' | 'right' | 'left'
 type CellType = 'th' | 'td'
 type BorderCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'
-type TableVariant = 'table' | 'card'
+export type TableVariant = 'table' | 'card' | 'mini'
 
 interface TableContextProps {
   cellType?: CellType
@@ -184,7 +184,7 @@ export const TableCell = React.forwardRef<HTMLTableDataCellElement, TableCellPro
       )
     }
 
-    props.variant = 'table'
+    props.variant = context.variant
     return (
       <StyledCell {...props} ref={ref}>
         {children}
@@ -245,7 +245,7 @@ Table.displayName = 'Table'
 Table.propTypes = {
   fullWidth: PropTypes.bool,
   cardBreakpoint: PropTypes.oneOf<Size>(['tiny', 'small', 'medium', 'large', 'extraLarge']),
-  variant: PropTypes.oneOf<TableVariant>(['table', 'card']),
+  variant: PropTypes.oneOf<TableVariant>(['table', 'card', 'mini']),
   as: PropTypes.elementType as PropTypes.Validator<React.ElementType>,
 }
 
@@ -302,6 +302,11 @@ const StyledCell = styled.td(
                 min-width: 160px;
               }
             `};
+    `,
+    mini: css<TableCellProps>`
+      text-align: ${(p): string => p.align || 'left'};
+      padding: 8px;
+      ${(p) => p.width && width};
     `,
     card: css`
       && {
@@ -363,7 +368,8 @@ const getCTABorder = (p: ThemeProps<CactusTheme>, focus?: boolean): ReturnType<t
 
 const table = css<TableProps>`
   display: table;
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
+  ${(p): FlattenSimpleInterpolation | TextStyle =>
+    textStyle(p.theme, p.variant === 'mini' ? 'small' : 'body')};
   border-spacing: 0;
   td,
   th {
@@ -488,5 +494,5 @@ const StyledTable = styled.table<TableProps>`
   th {
     font-weight: 600;
   }
-  ${variant({ table, card })};
+  ${variant({ table, card, mini: table })};
 `


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-578

### Testing

1. Check out this branch and start storybook
2. Bring up the Table > Layout story.
3. Set the variant to `mini`. Uncheck the `fullWidth` checkbox. Make sure the styles match the style guide. Question: should we still adhere to the `fullWidth` prop if the variant is `mini`?
4. Open the DataGrid > Basic Usage story. Set the variant to `mini` and make sure the styles match what's shown in the style guide.