### PR TITLE
CACTUS-647: fix incorrect link types (<link> != <a>)

### DIFF
--- a/modules/cactus-web/src/Link/Link.tsx
+++ b/modules/cactus-web/src/Link/Link.tsx
@@ -7,7 +7,7 @@ import { omitMargins } from '../helpers/omit'
 
 export interface LinkProps
   extends MarginProps,
-    Omit<React.LinkHTMLAttributes<HTMLAnchorElement>, 'href'> {
+    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
   to: string
   variant?: 'standard' | 'dark'
 }

--- a/modules/cactus-web/src/PrevNext/PrevNext.tsx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.tsx
@@ -17,7 +17,7 @@ export interface PrevNextProps extends MarginProps, React.HTMLAttributes<HTMLDiv
   nextText?: React.ReactNode
 }
 
-interface PrevNextLinkProps extends React.LinkHTMLAttributes<HTMLAnchorElement> {
+interface PrevNextLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   disabled: boolean
 }
 


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-647

Link has an `as` prop, anchor does not. Doesn't exactly fix the underlying problem with conflicting types on the `as` prop; to be honest I hate how ridiculously complicated the `styled-components` types are, and think maybe I could do better myself, but I'll do that on my own time, if at all.