### PR TITLE
CACTUS-630: fix props tables for various components

### DIFF
--- a/modules/cactus-web/src/Avatar/Avatar.mdx
+++ b/modules/cactus-web/src/Avatar/Avatar.mdx
@@ -13,8 +13,7 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 ### Try it out
 
-export const code = `
-<Avatar type="feedback" status="error" />`
+export const code = `<Avatar type="feedback" status="error" />`
 
 <LiveProvider code={code} scope={{ Avatar }}>
   <LiveEditor style={livePreviewStyle} />
@@ -24,13 +23,13 @@ export const code = `
 
 ## Basic usage
 
-The `Avatar` component are small, circular, figures used to give additional feedback to users. The avatars have two usage options, feedback and alert, which alter the opacity of the background. `Avatar` have a type, which is the icon that provides feedback to the user. The types are: error, warning, info, and success.
+The `Avatar` component is a small, circular icon used to give additional feedback to users. The avatars have two usage options, feedback and alert, which alters the opacity of the background. The `type` prop determines which icon is displayed.
 
 ```jsx
 import Avatar from '@repay/cactus-web'
 import React from 'react'
 
-export default () => <Avatar avatarUsage="error" avatarType="warning" />
+export default () => <Avatar status="error" type="alert" />
 ```
 
 ## Properties

--- a/modules/cactus-web/src/Breadcrumb/Breadcrumb.mdx
+++ b/modules/cactus-web/src/Breadcrumb/Breadcrumb.mdx
@@ -10,7 +10,7 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 # Breadcrumb
 
-The `Breadcrumb` comopnent allows you to render a navigation of your previusly visited sites, including the current one
+The `Breadcrumb` component allows you to render a navigation of previously visited pages or page hierarchy, including the current page.
 
 ### Try it out
 

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.mdx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.mdx
@@ -40,7 +40,7 @@ export const code = `
 
 - Use meaningful labels to ensure accessibility.
 - `CheckBoxGroup` props will only be forwarded to the individual checkboxes if they are direct children of `CheckBoxGroup`.
-If you use an intermediate component, the component will have to accept the forwarded props and pass them on.
+If you use an intermediate component, it will have to accept the forwarded props and pass them on.
 - You can control the values using one of two methods, which should not be mixed:
   - Pass `checked` to `CheckBoxGroup`. This should be an object, mapping the checkbox names to their boolean values.
   - Pass `checked` or `defaultChecked` to `CheckBoxGroup.Item`s.

--- a/modules/cactus-web/src/ConfirmModal/ConfirmModal.mdx
+++ b/modules/cactus-web/src/ConfirmModal/ConfirmModal.mdx
@@ -14,7 +14,7 @@ import Button from '../Button/Button'
 # ConfirmModal
 
 The `ConfirmModal` is an implementation of the simple `Modal`, in which you can collect data from the user and/or confirm some action that could be dangerous.
-It also allows to pass an Icon as prop, that can be large or medium
+It also allows passing an Icon as a prop, to help indicate what kind of action is being confirmed.
 
 ### Try it out
 

--- a/modules/cactus-web/src/DataGrid/DataGrid.mdx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.mdx
@@ -211,7 +211,7 @@ render(<ScreenSizeProvider><DataGridContainer /></ScreenSizeProvider>)
 <PropsTable of={DataGrid} staticProp="DataGrid.TopSection" />
 
 ### DataGrid.Table
-<PropsTable of={Table} />
+<PropsTable of={DataGrid.Table} staticProp="DataGridTable" />
 
 ### DataGrid.Pagination
 <PropsTable of={DataGrid} staticProp="Pagination" />

