### PR TITLE
CACTUS-658 :: Increase MenuBar dropdown min-width

### DIFF
--- a/modules/cactus-web/src/MenuBar/MenuBar.tsx
+++ b/modules/cactus-web/src/MenuBar/MenuBar.tsx
@@ -151,26 +151,17 @@ const MenuBarList = React.forwardRef<HTMLSpanElement, ListProps>(
     const variant = useVariant()
     const isTopbar = variant === 'top'
     const { wrapperProps, buttonProps, popupProps } = useSubmenu(props.id, isTopbar)
-    const menuBtnRef: React.MutableRefObject<HTMLSpanElement | null> = React.useRef(null)
-    const [menuBtnWidth, setMenuBtnWidth] = React.useState<number | undefined>(undefined)
-
-    React.useImperativeHandle(ref, () => menuBtnRef.current as HTMLSpanElement)
-    React.useEffect(() => {
-      setMenuBtnWidth(menuBtnRef.current?.getBoundingClientRect().width)
-    }, [menuBtnRef])
 
     return (
       <li {...wrapperProps}>
-        <MenuButton {...props} {...buttonProps} ref={menuBtnRef}>
+        <MenuButton {...props} {...buttonProps} ref={ref}>
           <TextWrapper>{title}</TextWrapper>
           <IconWrapper aria-hidden>
             <NavigationArrowDown />
           </IconWrapper>
         </MenuButton>
         {isTopbar ? (
-          <FloatingMenu minWidth={menuBtnWidth} {...popupProps}>
-            {children}
-          </FloatingMenu>
+          <FloatingMenu {...popupProps}>{children}</FloatingMenu>
         ) : (
           <SideMenu {...popupProps} aria-orientation="vertical">
             {children}
@@ -204,21 +195,16 @@ const getPanelScrollInfo: GetScrollInfo = (menu) => ({
   listItems: getVisibleMenuItems(menu),
 })
 
-interface FoatingMenuProps extends React.HTMLAttributes<HTMLElement> {
-  minWidth: number | undefined
-}
-
-const FloatingMenu: React.FC<FoatingMenuProps> = ({
+const FloatingMenu: React.FC<React.HTMLAttributes<HTMLElement>> = ({
   children,
   'aria-hidden': hidden,
   tabIndex,
   onKeyDown,
-  minWidth,
   ...props
 }) => {
   const [menuRef, scroll] = useScroll<HTMLUListElement>('vertical', !hidden, getWrappedScrollInfo)
   return (
-    <MenuWrapper aria-hidden={hidden} minWidth={minWidth} tabIndex={tabIndex} onKeyDown={onKeyDown}>
+    <MenuWrapper aria-hidden={hidden} tabIndex={tabIndex} onKeyDown={onKeyDown}>
       <ScrollButton hidden={!scroll.showScroll} onClick={scroll.clickBack}>
         <NavigationChevronUp />
       </ScrollButton>
@@ -485,7 +471,7 @@ const SidebarMenu = styled.ul`
   }
 `
 
-const MenuWrapper = styled.div<{ minWidth: number | undefined }>`
+const MenuWrapper = styled.div`
   ${(p) => p.theme.colorStyles.standard};
   display: flex;
   &[aria-hidden='true'] {
@@ -502,7 +488,7 @@ const MenuWrapper = styled.div<{ minWidth: number | undefined }>`
   flex-flow: column nowrap;
   align-items: stretch;
   width: max-content;
-  min-width: ${(p) => (p.minWidth ? `${p.minWidth}px` : '200px')};
+  min-width: 200px;
   max-width: 320px;
   max-height: 70vh;
   z-index: 100;

--- a/modules/cactus-web/src/MenuBar/scroll.ts
+++ b/modules/cactus-web/src/MenuBar/scroll.ts
@@ -64,6 +64,7 @@ function positionMenu(menuWrapper: HTMLElement, menuButton: HTMLElement | null) 
   // Using 3d because Safari handles the z-index stupidly https://bucketpress.com/css-translate-and-z-index-problems-in-safari-browser
   menuWrapper.style.transform = `translate3d(${left}px, 0, 0)`
   menuWrapper.style.top = top || ''
+  menuWrapper.style.minWidth = `${buttonRect.width}px`
 }
 
 const isExpanded = (button: HTMLElement) => button.getAttribute('aria-expanded') === 'true'


### PR DESCRIPTION
[CACTUS-658](https://repayonline.atlassian.net/browse/CACTUS-658)

This is my solution to this ticket. I just wanted to implement a dynamic `min-width` value depending on the `MenuButton` `width`,

I followed [this](https://medium.com/vimeo-engineering-blog/handling-internal-and-external-refs-to-the-same-element-with-useimperativehandle-in-react-746ff6d377fe) approach.

I would like to validate with you guys if what I've done is a valid solution and it doesn't _block_ any feature. 

### To test this you must:

1. Pull this branch and run the stories. 
2. Go to the Layout story and check if the dropdown item in the MenuBar works well and the floating menu is currently taking the same width as their menu button.

<img width="779" alt="Screen Shot 2021-07-06 at 11 42 44 AM" src="https://user-images.githubusercontent.com/77983162/124643651-f1c97e80-de56-11eb-8989-e33d650fdd44.png">
