### PR TITLE
CACTUS-661 :: Flatten Action Colors

### DIFF
--- a/docs/Design Guides/Theme.mdx
+++ b/docs/Design Guides/Theme.mdx
@@ -49,7 +49,7 @@ Our color scheme uses a monochromatic palette and a complementary action scheme.
   <Grid.Item tiny={6} medium={4} large={3}>
     <Flex height='100px' justifyContent='space-between'>
         <Box width='100%' height='48px' borderRadius='themed' backgroundColor='callToAction'/>
-        <Box width='100%' height='48px' borderRadius='themed' backgroundColor='transparentCTA'/>
+        <Box width='100%' height='48px' borderRadius='themed' backgroundColor='lightCallToAction'/>
     </Flex>
     <Text fontWeight='600'>CTA</Text>
 
@@ -74,7 +74,8 @@ Our color scheme uses a monochromatic palette and a complementary action scheme.
 <Grid>
   <Grid.Item tiny={6} medium={4} large={3}>
   <Flex height='100px' justifyContent='space-between'>
-        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='transparentSuccess'/>
+        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='successLight'/>
+        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='successMedium'/>
         <Box width='100%' height='30px' borderRadius='themed' backgroundColor='success'/>
         <Box width='100%' height='30px' borderRadius='themed' backgroundColor='successDark'/>
     </Flex>    
@@ -82,7 +83,8 @@ Our color scheme uses a monochromatic palette and a complementary action scheme.
   </Grid.Item>
   <Grid.Item tiny={6} medium={4} large={3}>
     <Flex height='100px' justifyContent='space-between'>
-        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='transparentError'/>
+        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='errorLight'/>
+        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='errorMedium'/>
         <Box width='100%' height='30px' borderRadius='themed' backgroundColor='error'/>
         <Box width='100%' height='30px' borderRadius='themed' backgroundColor='errorDark'/>
     </Flex>    
@@ -91,7 +93,8 @@ Our color scheme uses a monochromatic palette and a complementary action scheme.
   </Grid.Item>
   <Grid.Item tiny={6} medium={4} large={3}>
     <Flex height='100px' justifyContent='space-between'>
-        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='transparentWarning'/>
+        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='warningLight'/>
+        <Box width='100%' height='30px' borderRadius='themed' backgroundColor='warningMedium'/>
         <Box width='100%' height='30px' borderRadius='themed' backgroundColor='warning'/>
         <Box width='100%' height='30px' borderRadius='themed' backgroundColor='warningDark'/>
     </Flex>    