--- a/modules/cactus-web/src/Dimmer/Dimmer.mdx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.mdx
@@ -42,4 +42,4 @@ export default () => {
 
 ## Properties
 
-<PropsTable of={Dimmer} />
+<PropsTable of={Dimmer} staticProp="Dimmer" />

--- a/modules/cactus-web/src/Divider/Divider.mdx
+++ b/modules/cactus-web/src/Divider/Divider.mdx
@@ -4,7 +4,9 @@ menu: Components
 ---
 
 import PropsTable from 'website-src/components/PropsTable'
+import { livePreviewStyle } from '../helpers/constants'
 import Divider from './Divider'
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 # Divider
 
@@ -12,11 +14,15 @@ This component is an `hr` that can be used to separate out sections of a form or
 
 ## Basic usage
 
-```tsx
-import * as React from 'react'
-import { Divider } from '@repay/cactus-web'
-;<Divider />
-```
+### Try it out
+
+export const code = `<Divider margin={4} />`
+
+<LiveProvider code={code} scope={{ Divider }}>
+  <LiveEditor style={livePreviewStyle} />
+  <LiveError />
+  <LivePreview />
+</LiveProvider>
 
 ## Properties
 

--- a/modules/cactus-web/src/Flex/Flex.mdx
+++ b/modules/cactus-web/src/Flex/Flex.mdx
@@ -3,7 +3,6 @@ name: Flex
 menu: Components
 ---
 
-import PropsTable from 'website-src/components/PropsTable'
 import { livePreviewStyle } from '../helpers/constants'
 import Flex from './Flex'
 import Button from '../Button/Button'
@@ -33,7 +32,7 @@ The `flexDirection=reverse` property should only be used for user experience pur
 
 ## Basic usage
 
-The `Flex` component is a generic component which is an extension of the [`Box`](../Box.md) component which adds flex based styling.
+The `Flex` component is a generic component which is an extension of the <a href="../box/">Box</a> component which adds flex based styling.
 
 ```jsx
 import React from 'react'
@@ -54,4 +53,4 @@ export default () => (
 
 ## Properties
 
-<PropsTable of={Flex} />
+Has the same styled props as <a href="../box/">Box</a>, plus the [styled-system flexbox](https://styled-system.com/api/#flexbox) props.

--- a/modules/cactus-web/src/Footer/Footer.mdx
+++ b/modules/cactus-web/src/Footer/Footer.mdx
@@ -45,7 +45,7 @@ export const code = `
 ## Properties
 
 ### Footer
-<PropsTable of={Footer} />
+<PropsTable of={Footer} staticProp="Footer" />
 
 ### Footer.Link
-<PropsTable of={Footer} staticProp="FooterLink" />
+<PropsTable of={Footer} staticProp="Footer.Link" />

--- a/modules/cactus-web/src/Layout/Layout.mdx
+++ b/modules/cactus-web/src/Layout/Layout.mdx
@@ -58,9 +58,6 @@ const MySite = () => (
 )
 ```
 
-The `Router` inside `Layout.Content` is used to navigate between different pages and components.
-Depending on the library, the MenuBar may also need to be connected to the Router so that links will work.
-
 ## Properties
 
 `Layout` takes no props aside from `children`.

--- a/modules/cactus-web/src/MenuButton/MenuButton.mdx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.mdx
@@ -109,7 +109,7 @@ export default props => {
 
 ## Properties
 
-<PropsTable of={MenuButton} />
+<PropsTable of={MenuButton} staticProp="MenuButton" />
 
 ## MenuButton Item
 

--- a/modules/cactus-web/src/Modal/Modal.mdx
+++ b/modules/cactus-web/src/Modal/Modal.mdx
@@ -1,3 +1,5 @@
+---
+
 name: Modal
 menu: Components
 

--- a/modules/cactus-web/src/PrevNext/PrevNext.mdx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.mdx
@@ -10,7 +10,7 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 # PrevNext
 
-The `PrevNext` component is similar to [Pagination](/components/pagination), but is used when it is unknown how many pages
+The `PrevNext` component is similar to <a to="../pagination/">Pagination</a>, but is used when it is unknown how many pages
 there are.  This component simply renders two links: one to go to the previous page, and another to
 go to the next page.  The caller controls what action is taken when the links are clicked and when
 the links should be disabled.  In addition, the caller can pass in custom text for the links to

--- a/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.mdx
+++ b/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.mdx
@@ -3,7 +3,7 @@ name: ScreenSizeProvider
 menu: Components
 ---
 
-import ScreenSizeProvider, { ScreenSizeContext, SIZES } from './ScreenSizeProvider'
+import ScreenSizeProvider, { SIZES, useScreenSize } from './ScreenSizeProvider'
 import StyleProvider from '../StyleProvider/StyleProvider'
 import { livePreviewStyle } from '../helpers/constants'
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
@@ -15,13 +15,13 @@ The `ScreenSizeProvider` gives a programatic way of determining what the current
 
 ## Basic Usage
 
-You can utilize the value of the provider via the `ScreenSizeContext`. The value is not a string, but calling `toString()` on it will give you the name of the size. There is also a `SIZES` constant that can be used to do comparison logic.
+You can utilize the value of the provider via the `useScreenSize` hook. The value is not a string, but calling `toString()` on it will give you the name of the size. There is also a `SIZES` constant that can be used to do comparison logic.
 
 ```jsx
-import { ScreenSizeContext, SIZES } from '@repay/cactus-web'
+import { SIZES, useScreenSize } from '@repay/cactus-web'
 
 const SmallScreensOnly = () => {
-  const size = React.useContext(ScreenSizeContext)
+  const size = useScreenSize()
   if (size < SIZES.medium) {
     return `This screen is ${size.toString()}.`
   }
@@ -35,13 +35,13 @@ const SmallScreensOnly = () => {
 
 export const code = `
 function ScreenSize() {
-  const size = React.useContext(ScreenSizeContext)
+  const size = useScreenSize()
   return <>{size.toString()}</>
 }
 render(<StyleProvider><ScreenSizeProvider><ScreenSize/></ScreenSizeProvider></StyleProvider>)
 `
 
-<LiveProvider code={code} scope={{ ScreenSizeProvider, ScreenSizeContext, SIZES, StyleProvider }} noInline>
+<LiveProvider code={code} scope={{ ScreenSizeProvider, SIZES, StyleProvider, useScreenSize }} noInline>
   <LiveEditor style={livePreviewStyle} />
   <LiveError />
   <LivePreview />

--- a/modules/cactus-web/src/Spinner/Spinner.mdx
+++ b/modules/cactus-web/src/Spinner/Spinner.mdx
@@ -3,7 +3,6 @@ name: Spinner
 menu: Components
 ---
 
-import PropsTable from 'website-src/components/PropsTable'
 import { livePreviewStyle } from '../helpers/constants'
 import Spinner from './Spinner'
 import cactusTheme from '@repay/cactus-theme'
@@ -40,4 +39,4 @@ export default ({ isLoading }) => (isLoading ? <Spinner /> : <div>Content</div>)
 
 ## Properties
 
-<PropsTable of={Spinner} />
+Has the same props as the icons from `@repay/cactus-icons`.

--- a/modules/cactus-web/src/SplitButton/SplitButton.mdx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.mdx
@@ -39,7 +39,7 @@ single action.
 
 ### SplitButton
 
-<PropsTable of={SplitButton} />
+<PropsTable of={SplitButton} staticProp="SplitButton" />
 
 ### SplitButton Action
 

--- a/modules/cactus-web/src/StyleProvider/StyleProvider.mdx
+++ b/modules/cactus-web/src/StyleProvider/StyleProvider.mdx
@@ -76,4 +76,4 @@ const App = () => {
 
 # Properties
 
-<PropsTable of={StyleProvider} />
+<PropsTable of={StyleProvider} staticProp="StyleProvider" />

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -255,7 +255,7 @@ const StyledLink = styled(Link)`
 
 const StyledA = StyledLink.withComponent('a')
 
-const isStorybookUrl = (url: string): boolean => /stories\/[a-zA-Z]/.test(url)
+const isExternalUrl = (url: string): boolean => /^http/.test(url)
 
 const NavToggle = ({ toggle, ...rest }: any): React.ReactElement => (
   <IconButton {...rest} onClick={toggle} label="open section" iconSize="small">
@@ -269,7 +269,7 @@ const MenuItem: React.FC<{ item: MenuGroup }> = ({ item }): React.ReactElement =
 
   return (
     <li>
-      {isStorybookUrl(item.url) ? (
+      {isExternalUrl(item.url) ? (
         <StyledA href={item.url}>{item.title}</StyledA>
       ) : (
         <StyledLink to={item.url} onClick={toggle}>

--- a/website/src/components/PropsTable.tsx
+++ b/website/src/components/PropsTable.tsx
@@ -158,7 +158,9 @@ const PropsTable: React.FC<PropsTableProps> = ({
   staticProp,
 }): React.ReactElement | null => {
   const data = useDocgen()
-  const fileName = component.__filemeta && component.__filemeta.filename
+  // Not sure why some pull from `dist` instead of `src`.
+  const fileName =
+    component.__filemeta && component.__filemeta.filename.replace(/dist(.*)js/, 'src$1tsx')
   const docItem = data.find((doc): boolean => doc.key === fileName)
 
   const { ownProps, styledSystemProps } = React.useMemo((): PropsMemo => {


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-630

Also fixed a few other problems with bad links, grammar, outdated info, etc., though I'm sure I didn't get everything.

The doc generator seems so random... A few components have their filename from `dist` instead of `src`; some components have an automatically generated `displayName`, some don't, and some don't even seem to work when they have an _explicit_ `displayName`. Grr.