### PR TITLE
CACTUS-650 :: Notification Border Radius

### DIFF
--- a/modules/cactus-web/src/Notification/Notification.tsx
+++ b/modules/cactus-web/src/Notification/Notification.tsx
@@ -39,6 +39,7 @@ const NotificationWrapper = styled.div<NotificationWrapperProps>`
   position: fixed;
   z-index: 100;
   background-color: ${(p) => p.theme.colors.white};
+  border-radius: 8px;
 
   ${getNotificationPosition}
 `


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-650

So this got me thinking when I picked it up...although the only children I've ever seen rendered in `Notification` are `Alert`s, it doesn't mean that's the _only_ thing you could render in there. I just don't know if we can reliably get child border-radius styles and apply them to the wrapper. I guess it won't matter soon since we'll be updating the colors and we can get rid of the wrapper altogether, so I suppose this will do for now.

### Testing
1. Pull down this branch and start storybook.
2. Go to the Notification > Basic Usage story.
3. Open the "Cactus Theme" tab in the storybook knobs section and check the "Inverse" checkbox under "Background".
4. Click the button to open the notification and make sure you don't see any white corners on the notification.