--- a/modules/cactus-theme/src/theme.ts
+++ b/modules/cactus-theme/src/theme.ts
@@ -74,7 +74,7 @@ export interface CactusTheme {
     baseText: string
     callToAction: string
     callToActionText: string
-    transparentCTA: string
+    lightCallToAction: string
 
     /** Contrasts */
     lightContrast: string
@@ -92,12 +92,15 @@ export interface CactusTheme {
     success: string
     warning: string
     error: string
-    transparentSuccess: string
-    transparentWarning: string
-    transparentError: string
-    errorDark: string
-    warningDark: string
+    successLight: string
+    warningLight: string
+    errorLight: string
+    successMedium: string
+    warningMedium: string
+    errorMedium: string
     successDark: string
+    warningDark: string
+    errorDark: string
 
     status: StatusColors
   }
@@ -117,13 +120,16 @@ export interface CactusTheme {
     error: ColorStyle
     warning: ColorStyle
     disable: ColorStyle
-    transparentCTA: ColorStyle
-    transparentError: ColorStyle
-    transparentSuccess: ColorStyle
-    transparentWarning: ColorStyle
+    lightCallToAction: ColorStyle
+    successLight: ColorStyle
+    errorLight: ColorStyle
+    warningLight: ColorStyle
+    successMedium: ColorStyle
+    errorMedium: ColorStyle
+    warningMedium: ColorStyle
+    successDark: ColorStyle
     errorDark: ColorStyle
     warningDark: ColorStyle
-    successDark: ColorStyle
   }
   border: BorderSize
   shape: Shape
@@ -138,32 +144,35 @@ export type ColorVariant = keyof CactusTheme['colorStyles']
 const grayscaleLightContrast = 'hsl(0, 0%, 90%)'
 
 /** Neutrals */
-const white = `hsl(0, 0%, 100%)`
-const lightGray = `hsl(0, 0%, 90%)`
-const mediumGray = `hsl(0, 0%, 70%)`
-const darkGray = `hsl(0, 0%, 50%)`
+const white = 'hsl(0, 0%, 100%)'
+const lightGray = 'hsl(0, 0%, 90%)'
+const mediumGray = 'hsl(0, 0%, 70%)'
+const darkGray = 'hsl(0, 0%, 50%)'
 
 /** Notification Colors */
-const success = `hsl(145, 89%, 28%)`
-const error = `hsl(353, 84%, 44%)`
-const warning = `hsl(47, 82%, 47%)`
-const transparentSuccess = `hsla(145, 89%, 28%, 0.3)`
-const transparentError = `hsla(353, 84%, 44%, 0.3)`
-const transparentWarning = `hsla(47, 82%, 47%, 0.3)`
-const errorDark = `hsl(353, 96%, 11%)`
-const warningDark = `hsl(47, 96%, 11%)`
-const successDark = `hsl(145, 96%, 11%)`
+const success = 'hsl(145, 89%, 28%)'
+const error = 'hsl(353, 84%, 44%)'
+const warning = 'hsl(47, 82%, 47%)'
+const successLight = 'hsl(145, 33%, 78%)'
+const errorLight = 'hsl(353, 67%, 83%)'
+const warningLight = 'hsl(47, 73%, 84%)'
+const successMedium = 'hsl(145, 33%, 63%)'
+const errorMedium = 'hsl(353, 67%, 72%)'
+const warningMedium = 'hsl(47, 72%, 73%)'
+const errorDark = 'hsl(353, 96%, 11%)'
+const warningDark = 'hsl(47, 96%, 11%)'
+const successDark = 'hsl(145, 96%, 11%)'
 
 const status: StatusColors = {
   background: {
-    success: transparentSuccess,
-    warning: transparentWarning,
-    error: transparentError,
+    success: successLight,
+    warning: warningLight,
+    error: errorLight,
   },
   avatar: {
-    success: transparentSuccess,
-    warning: transparentWarning,
-    error: transparentError,
+    success: successMedium,
+    warning: warningMedium,
+    error: errorMedium,
   },
 }
 
@@ -179,15 +188,34 @@ interface HueGeneratorOptions extends SharedGeneratorOptions {
   primaryHue: number
 }
 
+function convertToLightCTASaturation(ctaSaturation: number, ctaLightness: number): number {
+  return Math.round(1.5 * (ctaLightness / 10) * (ctaSaturation / 10) - 1.5 * (ctaLightness / 10))
+}
+
+function getHslString(colorParams: number[]): string {
+  const [hue, saturation, lightness] = colorParams
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`
+}
+
+function getLightCallToAction(ctaParams: number[]): string {
+  const [ctaHue, ctaSaturation, ctaLightness] = ctaParams
+  const lightCTAHue = ctaHue
+  const lightCTASaturation =
+    ctaLightness <= 50 ? convertToLightCTASaturation(ctaSaturation, ctaLightness) : ctaSaturation
+  const lightCTALightness = Math.round((ctaLightness / 10) * 3 + 70)
+  return getHslString([lightCTAHue, lightCTASaturation, lightCTALightness])
+}
+
 function fromHue({
   primaryHue,
 }: HueGeneratorOptions): [CactusTheme['colors'], CactusTheme['colorStyles']] {
   /** Core colors */
   const base = `hsl(${primaryHue}, 96%, 11%)`
   const baseText = `hsl(0, 0%, 100%)`
-  const callToAction = `hsl(${primaryHue}, 96%, 35%)`
+  const ctaParams = [primaryHue, 96, 35]
+  const callToAction = getHslString(ctaParams)
   const callToActionText = `hsl(0, 0%, 100%)`
-  const transparentCTA = `hsla(${primaryHue}, 96%, 35%, 0.3)`
+  const lightCallToAction = getLightCallToAction(ctaParams)
 
   /** Contrasts */
   const lightContrast = `hsl(${primaryHue}, 29%, 90%)`
@@ -202,7 +230,7 @@ function fromHue({
       baseText,
       callToAction,
       callToActionText,
-      transparentCTA,
+      lightCallToAction,
 
       /** Contrasts */
       lightContrast,
@@ -220,12 +248,15 @@ function fromHue({
       success,
       error,
       warning,
-      transparentSuccess,
-      transparentError,
-      transparentWarning,
+      successLight,
+      errorLight,
+      warningLight,
+      successMedium,
+      errorMedium,
+      warningMedium,
+      successDark,
       errorDark,
       warningDark,
-      successDark,
 
       /** Status Colors */
       status,
@@ -267,20 +298,32 @@ function fromHue({
         backgroundColor: lightGray,
         color: mediumGray,
       },
-      transparentCTA: {
-        backgroundColor: transparentCTA,
+      lightCallToAction: {
+        backgroundColor: lightCallToAction,
         color: darkestContrast,
       },
-      transparentError: {
-        backgroundColor: transparentError,
+      successLight: {
+        backgroundColor: successLight,
         color: darkestContrast,
       },
-      transparentSuccess: {
-        backgroundColor: transparentSuccess,
+      errorLight: {
+        backgroundColor: errorLight,
         color: darkestContrast,
       },
-      transparentWarning: {
-        backgroundColor: transparentWarning,
+      warningLight: {
+        backgroundColor: warningLight,
+        color: darkContrast,
+      },
+      successMedium: {
+        backgroundColor: successMedium,
+        color: darkestContrast,
+      },
+      errorMedium: {
+        backgroundColor: errorMedium,
+        color: darkestContrast,
+      },
+      warningMedium: {
+        backgroundColor: warningMedium,
         color: darkContrast,
       },
       errorDark: {
@@ -318,8 +361,9 @@ function fromTwoWhite(primaryHue: number): [CactusTheme['colors'], CactusTheme['
   const darkContrast = `hsl(${primaryHue}, 9%, 35%)`
   const darkestContrast = `hsl(${primaryHue}, 10%, 20%)`
 
-  const callToAction = `hsl(244, 48%, 26%)`
-  const transparentCTA = `hsla(244, 48%, 26%, 0.3)`
+  const ctaParams = [244, 48, 26]
+  const callToAction = getHslString(ctaParams)
+  const lightCallToAction = getLightCallToAction(ctaParams)
   const callToActionText = white
 
   return [
@@ -327,9 +371,9 @@ function fromTwoWhite(primaryHue: number): [CactusTheme['colors'], CactusTheme['
       /** Core colors */
       base: white,
       baseText: darkestContrast,
-      callToAction: callToAction,
-      callToActionText: callToActionText,
-      transparentCTA: transparentCTA,
+      callToAction,
+      callToActionText,
+      lightCallToAction,
 
       /** Contrasts */
       lightContrast,
@@ -347,12 +391,15 @@ function fromTwoWhite(primaryHue: number): [CactusTheme['colors'], CactusTheme['
       success,
       error,
       warning,
-      transparentSuccess,
-      transparentError,
-      transparentWarning,
+      successLight,
+      errorLight,
+      warningLight,
+      successMedium,
+      errorMedium,
+      warningMedium,
+      successDark,
       errorDark,
       warningDark,
-      successDark,
 
       /** Status Colors */
       status,
@@ -394,21 +441,33 @@ function fromTwoWhite(primaryHue: number): [CactusTheme['colors'], CactusTheme['
         backgroundColor: lightGray,
         color: mediumGray,
       },
-      transparentCTA: {
-        backgroundColor: transparentCTA,
+      lightCallToAction: {
+        backgroundColor: lightCallToAction,
         color: darkestContrast,
       },
-      transparentError: {
-        backgroundColor: transparentError,
+      successLight: {
+        backgroundColor: successLight,
         color: darkestContrast,
       },
-      transparentSuccess: {
-        backgroundColor: transparentSuccess,
+      errorLight: {
+        backgroundColor: errorLight,
         color: darkestContrast,
       },
-      transparentWarning: {
-        backgroundColor: transparentWarning,
+      warningLight: {
+        backgroundColor: warningLight,
+        color: darkContrast,
+      },
+      successMedium: {
+        backgroundColor: successMedium,
         color: darkestContrast,
+      },
+      errorMedium: {
+        backgroundColor: errorMedium,
+        color: darkestContrast,
+      },
+      warningMedium: {
+        backgroundColor: warningMedium,
+        color: darkContrast,
       },
       errorDark: {
         backgroundColor: errorDark,
@@ -446,9 +505,10 @@ function fromWhiteSecondary(
   const updatedSecondaryHue = primary.lightness !== 0 ? primary.hue : 244
   const updatedSecondarySaturation = primary.lightness > 21 ? 98 : 96
   const updatedSecondaryLightness = primary.lightness > 21 ? 10 : 35
-  const callToAction = `hsl(${updatedSecondaryHue}, ${updatedSecondarySaturation}%, ${updatedSecondaryLightness}%)`
+  const ctaParams = [updatedSecondaryHue, updatedSecondarySaturation, updatedSecondaryLightness]
+  const callToAction = getHslString(ctaParams)
   const callToActionText = white
-  const transparentCTA = `hsla(${updatedSecondaryHue}, ${updatedSecondarySaturation}%, ${updatedSecondaryLightness}%, 0.3)`
+  const lightCallToAction = getLightCallToAction(ctaParams)
 
   return [
     {
@@ -457,7 +517,7 @@ function fromWhiteSecondary(
       baseText,
       callToAction,
       callToActionText,
-      transparentCTA,
+      lightCallToAction,
 
       /** Contrasts */
       lightContrast,
@@ -475,12 +535,15 @@ function fromWhiteSecondary(
       success,
       error,
       warning,
-      transparentSuccess,
-      transparentError,
-      transparentWarning,
+      successLight,
+      errorLight,
+      warningLight,
+      successMedium,
+      errorMedium,
+      warningMedium,
+      successDark,
       errorDark,
       warningDark,
-      successDark,
 
       /** Status Colors */
       status,
@@ -522,20 +585,32 @@ function fromWhiteSecondary(
         backgroundColor: lightGray,
         color: mediumGray,
       },
-      transparentCTA: {
-        backgroundColor: transparentCTA,
+      lightCallToAction: {
+        backgroundColor: lightCallToAction,
         color: darkestContrast,
       },
-      transparentError: {
-        backgroundColor: transparentError,
+      successLight: {
+        backgroundColor: successLight,
         color: darkestContrast,
       },
-      transparentSuccess: {
-        backgroundColor: transparentSuccess,
+      errorLight: {
+        backgroundColor: errorLight,
         color: darkestContrast,
       },
-      transparentWarning: {
-        backgroundColor: transparentWarning,
+      warningLight: {
+        backgroundColor: warningLight,
+        color: darkContrast,
+      },
+      successMedium: {
+        backgroundColor: successMedium,
+        color: darkestContrast,
+      },
+      errorMedium: {
+        backgroundColor: errorMedium,
+        color: darkestContrast,
+      },
+      warningMedium: {
+        backgroundColor: warningMedium,
         color: darkContrast,
       },
       errorDark: {
@@ -569,9 +644,10 @@ function fromTwoNonWhite(
 
   const baseText = isDark(...primary.rgb) ? white : darkestContrast
 
-  const callToAction = `hsl(${secondary.hue}, ${secondary.saturation}%, ${secondary.lightness}%)`
+  const ctaParams = [secondary.hue, secondary.saturation, secondary.lightness]
+  const callToAction = getHslString(ctaParams)
   const callToActionText = isDark(...secondary.rgb) ? white : darkestContrast
-  const transparentCTA = `hsla(${secondary.hue}, ${secondary.saturation}%, ${secondary.lightness}%, 0.3)`
+  const lightCallToAction = getLightCallToAction(ctaParams)
 
   return [
     {
@@ -580,7 +656,7 @@ function fromTwoNonWhite(
       baseText,
       callToAction,
       callToActionText,
-      transparentCTA,
+      lightCallToAction,
 
       /** Contrasts */
       lightContrast,
@@ -598,12 +674,15 @@ function fromTwoNonWhite(
       success,
       error,
       warning,
-      transparentSuccess,
-      transparentError,
-      transparentWarning,
+      successLight,
+      errorLight,
+      warningLight,
+      successMedium,
+      errorMedium,
+      warningMedium,
+      successDark,
       errorDark,
       warningDark,
-      successDark,
 
       /** Status Colors */
       status,
@@ -645,20 +724,32 @@ function fromTwoNonWhite(
         backgroundColor: lightGray,
         color: mediumGray,
       },
-      transparentCTA: {
-        backgroundColor: transparentCTA,
+      lightCallToAction: {
+        backgroundColor: lightCallToAction,
         color: darkestContrast,
       },
-      transparentError: {
-        backgroundColor: transparentError,
+      successLight: {
+        backgroundColor: successLight,
         color: darkestContrast,
       },
-      transparentSuccess: {
-        backgroundColor: transparentSuccess,
+      errorLight: {
+        backgroundColor: errorLight,
         color: darkestContrast,
       },
-      transparentWarning: {
-        backgroundColor: transparentWarning,
+      warningLight: {
+        backgroundColor: warningLight,
+        color: darkContrast,
+      },
+      successMedium: {
+        backgroundColor: successMedium,
+        color: darkestContrast,
+      },
+      errorMedium: {
+        backgroundColor: errorMedium,
+        color: darkestContrast,
+      },
+      warningMedium: {
+        backgroundColor: warningMedium,
         color: darkContrast,
       },
       errorDark: {

--- a/modules/cactus-theme/tests/theme.test.ts
+++ b/modules/cactus-theme/tests/theme.test.ts
@@ -24,16 +24,7 @@ function themeAccessibility(themeName: string, theme: CactusTheme): void {
     })
 
     Object.keys(theme.colorStyles).forEach((name): void => {
-      if (name.includes('transparent')) {
-        test(`colorStyle ${name}`, (): void => {
-          const color = new Color(theme.colorStyles[name].backgroundColor)
-          expect(
-            color
-              .mix(new Color('white').alpha(1 - color.alpha()))
-              .contrast(new Color(theme.colorStyles[name].color))
-          ).toBeGreaterThanOrEqual(4.5)
-        })
-      } else if (typeof name === 'string' && name !== 'disable') {
+      if (name !== 'disable') {
         test(`colorStyle ${name}`, (): void => {
           expect(
             new Color(theme.colorStyles[name].backgroundColor).contrast(
@@ -44,6 +35,67 @@ function themeAccessibility(themeName: string, theme: CactusTheme): void {
       }
     })
   })
+}
+
+const white = 'hsl(0, 0%, 100%)'
+
+const expectedActionColors = {
+  success: 'hsl(145, 89%, 28%)',
+  warning: 'hsl(47, 82%, 47%)',
+  error: 'hsl(353, 84%, 44%)',
+  successLight: 'hsl(145, 33%, 78%)',
+  warningLight: 'hsl(47, 73%, 84%)',
+  errorLight: 'hsl(353, 67%, 83%)',
+  successMedium: 'hsl(145, 33%, 63%)',
+  warningMedium: 'hsl(47, 72%, 73%)',
+  errorMedium: 'hsl(353, 67%, 72%)',
+  successDark: 'hsl(145, 96%, 11%)',
+  warningDark: 'hsl(47, 96%, 11%)',
+  errorDark: 'hsl(353, 96%, 11%)',
+}
+
+const expectedActionStyles = {
+  success: {
+    backgroundColor: expectedActionColors.success,
+    color: white,
+  },
+  error: {
+    backgroundColor: expectedActionColors.error,
+    color: white,
+  },
+  warning: {
+    backgroundColor: expectedActionColors.warning,
+  },
+  successLight: {
+    backgroundColor: expectedActionColors.successLight,
+  },
+  errorLight: {
+    backgroundColor: expectedActionColors.errorLight,
+  },
+  warningLight: {
+    backgroundColor: expectedActionColors.warningLight,
+  },
+  successMedium: {
+    backgroundColor: expectedActionColors.successMedium,
+  },
+  errorMedium: {
+    backgroundColor: expectedActionColors.errorMedium,
+  },
+  warningMedium: {
+    backgroundColor: expectedActionColors.warningMedium,
+  },
+  successDark: {
+    backgroundColor: expectedActionColors.successDark,
+    color: white,
+  },
+  errorDark: {
+    backgroundColor: expectedActionColors.errorDark,
+    color: white,
+  },
+  warningDark: {
+    backgroundColor: expectedActionColors.warningDark,
+    color: white,
+  },
 }
 
 describe('@repay/cactus-theme', (): void => {
@@ -58,6 +110,12 @@ describe('@repay/cactus-theme', (): void => {
     expect(theme.colors).toMatchObject({
       base: 'hsl(200, 96%, 11%)',
       callToAction: 'hsl(200, 96%, 35%)',
+      lightCallToAction: 'hsl(200, 45%, 81%)',
+      ...expectedActionColors,
+    })
+    expect(theme.colorStyles).toMatchObject({
+      ...expectedActionStyles,
+      lightCallToAction: { backgroundColor: 'hsl(200, 45%, 81%)', color: 'hsl(200, 10%, 20%)' },
     })
   })
 
@@ -68,9 +126,15 @@ describe('@repay/cactus-theme', (): void => {
     expect(theme.colors).toMatchObject({
       base: 'hsl(200, 96%, 11%)',
       callToAction: 'hsl(200, 96%, 35%)',
+      lightCallToAction: 'hsl(200, 45%, 81%)',
       lightContrast: 'hsl(0, 0%, 90%)',
+      ...expectedActionColors,
     })
-    expect(theme.colorStyles.lightContrast.backgroundColor).toBe('hsl(0, 0%, 90%)')
+    expect(theme.colorStyles).toMatchObject({
+      ...expectedActionStyles,
+      lightCallToAction: { backgroundColor: 'hsl(200, 45%, 81%)', color: 'hsl(200, 10%, 20%)' },
+      lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' },
+    })
   })
 
   themeAccessibility(
@@ -86,8 +150,17 @@ describe('@repay/cactus-theme', (): void => {
   test('generates a grayscale theme when primary color is provided', (): void => {
     const theme = generateTheme({ primary: '#012537 ', grayscaleContrast: true })
     expect(theme).toMatchObject({
-      colors: { lightContrast: 'hsl(0, 0%, 90%)' },
-      colorStyles: { lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' } },
+      colors: {
+        lightContrast: 'hsl(0, 0%, 90%)',
+        callToAction: 'hsl(200, 96%, 35%)',
+        lightCallToAction: 'hsl(200, 45%, 81%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        lightCallToAction: { backgroundColor: 'hsl(200, 45%, 81%)', color: 'hsl(200, 10%, 20%)' },
+        lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' },
+        ...expectedActionStyles,
+      },
     })
   })
 
@@ -97,6 +170,12 @@ describe('@repay/cactus-theme', (): void => {
       colors: {
         base: 'hsl(200, 96%, 11%)',
         callToAction: 'hsl(240, 100%, 50%)',
+        lightCallToAction: 'hsl(240, 68%, 85%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        ...expectedActionStyles,
+        lightCallToAction: { backgroundColor: 'hsl(240, 68%, 85%)', color: 'hsl(200, 10%, 20%)' },
       },
     })
   })
@@ -116,10 +195,14 @@ describe('@repay/cactus-theme', (): void => {
       colors: {
         base: 'hsl(200, 96%, 11%)',
         callToAction: 'hsl(240, 100%, 50%)',
+        lightCallToAction: 'hsl(240, 68%, 85%)',
         lightContrast: 'hsl(0, 0%, 90%)',
+        ...expectedActionColors,
       },
       colorStyles: {
+        lightCallToAction: { backgroundColor: 'hsl(240, 68%, 85%)', color: 'hsl(200, 10%, 20%)' },
         lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' },
+        ...expectedActionStyles,
       },
     })
   })
@@ -138,6 +221,12 @@ describe('@repay/cactus-theme', (): void => {
       colors: {
         base: 'hsl(200, 96%, 11%)',
         callToAction: 'hsl(200, 96%, 35%)',
+        lightCallToAction: 'hsl(200, 45%, 81%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        ...expectedActionStyles,
+        lightCallToAction: { backgroundColor: 'hsl(200, 45%, 81%)', color: 'hsl(200, 10%, 20%)' },
       },
     })
   })
@@ -156,6 +245,12 @@ describe('@repay/cactus-theme', (): void => {
       colors: {
         base: 'hsl(200, 96%, 11%)',
         callToAction: 'hsl(0, 23%, 57%)',
+        lightCallToAction: 'hsl(0, 23%, 87%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        ...expectedActionStyles,
+        lightCallToAction: { backgroundColor: 'hsl(0, 23%, 87%)', color: 'hsl(200, 10%, 20%)' },
       },
     })
   })
@@ -168,7 +263,16 @@ describe('@repay/cactus-theme', (): void => {
   test('generates a white theme when invalid colors are provided', (): void => {
     const theme = generateTheme({ primary: '' })
     expect(theme).toMatchObject({
-      colors: { base: 'hsl(0, 0%, 100%)', callToAction: 'hsl(244, 48%, 26%)' },
+      colors: {
+        base: 'hsl(0, 0%, 100%)',
+        callToAction: 'hsl(244, 48%, 26%)',
+        lightCallToAction: 'hsl(244, 15%, 78%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        ...expectedActionStyles,
+        lightCallToAction: { backgroundColor: 'hsl(244, 15%, 78%)', color: 'hsl(0, 10%, 20%)' },
+      },
     })
   })
 
@@ -180,9 +284,15 @@ describe('@repay/cactus-theme', (): void => {
       colors: {
         base: 'hsl(0, 0%, 100%)',
         callToAction: 'hsl(244, 48%, 26%)',
+        lightCallToAction: 'hsl(244, 15%, 78%)',
         lightContrast: 'hsl(0, 0%, 90%)',
+        ...expectedActionColors,
       },
-      colorStyles: { lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' } },
+      colorStyles: {
+        lightCallToAction: { backgroundColor: 'hsl(244, 15%, 78%)', color: 'hsl(0, 10%, 20%)' },
+        lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' },
+        ...expectedActionStyles,
+      },
     })
   })
 
@@ -194,7 +304,16 @@ describe('@repay/cactus-theme', (): void => {
   test('generates a black theme when the primary color is black', (): void => {
     const theme = generateTheme({ primary: '#000000' })
     expect(theme).toMatchObject({
-      colors: { base: 'hsl(0, 0%, 0%)', callToAction: 'hsl(244, 96%, 35%)' },
+      colors: {
+        base: 'hsl(0, 0%, 0%)',
+        callToAction: 'hsl(244, 96%, 35%)',
+        lightCallToAction: 'hsl(244, 45%, 81%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        ...expectedActionStyles,
+        lightCallToAction: { backgroundColor: 'hsl(244, 45%, 81%)', color: 'hsl(0, 10%, 20%)' },
+      },
     })
   })
 
@@ -206,9 +325,15 @@ describe('@repay/cactus-theme', (): void => {
       colors: {
         base: 'hsl(0, 0%, 0%)',
         callToAction: 'hsl(244, 96%, 35%)',
+        lightCallToAction: 'hsl(244, 45%, 81%)',
         lightContrast: 'hsl(0, 0%, 90%)',
+        ...expectedActionColors,
       },
-      colorStyles: { lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' } },
+      colorStyles: {
+        lightCallToAction: { backgroundColor: 'hsl(244, 45%, 81%)', color: 'hsl(0, 10%, 20%)' },
+        lightContrast: { backgroundColor: 'hsl(0, 0%, 90%)' },
+        ...expectedActionStyles,
+      },
     })
   })
 

--- a/modules/cactus-web/package.json
+++ b/modules/cactus-web/package.json
@@ -77,6 +77,7 @@
     "@babel/core": "^7.14.6",
     "@babel/plugin-proposal-private-property-in-object": "^7.14.5",
     "@repay/babel-preset": "^1.1.1",
+    "@repay/cactus-theme": "^2.1.0",
     "@repay/scripts": "^3.0.0",
     "@storybook/addon-actions": "^6.3.2",
     "@storybook/addon-docs": "^6.3.2",
@@ -119,6 +120,7 @@
     "typescript": "~4.2.4"
   },
   "peerDependencies": {
+    "@repay/cactus-theme": ">=3.0.0",
     "prop-types": ">=15.7.0",
     "react": "^16.8.3 || ^17.0.0",
     "styled-components": "^5.1.0"
@@ -132,7 +134,6 @@
     "@reach/utils": "^0.15.2",
     "@reach/visually-hidden": "^0.15.2",
     "@repay/cactus-icons": "^2.5.0",
-    "@repay/cactus-theme": "^2.1.0",
     "lodash": "^4.17.21",
     "react-color": "^2.19.3",
     "react-transition-group": "^4.4.2",

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -29,13 +29,13 @@ const backgroundColor = (props: AlertProps & ThemeProps<CactusTheme>): string | 
   const { status } = props
   switch (status) {
     case 'error':
-      return props.theme.colors.status.avatar.error
+      return props.theme.colors.status.background.error
     case 'warning':
-      return props.theme.colors.status.avatar.warning
+      return props.theme.colors.status.background.warning
     case 'info':
       return props.theme.colors.white
     case 'success':
-      return props.theme.colors.status.avatar.success
+      return props.theme.colors.status.background.success
   }
 }
 

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -287,7 +287,7 @@ const InputWrapper = styled.div`
 
     &:focus {
       outline: none;
-      background-color: ${(p): string => p.theme.colors.transparentCTA};
+      background-color: ${(p): string => p.theme.colors.lightCallToAction};
     }
 
     &::placeholder {
@@ -439,15 +439,15 @@ const CalendarDayBase = styled.button.attrs({ type: 'button' })`
 
     &.selected-date {
       color: ${(p): string => p.theme.colors.darkContrast};
-      background-color: ${(p): string => p.theme.colors.transparentCTA};
+      background-color: ${(p): string => p.theme.colors.lightCallToAction};
     }
   }
 
   &.focused-date {
-    background-color: ${(p): string => p.theme.colors.transparentCTA};
+    background-color: ${(p): string => p.theme.colors.lightCallToAction};
 
     &[aria-disabled='true'] {
-      background-color: ${(p): string => p.theme.colors.transparentError};
+      background-color: ${(p): string => p.theme.colors.errorLight};
     }
   }
 
@@ -729,7 +729,7 @@ const MonthYearListWrapper = styled(MonthYearListScrollTrap)`
     }
 
     &:hover > span {
-      background-color: ${(p): string => p.theme.colors.transparentCTA};
+      background-color: ${(p): string => p.theme.colors.lightCallToAction};
     }
 
     &[aria-selected='true'] > span {

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -363,11 +363,11 @@ const fileBoxColors = {
   `,
   loaded: css`
     border-color: ${(p) => p.theme.colors.success};
-    background-color: ${(p) => p.theme.colors.transparentSuccess};
+    background-color: ${(p) => p.theme.colors.successLight};
   `,
   error: css`
     border-color: ${(p) => p.theme.colors.error};
-    background-color: ${(p) => p.theme.colors.transparentError};
+    background-color: ${(p) => p.theme.colors.errorLight};
   `,
 }
 

--- a/modules/cactus-web/src/Footer/Footer.tsx
+++ b/modules/cactus-web/src/Footer/Footer.tsx
@@ -255,6 +255,6 @@ const StyledLink = styled(Link)`
   }
 
   :focus {
-    background-color: ${(p) => p.theme.colors.transparentCTA};
+    background-color: ${(p) => p.theme.colors.lightCallToAction};
   }
 `

--- a/modules/cactus-web/src/Link/Link.tsx
+++ b/modules/cactus-web/src/Link/Link.tsx
@@ -40,7 +40,7 @@ export const Link = styled(LinkBase).withConfig({
 
   :focus {
     color: ${(p): string => p.theme.colors.callToAction};
-    background-color: ${(p): string => p.theme.colors.transparentCTA};
+    background-color: ${(p): string => p.theme.colors.lightCallToAction};
   }
 
   ${margin};

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -9,7 +9,7 @@ import { dimmerStyles } from '../Dimmer/Dimmer'
 import Flex from '../Flex/Flex'
 import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { omitProps } from '../helpers/omit'
-import { border, boxShadow, radius } from '../helpers/theme'
+import { border, radius } from '../helpers/theme'
 import cssVariant from '../helpers/variant'
 import IconButton from '../IconButton/IconButton'
 
@@ -98,7 +98,6 @@ export const ModalPopUp = styled(DialogOverlay).withConfig(
     border: ${(p) => border(p.theme, '')};
     border-radius: ${radius(20)};
     background: white;
-    ${(p): string => boxShadow(p.theme, 2)};
     max-width: ${(p) => !p.width && '80%'};
     ${width}
     ${flexItem}

--- a/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
+++ b/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
@@ -17,13 +17,13 @@ type StatusMap = { [K in Status]: ReturnType<typeof css> }
 
 const statusMap: StatusMap = {
   success: css`
-    background-color: ${(p): string => p.theme.colors.status.avatar.success};
+    background-color: ${(p): string => p.theme.colors.status.background.success};
   `,
   warning: css`
-    background-color: ${(p): string => p.theme.colors.status.avatar.warning};
+    background-color: ${(p): string => p.theme.colors.status.background.warning};
   `,
   error: css`
-    background-color: ${(p): string => p.theme.colors.status.avatar.error};
+    background-color: ${(p): string => p.theme.colors.status.background.error};
   `,
 }
 

--- a/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
+++ b/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
@@ -89,9 +89,9 @@ h4, h5, h6 {
 let shouldCheckTheme = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test'
 
 const checkThemeProperties = (theme: CactusTheme): void => {
-  if (theme.colors.transparentCTA === undefined) {
+  if (theme.colors.lightCallToAction === undefined) {
     console.warn(
-      "You are using an outdated version of @repay/cactus-theme. Some features won't be available in @repay/cactus-web with this version. Please upgrade to @repay/cactus-theme >= 0.4.3."
+      "You are using an outdated version of @repay/cactus-theme. Some features won't be available in @repay/cactus-web with this version. Please upgrade to @repay/cactus-theme >= 3.0.0."
     )
   }
   shouldCheckTheme = false
@@ -172,7 +172,7 @@ StyleProvider.propTypes = {
       baseText: PropTypes.string.isRequired,
       callToAction: PropTypes.string.isRequired,
       callToActionText: PropTypes.string.isRequired,
-      transparentCTA: PropTypes.string.isRequired,
+      lightCallToAction: PropTypes.string.isRequired,
       lightContrast: PropTypes.string.isRequired,
       mediumContrast: PropTypes.string.isRequired,
       darkContrast: PropTypes.string.isRequired,
@@ -184,12 +184,15 @@ StyleProvider.propTypes = {
       success: PropTypes.string.isRequired,
       warning: PropTypes.string.isRequired,
       error: PropTypes.string.isRequired,
-      transparentSuccess: PropTypes.string.isRequired,
-      transparentWarning: PropTypes.string.isRequired,
-      transparentError: PropTypes.string.isRequired,
-      errorDark: PropTypes.string.isRequired,
-      warningDark: PropTypes.string.isRequired,
+      successLight: PropTypes.string.isRequired,
+      warningLight: PropTypes.string.isRequired,
+      errorLight: PropTypes.string.isRequired,
+      successMedium: PropTypes.string.isRequired,
+      warningMedium: PropTypes.string.isRequired,
+      errorMedium: PropTypes.string.isRequired,
       successDark: PropTypes.string.isRequired,
+      warningDark: PropTypes.string.isRequired,
+      errorDark: PropTypes.string.isRequired,
       status: PropTypes.shape({
         background: statusObj,
         avatar: statusObj,
@@ -211,13 +214,16 @@ StyleProvider.propTypes = {
       error: colorStyleObj,
       warning: colorStyleObj,
       disable: colorStyleObj,
-      transparentCTA: colorStyleObj,
-      transparentError: colorStyleObj,
-      transparentSuccess: colorStyleObj,
-      transparentWarning: colorStyleObj,
+      lightCallToAction: colorStyleObj,
+      successLight: colorStyleObj,
+      errorLight: colorStyleObj,
+      warningLight: colorStyleObj,
+      successMedium: colorStyleObj,
+      errorMedium: colorStyleObj,
+      warningMedium: colorStyleObj,
+      successDark: colorStyleObj,
       errorDark: colorStyleObj,
       warningDark: colorStyleObj,
-      successDark: colorStyleObj,
     }).isRequired,
     border: PropTypes.oneOf(['thin', 'thick']).isRequired,
     shape: PropTypes.oneOf(['square', 'intermediate', 'round']).isRequired,

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -358,7 +358,7 @@ const getCTABorder = (p: ThemeProps<CactusTheme>, focus?: boolean): ReturnType<t
       border-left-color: ${p.theme.colors.callToAction};
       border-top-color: ${p.theme.colors.callToAction};
       border-bottom-color: ${p.theme.colors.callToAction};
-      background-color: ${focus && p.theme.colors.transparentCTA};
+      background-color: ${focus && p.theme.colors.lightCallToAction};
     }
     td:last-child {
       border-color: ${p.theme.colors.callToAction};

--- a/modules/cactus-web/src/helpers/status.ts
+++ b/modules/cactus-web/src/helpers/status.ts
@@ -7,14 +7,14 @@ type StatusMap = { [K in Status]: ReturnType<typeof css> }
 export const textFieldStatusMap: StatusMap = {
   success: css`
     border-color: ${(p): string => p.theme.colors.success};
-    background: ${(p): string => p.theme.colors.transparentSuccess};
+    background: ${(p): string => p.theme.colors.successLight};
   `,
   warning: css`
     border-color: ${(p): string => p.theme.colors.warning};
-    background: ${(p): string => p.theme.colors.transparentWarning};
+    background: ${(p): string => p.theme.colors.warningLight};
   `,
   error: css`
     border-color: ${(p): string => p.theme.colors.error};
-    background: ${(p): string => p.theme.colors.transparentError};
+    background: ${(p): string => p.theme.colors.errorLight};
   `,
 }

--- a/modules/cactus-web/src/helpers/theme.ts
+++ b/modules/cactus-web/src/helpers/theme.ts
@@ -130,7 +130,7 @@ export const boxShadow = (theme: CactusTheme, shadowType: number | string): stri
     if (typeof shadowType === 'number') {
       shadowType = shadowTypes[shadowType]
     }
-    return `box-shadow: ${shadowType} ${theme.colors.transparentCTA}`
+    return `box-shadow: ${shadowType} ${theme.colors.lightCallToAction}`
   } else {
     return ''
   }


### PR DESCRIPTION
Ticket and UAT: https://repayonline.atlassian.net/browse/CACTUS-661

Note that, with Hector's approval, I ditched the box shadow on the Modal.  You couldn't really see it anyway in the old version, since it was a transparent color over a very dark background.  The new shadow, because it's no longer transparent, just looked weird and bright against the dark background (see attached screenshot).  So we just got rid of it.
![Screen Shot 2021-07-14 at 3 05 57 PM](https://user-images.githubusercontent.com/46460514/125694946-2df37d64-7972-492e-bb79-41e0e5222ad6.png)

Otherwise, there should be no visible changes to any components.