### PR TITLE
CACTUS-664 Theme Style Helpers

### DIFF
--- a/docs/Theme/README.md
+++ b/docs/Theme/README.md
@@ -14,6 +14,10 @@ The `@repay/cactus-theme` library exports a theme generator which will create a 
 
 The [styled-components](https://www.npmjs.com/package/styled-components) package created the `ThemeProvider` component, and we recommend that you check their documentation out for even more clarity.
 
+### Style Helpers
+
+We also provide a number of useful functions for reducing boilerplate in `styled-components`: see <a href="./style-helpers/#">the style helpers documentation</a> for a full list.
+
 ## Usage
 
 The `@repay/cactus-theme` library exports a theme generator function, and a default theme.

--- a/docs/Theme/Style Helpers.md
+++ b/docs/Theme/Style Helpers.md
@@ -1,0 +1,4 @@
+---
+title: Style Helpers
+order: -99
+---

--- a/docs/Theme/Style Helpers.md
+++ b/docs/Theme/Style Helpers.md
@@ -2,3 +2,190 @@
 title: Style Helpers
 order: -99
 ---
+
+# Style Helpers
+
+Accessing theme properties from `styled-components` styles is not difficult, but can involve a lot of boilerplate; after the tenth time you write something like `${(p) => p.theme.space[3]}` you start to want to refactor. The helpers defined in `@repay/cactus-theme` can help reduce that boilerplate, as well as provide logical help around some of the less common properties (like `boxShadows`).
+
+### Usage
+
+All the helper functions (with the exception of `isResponsiveTouchDevice`) have two call modes. When called in "binding" mode you pass the normal arguments, and it returns a function that takes in theme props (an object with `theme` property) and returns the result. In the other call mode, you pass the theme props as the first argument, then the regular arguments, and it directly returns the results. These four are all the same:
+
+```
+const Sample = styled.div`
+  margin: ${space(3)};
+  margin: ${(p) => space(3)(p)};
+  margin: ${(p) => space(p, 3)};
+  margin: ${(p) => p.theme.space[3]}px;
+`
+```
+
+Binding mode is the most common since it's concise and compatible with `styled-components`; the other mode mostly exists to make it possible to compose several helpers into a single function call.
+
+## Space/Sizes
+
+#### space
+```
+function space(index: number): '[number]px';
+```
+
+Indexes into the `theme.space` array, and returns the result as a pixel length (e.g '4px').
+
+#### iconSize
+```
+function iconSize(size: keyof IconSizes): '[number]px;
+```
+
+Returns the value from the `theme.iconSizes` object as a pixel length.
+
+#### fontSize
+```
+function fontSize(size: keyof FontSizes): 'font-size: [number]px;' | `
+  font-size: [number]px;
+  @media screen and (min-width: [medium breakpoint]) {
+    font-size: [number]px;
+  }
+`;
+```
+
+Returns values from the `theme.fontSizes` & `theme.mobileFontSizes` objects. If the values are the same, returns a single property e.g. "font-size: 15px;". If the values are different, returns a CSS block with a media query.
+
+#### textStyle
+```
+function textStyle(size: keyof TextStyles): {
+  fontSize: '[number]px',
+  lineHeight: [number],
+} | `
+  font-size: [number]px;
+  line-height: [number];
+  @media screen and (min-width: [medium breakpoint]) {
+    font-size: [number]px;
+    line-height: [number];
+  }
+`;
+```
+
+Returns values from the `theme.textStyles` & `theme.mobileTextStyles` objects. If the values are the same, returns the value (which is an object with keys `fontSize` & `lineHeight`). If the values are different, returns a CSS block with a media query.
+
+## Colors
+
+#### color
+```
+function color(colorName: keyof Colors): ColorValue;
+```
+
+Returns a value from the `theme.colors` object.
+
+#### colorStyle
+```
+type ColorStyle = { color: ColorValue; backgroundColor: ColorValue }
+function colorStyle(styleName: keyof ColorStyles): ColorStyle;
+function colorStyle(foregroundColor: string, backgroundColor: string): ColorStyle;
+```
+
+This one can be used two ways. Called with a name from the `theme.colorStyles` object, it will return the value from the theme. Called with two arguments, it will return a custom style with the given colors: each color can either be a browser-recognized color value, or a name from the `theme.colors` object.
+
+## Borders
+
+#### borderSize
+```
+const BORDER_SIZE = { thin: '1px', thick: '2px' }
+function borderSize(opts: { thin: unknown; thick: unknown } = BORDER_SIZE): unknown;
+```
+
+Returns a value from the opts argument depending on the `theme.border` setting. When called with no arguments, returns the default border thickness.
+
+#### border
+```
+type Opts = { thin?: string; thick?: string }
+function border(color: string, opts?: Opts): '[thickness] solid [color]';
+```
+
+Returns a CSS value appropriate for use with `border` or `outline` properties, e.g. "1px solid black". The _color_ can be any color string recognized by browsers, or the name of a color in `theme.colors`. Both keys in the _opts_ object are optional, so you can override just one of the border thicknesses if you want to use the default for the other.
+
+#### radius
+```
+function radius(maxRadius: number, intermediateScaleFactor = 0.4): '[number]px';
+```
+
+Returns a radius scaled according to the `theme.shape` setting: for "square" the radius is always "0px" (scale factor 0), and for "round" it's the number you passed in (scale factor 1). In addition, the result of the scale operation is passed through `Math.ceil`, so calling `radius(8)` will do `Math.ceil(8*.4[=3.2])[=4]px`.
+
+#### insetBorder
+```
+type Direction = 'top' | 'bottom' | 'left' | 'right'
+type Opts = { thin?: string; thick?: string }
+function insetBorder(color: string, dir?: Direction, opts?: Opts): 'box-shadow: inset [size] [color]';
+```
+
+Returns a `box-shadow` CSS property for a solid inset border. The _color_ and _opts_ arguments behave the same way they do in the regular `border` function. If a _direction_ is specified, the border will only appear on the specified side, otherwise it will be on all four sides.
+
+Obviously this can't be used alongside a regular box shadow property, but inset borders are useful in situations where you want to add a visual border without affecting the layout (since a normal border takes up space between the margins and padding).
+
+## Shadows
+
+The REPAY style guide defines several box shadow "types", which are numbered 0-5. Though these are technically unrelated to either the theme or `styled-component`, they are often used in conjunction with other properties so it's well worth adding helpers for them.
+
+#### boxShadow
+```
+function boxShadow(shadowType: number, color: string = 'lightCallToAction'): 'box-shadow: [size] [color]';
+```
+
+Returns a `box-shadow` CSS property with the given type. The _color_ can be a browser-recognized color value, or a name from `theme.colors`; it defaults to `theme.colors.lightCallToAction`.
+
+#### shadow
+```
+type Shadow = string | CSSObject | undefined
+function shadow(shadowTypeOrSize: number | string, fallback?: Shadow | (props) => Shadow): Shadow;
+```
+
+Similar to `boxShadow`, except it only returns the `box-shadow` property if `theme.boxShadows` is true and the color can't be customized. You can also pass a custom shadow size if needed, rather than being restricted to the predefined types from the style guide.
+
+If `theme.boxShadows` is false, the fallback is returned instead:
+- If _fallback_ is a function, it is called with the theme props as the only argument.
+- If _fallback_ is a string with no ":", it is passed to the `border` helper as a color.
+- If _fallback_ or the result of previous steps is a string with no ":", it is returned as a `border` CSS property.
+- Else it's returned as-is.
+
+```
+shadow(0, 'lightContrast') // = 'border: 1px solid [theme.colors.lightContrast]'
+shadow(0, border('red', { thin: '2px' })) // = 'border: 2px solid red'
+shadow(0, 'outline: 1px solid green') // = 'outline: 1px solid green'
+shadow(0, { margin: '2px' }) // = { margin: '2px' }
+```
+
+## Breakpoints
+
+#### mediaGTE
+```
+function mediaGTE(breakpoint: keyof Breakpoints): '@media (min-width: [breakpoint])';
+```
+
+Returns a min-width media query for the given breakpoint, similar to the kind used by `styled-system`. (The GTE indicates "greater than or equal to", e.g. `mediaGTE('small')` matches all widths greater than or equal to the small breakpoint.)
+
+#### mediaLT
+```
+function mediaLT(breakpoint: keyof Breakpoints): '@media (max-width: [breakpoint])';
+```
+
+Returns a max-width media query for the given breakpoint (technically it's a "not (min-width: ...)" query, which is why the function is called "less than" and not "less than or equal to").
+
+#### breakpoint
+```
+function breakpoint(breakpoint: number | keyof Breakpoints): '[breakpoint]'
+```
+
+Returns the given value from `theme.breakpoints`. Since that's an array rather than an object you can pass an array index, e.g. `breakpoint(0)` for the first breakpoint, but you can also use the names from the media queries, e.g. `breakpoint('small').
+
+## Special
+
+#### isResponsiveTouchDevice
+
+Returns true if the code is running on a touch-enabled device with a "tiny" screen size (width < "small" breakpoint), and whose screen is the same width as the window; e.g. a smart phone or small tablet.
+
+This one is special in that it's only incidentally related to the theme (it uses the first breakpoint), and it doesn't do the argument currying that the others do: because it returns a boolean it must always be used in a block with other statements, so there would be no value in being able to throw `${isResponsiveTouchDevice()}` in your styles.
+
+```
+const StyledDifferentlyOnMobile = styled.div`
+  ${(p) => isResponsiveTouchDevice(p) ? mobileStyles : regularStyles};
+`
+```

--- a/docs/Theme/Style Helpers.md
+++ b/docs/Theme/Style Helpers.md
@@ -67,6 +67,20 @@ function textStyle(size: keyof TextStyles): {
 
 Returns values from the `theme.textStyles` & `theme.mobileTextStyles` objects. If the values are the same, returns the value (which is an object with keys `fontSize` & `lineHeight`). If the values are different, returns a CSS block with a media query.
 
+#### lineHeight
+```
+type RenderFunc = (lineHeight: number, fontSize: number, p: ThemeProps) => string
+type RenderOpt = 'em' | 'px' | string | RenderFunc
+function lineHeight(size: keyof TextStyles, opt: RenderOpt = 'px'): string;
+```
+
+Returns a value from `theme.textStyles` or `theme.mobileTextStyles`. The default mode is to calculate the height as a pixel length, but there are three options to change the behavior:
+- If you pass `'em'` as the option, it will return an `em` length instead of a pixel length.
+- If you pass a string it will be treated as CSS property name, and return a full CSS block (including media query if needed).
+- If you pass a function it will be called with the text style, and should return a full CSS property (including ';'). If needed the function will be called twice and the result will include a media query.
+
+In the value modes (px or em) it uses `window.matchMedia` to choose between mobile and regular styles. Unlike the modes with media queries it can't dynamically change the value as the window resizes; you can get around this, however, by rendering your component inside a `ScreenSizeContext` consumer (from '@repay/cactus-web').
+
 ## Colors
 
 #### color

--- a/docs/Theme/Style Helpers.md
+++ b/docs/Theme/Style Helpers.md
@@ -69,17 +69,15 @@ Returns values from the `theme.textStyles` & `theme.mobileTextStyles` objects. I
 
 #### lineHeight
 ```
-type RenderFunc = (lineHeight: number, fontSize: number, p: ThemeProps) => string
-type RenderOpt = 'em' | 'px' | string | RenderFunc
-function lineHeight(size: keyof TextStyles, opt: RenderOpt = 'px'): string;
+type RenderFunc = (lineHeight: string, p: ThemeProps) => string
+function lineHeight(
+  size: keyof TextStyles,
+  prop: string | RenderFunc,
+  type: 'px' | 'em' = 'px'
+): string;
 ```
 
-Returns a value from `theme.textStyles` or `theme.mobileTextStyles`. The default mode is to calculate the height as a pixel length, but there are three options to change the behavior:
-- If you pass `'em'` as the option, it will return an `em` length instead of a pixel length.
-- If you pass a string it will be treated as CSS property name, and return a full CSS block (including media query if needed).
-- If you pass a function it will be called with the text style, and should return a full CSS property (including ';'). If needed the function will be called twice and the result will include a media query.
-
-In the value modes (px or em) it uses `window.matchMedia` to choose between mobile and regular styles. Unlike the modes with media queries it can't dynamically change the value as the window resizes; you can get around this, however, by rendering your component inside a `ScreenSizeContext` consumer (from '@repay/cactus-web').
+Returns a CSS property or block calculated from `theme.textStyles` and `theme.mobileTextStyles`. The value is calculated as a pixel length by default (`lineHeight * fontSize`), but you can also get the value in em units. There are two ways to render: specify the name of the CSS property, or pass a function to do the rendering. In both cases, if the calculated value is different for mobile & regular styles, the output is turned into a CSS block with a media query, similar to `fontSize` and `textStyle`.
 
 ## Colors
 

--- a/modules/cactus-theme/package.json
+++ b/modules/cactus-theme/package.json
@@ -4,9 +4,9 @@
   "description": "The theme for the Cactus design-system at REPAY",
   "repository": "https://github.com/repaygithub/cactus/tree/master/modules/cactus-theme",
   "license": "MIT",
-  "main": "dist/theme.cjs.js",
-  "module": "dist/theme.esm.js",
-  "types": "dist/theme.d.ts",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "cleanup": "rm -rf dist",
@@ -15,9 +15,9 @@
     "test:local": " yarn test:types && yarn test",
     "test:ci": "yarn test:local --maxWorkers=2",
     "test:types": "tsc --project ./tsconfig.json --noEmit",
-    "dev": "repay-scripts dev --lib src/theme.ts",
+    "dev": "repay-scripts dev --lib src/index.ts",
     "prebuild": "yarn build:types",
-    "build": "repay-scripts build --lib src/theme.ts",
+    "build": "repay-scripts build --lib src/index.ts",
     "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly"
   },
   "devDependencies": {

--- a/modules/cactus-theme/package.json
+++ b/modules/cactus-theme/package.json
@@ -18,7 +18,7 @@
     "dev": "repay-scripts dev --lib src/theme.ts",
     "prebuild": "yarn build:types",
     "build": "repay-scripts build --lib src/theme.ts",
-    "build:types": "tsc --project ./tsconfig.json --emitDeclarationOnly"
+    "build:types": "tsc --project ./tsconfig.build.json --emitDeclarationOnly"
   },
   "devDependencies": {
     "@babel/core": "^7.14.6",

--- a/modules/cactus-theme/src/converters.ts
+++ b/modules/cactus-theme/src/converters.ts
@@ -8,7 +8,7 @@ export function rgbToHsl(red: number, green: number, blue: number): [number, num
 
   const max = Math.max(red, green, blue)
   const min = Math.min(red, green, blue)
-  let hue: number
+  let hue = 0
   let saturation: number
   let lightness = (max + min) / 2
 
@@ -45,19 +45,22 @@ export function rgbToHsl(red: number, green: number, blue: number): [number, num
 export function hexToRgb(hex: string): [number, number, number] {
   hex = hex?.trim?.()
   if (/^#?([a-f\d]{3}){1,2}$/i.test(hex)) {
-    let result
+    let result: string[] | null = null
     if (hex.length < 6) {
       result = /^#?([a-f\d]{1})([a-f\d]{1})([a-f\d]{1})$/i.exec(hex)
-      result[1] += result[1]
-      result[2] += result[2]
-      result[3] += result[3]
+      if (result) {
+        result[1] += result[1]
+        result[2] += result[2]
+        result[3] += result[3]
+      }
     } else {
       result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
     }
-    return [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
-  } else {
-    return [255, 255, 255]
+    if (result) {
+      return [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
+    }
   }
+  return [255, 255, 255]
 }
 
 // Calculating YIQ for easy contrast comparisons based on https://24ways.org/2010/calculating-color-contrast

--- a/modules/cactus-theme/src/helpers/base.ts
+++ b/modules/cactus-theme/src/helpers/base.ts
@@ -1,0 +1,40 @@
+import { CactusTheme } from '../theme'
+
+export type ThemeProps = { theme: CactusTheme }
+
+type ThemeFunc<A extends any[], R> = (props: ThemeProps, ...args: A) => R
+
+export type StyleFunc<R> = (props: ThemeProps) => R
+
+export interface HelperFunc<A extends any[], R> {
+  (...args: A): StyleFunc<R>
+  (pt: CactusTheme | ThemeProps, ...args: A): R
+}
+
+export const wrap = <A extends any[], R>(func: ThemeFunc<A, R>): HelperFunc<A, R> => {
+  const helper: any = (first: any, ...rest: any[]) => {
+    if (typeof first === 'object') {
+      if ('theme' in first) {
+        return (func as any)(first, ...rest)
+      } else if ('space' in first && 'mediaQueries' in first) {
+        // Picked two relatively uncommon names to represent the theme shape.
+        return (func as any)({ theme: first }, ...rest)
+      }
+    } else if (rest.length === 0 && first in helper) {
+      return helper[first]
+    }
+    return (p: ThemeProps) => (func as any)(p, first, ...rest)
+  }
+  return helper
+}
+
+export const memo = <A extends any[], R>(
+  func: ThemeFunc<A, R>,
+  ...toCache: A[0][]
+): HelperFunc<A, R> => {
+  const helper: any = wrap(func)
+  for (const arg of toCache) {
+    helper[arg] = (p: ThemeProps) => (func as any)(p, arg)
+  }
+  return helper
+}

--- a/modules/cactus-theme/src/helpers/base.ts
+++ b/modules/cactus-theme/src/helpers/base.ts
@@ -12,18 +12,20 @@ export interface HelperFunc<A extends any[], R> {
 }
 
 export const wrap = <A extends any[], R>(func: ThemeFunc<A, R>): HelperFunc<A, R> => {
-  const helper: any = (first: any, ...rest: any[]) => {
-    if (typeof first === 'object') {
-      if ('theme' in first) {
-        return (func as any)(first, ...rest)
-      } else if ('space' in first && 'mediaQueries' in first) {
+  const helper: any = (...args: A) => {
+    if (typeof args[0] === 'object') {
+      if ('theme' in args[0]) {
+        const first = args.shift() as ThemeProps
+        return func(first, ...args)
+      } else if ('space' in args[0] && 'mediaQueries' in args[0]) {
         // Picked two relatively uncommon names to represent the theme shape.
-        return (func as any)({ theme: first }, ...rest)
+        const theme = args.shift() as CactusTheme
+        return func({ theme }, ...args)
       }
-    } else if (rest.length === 0 && first in helper) {
-      return helper[first]
+    } else if (args.length === 1 && args[0] in helper) {
+      return helper[args[0]]
     }
-    return (p: ThemeProps) => (func as any)(p, first, ...rest)
+    return (p: ThemeProps) => func(p, ...args)
   }
   return helper
 }
@@ -34,7 +36,7 @@ export const memo = <A extends any[], R>(
 ): HelperFunc<A, R> => {
   const helper: any = wrap(func)
   for (const arg of toCache) {
-    helper[arg] = (p: ThemeProps) => (func as any)(p, arg)
+    helper[arg] = helper(arg)
   }
   return helper
 }

--- a/modules/cactus-theme/src/helpers/borders.ts
+++ b/modules/cactus-theme/src/helpers/borders.ts
@@ -1,0 +1,66 @@
+import { BorderSize, CactusColor, Shape } from '../theme'
+import { memo, ThemeProps, wrap } from './base'
+
+type BorderSizeOpts = { [K in BorderSize]: unknown }
+const DEFAULT_BORDER: BorderSizeOpts = { thin: '1px', thick: '2px' }
+const radiusFactors: { [K in Shape]: number | null } = { square: 0, intermediate: null, round: 1 }
+
+/**
+ * Returns a selected value depending on the `theme.border` setting.
+ * By default returns the border thickness, but can select any kind of value
+ * given an opts object: `{ thin: 'valueWhenThin', thick: 'valueWhenThick' }`.
+ */
+const _borderSize = (p: ThemeProps, opts: BorderSizeOpts = DEFAULT_BORDER) => opts[p.theme.border]
+export const borderSize = wrap(_borderSize)
+
+/**
+ * Returns a border CSS value with the given color and thickness according to `theme.border`.
+ * The color can be any color name or string, though `theme.colors` is checked first.
+ * The thickness can be customized with an options object like `borderSize` accepts.
+ */
+const _border = (p: ThemeProps, colorName: string, opts?: Partial<BorderSizeOpts>) => {
+  const thickness = _borderSize(p, { ...DEFAULT_BORDER, ...opts })
+  const color_ = p.theme.colors[colorName as CactusColor] || colorName
+  return `${thickness} solid ${color_}`
+}
+export const border = memo(_border, 'lightContrast')
+
+/**
+ * Returns a pixel length value of the given max radius, scaled according to `theme.shape`:
+ * `round` is the full radius, `intermediate` is scaled x0.4, and `square` is always zero.
+ */
+const _radius = (p: ThemeProps, maxRadius: number, intScaleFactor = 0.4) =>
+  `${Math.ceil(maxRadius * (radiusFactors[p.theme.shape] ?? intScaleFactor))}px`
+export const radius = memo(_radius, 8, 20)
+
+/**
+ * Returns a `box-shadow: inset` property declaration mimicking a border.
+ * Same args as `border`, plus an additional `direction` argument which restricts
+ * the inset border to only the given side of the element.
+ * NOTE: Can't be used alongside `boxShadow` or `shadow` helpers (obviously).
+ */
+const _insetBorder = (
+  p: ThemeProps,
+  colorName: string,
+  direction?: 'top' | 'bottom' | 'left' | 'right',
+  opts?: Partial<BorderSizeOpts>
+) => {
+  let hOffset = '0',
+    vOffset = '0',
+    spread = '0'
+  const thickness = _borderSize(p, { ...DEFAULT_BORDER, ...opts }) as string
+  if (direction === 'top') {
+    vOffset = thickness
+  } else if (direction === 'bottom') {
+    vOffset = `-${thickness}`
+  } else if (direction === 'left') {
+    hOffset = thickness
+  } else if (direction === 'right') {
+    hOffset = `-${thickness}`
+  } else {
+    spread = thickness
+  }
+  const color_ = p.theme.colors[colorName as CactusColor] || colorName
+  return `box-shadow: inset ${hOffset} ${vOffset} 0 ${spread} ${color_}`
+}
+export const insetBorder = wrap(_insetBorder)

--- a/modules/cactus-theme/src/helpers/borders.ts
+++ b/modules/cactus-theme/src/helpers/borders.ts
@@ -61,6 +61,6 @@ const _insetBorder = (
     spread = thickness
   }
   const color_ = p.theme.colors[colorName as CactusColor] || colorName
-  return `box-shadow: inset ${hOffset} ${vOffset} 0 ${spread} ${color_}`
+  return `box-shadow: inset ${hOffset} ${vOffset} 0 ${spread} ${color_};`
 }
 export const insetBorder = wrap(_insetBorder)

--- a/modules/cactus-theme/src/helpers/breakpoints.ts
+++ b/modules/cactus-theme/src/helpers/breakpoints.ts
@@ -1,0 +1,25 @@
+import { BreakpointsObject } from '../theme'
+import { memo, ThemeProps, wrap } from './base'
+
+type Breakpoint = keyof BreakpointsObject
+const bpMap: { [K in Breakpoint]: number } = {
+  small: 0,
+  medium: 1,
+  large: 2,
+  extraLarge: 3,
+}
+
+/** Returns a min-width media query of the type used by `styled-system`. */
+const _mediaGTE = (p: ThemeProps, breakpoint: Breakpoint) => p.theme.mediaQueries[breakpoint]
+export const mediaGTE = memo(_mediaGTE, 'small', 'medium')
+
+/** Returns a media query that's the inverse of the equivalent `mediaGTE(X)` query. */
+const _mediaLT = (p: ThemeProps, breakpoint: Breakpoint) =>
+  // Assumes query starts with `@media screen and (min-width:`
+  `@media screen and (not ${p.theme.mediaQueries[breakpoint].slice(18)})`
+export const mediaLT = memo(_mediaLT, 'small', 'medium')
+
+/** Returns the given breakpoint value; accepts either an index, or a screen size name. */
+const _breakpoint = (p: ThemeProps, breakpoint: number | Breakpoint) =>
+  p.theme.breakpoints[bpMap[breakpoint as Breakpoint] ?? (breakpoint as number)]
+export const breakpoint = wrap(_breakpoint)

--- a/modules/cactus-theme/src/helpers/breakpoints.ts
+++ b/modules/cactus-theme/src/helpers/breakpoints.ts
@@ -16,7 +16,7 @@ export const mediaGTE = memo(_mediaGTE, 'small', 'medium')
 /** Returns a media query that's the inverse of the equivalent `mediaGTE(X)` query. */
 const _mediaLT = (p: ThemeProps, breakpoint: Breakpoint) =>
   // Assumes query starts with `@media screen and (min-width:`
-  `@media screen and (not ${p.theme.mediaQueries[breakpoint].slice(18)})`
+  `@media not ${p.theme.mediaQueries[breakpoint].slice(7)}`
 export const mediaLT = memo(_mediaLT, 'small', 'medium')
 
 /** Returns the given breakpoint value; accepts either an index, or a screen size name. */

--- a/modules/cactus-theme/src/helpers/colors.ts
+++ b/modules/cactus-theme/src/helpers/colors.ts
@@ -1,0 +1,47 @@
+import { CactusColor, CactusTheme, ColorStyle, ColorVariant } from '../theme'
+import { memo, StyleFunc, ThemeProps } from './base'
+
+/** Returns the `theme.colors` value with the given color name. */
+const _color = (p: ThemeProps, colorName: CactusColor) => p.theme.colors[colorName]
+export const color = memo(
+  _color,
+  'base',
+  'callToAction',
+  'lightContrast',
+  'darkestContrast',
+  'white',
+  'lightGray',
+  'mediumGray',
+  'success',
+  'error'
+)
+
+interface ColorStyleHelper {
+  (style: ColorVariant): StyleFunc<ColorStyle>
+  (foreColor: string, bgColor: string): StyleFunc<ColorStyle>
+  (p: CactusTheme | ThemeProps, style: ColorVariant): ColorStyle
+  (p: CactusTheme | ThemeProps, foreColor: string, bgColor: string): ColorStyle
+}
+
+/**
+ * Returns the `theme.colorStyles` value with the given style name,
+ * or a ColorStyle object with the given fore- & background colors.
+ */
+const _colorStyle = (p: ThemeProps, style: string, bgColor?: string): ColorStyle => {
+  if (bgColor) {
+    return {
+      color: p.theme.colors[style as CactusColor] || style,
+      backgroundColor: p.theme.colors[bgColor as CactusColor] || bgColor,
+    }
+  }
+  return p.theme.colorStyles[style as ColorVariant]
+}
+export const colorStyle: ColorStyleHelper = memo(
+  _colorStyle,
+  'base',
+  'callToAction',
+  'standard',
+  'success',
+  'error',
+  'disable'
+)

--- a/modules/cactus-theme/src/helpers/index.ts
+++ b/modules/cactus-theme/src/helpers/index.ts
@@ -1,0 +1,14 @@
+export * from './borders'
+export * from './breakpoints'
+export * from './colors'
+export * from './sizes'
+export * from './shadows'
+import { ThemeProps } from './base'
+
+/** Checks if the current device has a TINY screen and is touch-enabled. */
+export const isResponsiveTouchDevice = (p: ThemeProps): boolean =>
+  typeof window !== 'undefined' &&
+  typeof screen !== 'undefined' &&
+  window.innerWidth < parseInt(p.theme.breakpoints[0]) &&
+  'ontouchstart' in window &&
+  screen.width === window.innerWidth

--- a/modules/cactus-theme/src/helpers/shadows.ts
+++ b/modules/cactus-theme/src/helpers/shadows.ts
@@ -1,0 +1,49 @@
+import { CactusColor } from '../theme'
+import { StyleFunc, ThemeProps, wrap } from './base'
+import { border } from './borders'
+
+type ShadowValue = string | Record<string, string> | undefined
+
+const shadowTypes = [
+  '0px 0px 3px',
+  '0px 3px 8px',
+  '0px 9px 24px',
+  '0px 12px 24px',
+  '0px 30px 42px',
+  '0px 45px 48px',
+]
+const isCssValue = (x: unknown): x is string => typeof x === 'string' && !x.includes(':')
+
+/** Returns a `box-shadow` property with the given standard shadow type (from the style guide). */
+const _boxShadow = (p: ThemeProps, shadowType: number, colorName = 'lightCallToAction') => {
+  const color_ = p.theme.colors[colorName as CactusColor] || colorName
+  return `box-shadow: ${shadowTypes[shadowType]} ${color_}`
+}
+export const boxShadow = wrap(_boxShadow)
+
+/**
+ * Returns a `box-shadow` property if `theme.boxShadows` is true, or a fallback value otherwise.
+ * `fallback` can be a function that takes the props object, or a string, or a CSS object.
+ * If it's a string that does not contain ':', it's assumed to be a border color.
+ * Similarly, if the function returns a string with no ':', it's automatically added
+ * to a `border:` property declaration.
+ */
+const _shadow = (
+  props: ThemeProps,
+  shadowTypeOrSize: number | string,
+  fallback?: ShadowValue | StyleFunc<ShadowValue>
+): ShadowValue => {
+  let value = fallback as ShadowValue
+  if (props.theme.boxShadows) {
+    const shadowSize = shadowTypes[shadowTypeOrSize as number] || shadowTypeOrSize
+    return `box-shadow: ${shadowSize} ${props.theme.colors.lightCallToAction}`
+  } else if (typeof fallback === 'function') {
+    value = fallback(props)
+  } else if (isCssValue(fallback)) {
+    // Assume string fallbacks are border colors.
+    value = border(props, fallback)
+  }
+  // If no CSS property is specified, assume `border` as the closest analogue of box shadows.
+  return isCssValue(value) ? `border: ${value}` : value
+}
+export const shadow = wrap(_shadow)

--- a/modules/cactus-theme/src/helpers/shadows.ts
+++ b/modules/cactus-theme/src/helpers/shadows.ts
@@ -17,7 +17,7 @@ const isCssValue = (x: unknown): x is string => typeof x === 'string' && !x.incl
 /** Returns a `box-shadow` property with the given standard shadow type (from the style guide). */
 const _boxShadow = (p: ThemeProps, shadowType: number, colorName = 'lightCallToAction') => {
   const color_ = p.theme.colors[colorName as CactusColor] || colorName
-  return `box-shadow: ${shadowTypes[shadowType]} ${color_}`
+  return `box-shadow: ${shadowTypes[shadowType]} ${color_};`
 }
 export const boxShadow = wrap(_boxShadow)
 
@@ -36,7 +36,7 @@ const _shadow = (
   let value = fallback as ShadowValue
   if (props.theme.boxShadows) {
     const shadowSize = shadowTypes[shadowTypeOrSize as number] || shadowTypeOrSize
-    return `box-shadow: ${shadowSize} ${props.theme.colors.lightCallToAction}`
+    return `box-shadow: ${shadowSize} ${props.theme.colors.lightCallToAction};`
   } else if (typeof fallback === 'function') {
     value = fallback(props)
   } else if (isCssValue(fallback)) {
@@ -44,6 +44,6 @@ const _shadow = (
     value = border(props, fallback)
   }
   // If no CSS property is specified, assume `border` as the closest analogue of box shadows.
-  return isCssValue(value) ? `border: ${value}` : value
+  return isCssValue(value) ? `border: ${value};` : value
 }
 export const shadow = wrap(_shadow)

--- a/modules/cactus-theme/src/helpers/sizes.ts
+++ b/modules/cactus-theme/src/helpers/sizes.ts
@@ -1,0 +1,52 @@
+import { FontSizeObject, IconSizeObject, TextStyleCollection } from '../theme'
+import { memo, ThemeProps, wrap } from './base'
+import { mediaGTE } from './breakpoints'
+
+/** Returns the `theme.space` value of the given index as a pixel length. */
+const _space = (p: ThemeProps, index: number) => `${p.theme.space[index]}px`
+export const space = memo(_space, 2, 3, 4, 5, 7)
+
+/** Returns the `theme.iconSizes` value of the given size as a pixel length. */
+const _iconSize = (p: ThemeProps, size: keyof IconSizeObject) => `${p.theme.iconSizes[size]}px`
+export const iconSize = wrap(_iconSize)
+
+/**
+ * Returns a CSS block with two `font-size` declarations at the given size:
+ * one from `theme.mobileFontSizes` for tiny/small screen sizes,
+ * and another from `theme.fontSizes` inside a `mediaGTE('medium')` block.
+ */
+const _fontSize = (p: ThemeProps, size: keyof FontSizeObject) => {
+  const fontSize = p.theme.fontSizes[size]
+  const mobileSize = p.theme.mobileFontSizes[size]
+  return fontSize === mobileSize
+    ? `font-size: ${fontSize}px;`
+    : `
+    font-size: ${mobileSize}px;
+    ${mediaGTE(p, 'medium')} {
+      font-size: ${fontSize}px;
+    }
+  `
+}
+export const fontSize = memo(_fontSize, 'body', 'small')
+
+/**
+ * Returns a CSS block with two text style (`font-size` & `line-height`) declarations:
+ * one from `theme.mobileTextStyles` for tiny/small screen sizes,
+ * and another from `theme.textStyles` inside a `mediaGTE('medium')` block.
+ */
+const _textStyle = (p: ThemeProps, size: keyof TextStyleCollection) => {
+  const mobile = p.theme.mobileTextStyles[size]
+  const regular = p.theme.textStyles[size]
+  if (mobile.fontSize === regular.fontSize && mobile.lineHeight === regular.lineHeight) {
+    return regular
+  }
+  return `
+    font-size: ${mobile.fontSize};
+    line-height: ${mobile.lineHeight};
+    ${mediaGTE(p, 'medium')} {
+      font-size: ${regular.fontSize};
+      line-height: ${regular.lineHeight};
+    }
+  `
+}
+export const textStyle = memo(_textStyle, 'body', 'small')

--- a/modules/cactus-theme/src/helpers/sizes.ts
+++ b/modules/cactus-theme/src/helpers/sizes.ts
@@ -31,9 +31,6 @@ const _fontSize = (p: ThemeProps, size: keyof FontSizeObject) => {
 }
 export const fontSize = memo(_fontSize, 'body', 'small')
 
-const needsMQ = (mobile: TextStyle, regular: TextStyle) =>
-  !(mobile.fontSize === regular.fontSize && mobile.lineHeight === regular.lineHeight)
-
 /**
  * Returns a CSS block with two text style (`font-size` & `line-height`) declarations:
  * one from `theme.mobileTextStyles` for tiny/small screen sizes,
@@ -42,7 +39,7 @@ const needsMQ = (mobile: TextStyle, regular: TextStyle) =>
 const _textStyle = (p: ThemeProps, size: TextStyleSize) => {
   const mobile = p.theme.mobileTextStyles[size]
   const regular = p.theme.textStyles[size]
-  if (!needsMQ(mobile, regular)) {
+  if (mobile.fontSize === regular.fontSize && mobile.lineHeight === regular.lineHeight) {
     return regular
   }
   return `
@@ -56,35 +53,38 @@ const _textStyle = (p: ThemeProps, size: TextStyleSize) => {
 }
 export const textStyle = memo(_textStyle, 'body', 'small')
 
-type RenderFunc = (lineHeight: number, fontSize: number, p: ThemeProps) => string
-type RenderOpt = 'px' | 'em' | string | RenderFunc
+type RenderFunc = (lineHeight: string, p: ThemeProps) => string
 
 const asPx = (style: TextStyle) => {
   const exact = parseFloat(style.lineHeight) * parseFloat(style.fontSize)
   return exact.toFixed(4).replace(/\.?0*$/, 'px')
 }
 
-const matchesMobile = (p: ThemeProps) => !window.matchMedia(mediaGTE(p, 'medium').slice(7)).matches
-
 /** Returns the line height for the given text style, as an em or pixel length. */
-const _lineHeight = (p: ThemeProps, size: TextStyleSize, opt: RenderOpt = 'px'): string => {
-  const mobile = p.theme.mobileTextStyles[size]
-  const regular = p.theme.textStyles[size]
-  if (opt === 'px') {
-    return asPx(needsMQ(mobile, regular) && matchesMobile(p) ? mobile : regular)
-  } else if (opt === 'em') {
-    const needsQuery = mobile.lineHeight !== regular.lineHeight
-    const style = needsQuery && matchesMobile(p) ? mobile : regular
-    return `${style.lineHeight}em`
-  } else if (typeof opt === 'function') {
-    const mob = opt(parseFloat(mobile.lineHeight), parseFloat(mobile.fontSize), p)
-    const reg = opt(parseFloat(regular.lineHeight), parseFloat(regular.fontSize), p)
-    if (mob === reg) return mob
-    return `${mob} ${mediaGTE(p, 'medium')} { ${reg} }`
+const _lineHeight = (
+  p: ThemeProps,
+  size: TextStyleSize,
+  prop: string | RenderFunc,
+  type: 'px' | 'em' = 'px'
+): string => {
+  const mobStyle = p.theme.mobileTextStyles[size]
+  const regStyle = p.theme.textStyles[size]
+  let mobile: string, regular: string
+  if (type === 'px') {
+    mobile = asPx(mobStyle)
+    regular = asPx(regStyle)
   } else {
-    const mob = `${opt}: ${asPx(mobile)};`
-    if (!needsMQ(mobile, regular)) return mob
-    return `${mob} ${mediaGTE(p, 'medium')} { ${opt}: ${asPx(regular)}; }`
+    mobile = `${mobStyle.lineHeight}em`
+    regular = `${mobStyle.lineHeight}em`
   }
+  if (mobile === regular) {
+    if (typeof prop === 'function') {
+      return prop(regular, p)
+    }
+    return `${prop}: ${regular};`
+  } else if (typeof prop === 'function') {
+    return `${prop(mobile, p)} ${mediaGTE(p, 'medium')} { ${prop(regular, p)} }`
+  }
+  return `${prop}: ${mobile}; ${mediaGTE(p, 'medium')} { ${prop}: ${regular}; }`
 }
 export const lineHeight = wrap(_lineHeight)

--- a/modules/cactus-theme/src/helpers/sizes.ts
+++ b/modules/cactus-theme/src/helpers/sizes.ts
@@ -1,6 +1,8 @@
-import { FontSizeObject, IconSizeObject, TextStyleCollection } from '../theme'
+import { FontSizeObject, IconSizeObject, TextStyle, TextStyleCollection } from '../theme'
 import { memo, ThemeProps, wrap } from './base'
 import { mediaGTE } from './breakpoints'
+
+type TextStyleSize = keyof TextStyleCollection
 
 /** Returns the `theme.space` value of the given index as a pixel length. */
 const _space = (p: ThemeProps, index: number) => `${p.theme.space[index]}px`
@@ -29,15 +31,18 @@ const _fontSize = (p: ThemeProps, size: keyof FontSizeObject) => {
 }
 export const fontSize = memo(_fontSize, 'body', 'small')
 
+const needsMQ = (mobile: TextStyle, regular: TextStyle) =>
+  !(mobile.fontSize === regular.fontSize && mobile.lineHeight === regular.lineHeight)
+
 /**
  * Returns a CSS block with two text style (`font-size` & `line-height`) declarations:
  * one from `theme.mobileTextStyles` for tiny/small screen sizes,
  * and another from `theme.textStyles` inside a `mediaGTE('medium')` block.
  */
-const _textStyle = (p: ThemeProps, size: keyof TextStyleCollection) => {
+const _textStyle = (p: ThemeProps, size: TextStyleSize) => {
   const mobile = p.theme.mobileTextStyles[size]
   const regular = p.theme.textStyles[size]
-  if (mobile.fontSize === regular.fontSize && mobile.lineHeight === regular.lineHeight) {
+  if (!needsMQ(mobile, regular)) {
     return regular
   }
   return `
@@ -50,3 +55,36 @@ const _textStyle = (p: ThemeProps, size: keyof TextStyleCollection) => {
   `
 }
 export const textStyle = memo(_textStyle, 'body', 'small')
+
+type RenderFunc = (lineHeight: number, fontSize: number, p: ThemeProps) => string
+type RenderOpt = 'px' | 'em' | string | RenderFunc
+
+const asPx = (style: TextStyle) => {
+  const exact = parseFloat(style.lineHeight) * parseFloat(style.fontSize)
+  return exact.toFixed(4).replace(/\.?0*$/, 'px')
+}
+
+const matchesMobile = (p: ThemeProps) => !window.matchMedia(mediaGTE(p, 'medium').slice(7)).matches
+
+/** Returns the line height for the given text style, as an em or pixel length. */
+const _lineHeight = (p: ThemeProps, size: TextStyleSize, opt: RenderOpt = 'px'): string => {
+  const mobile = p.theme.mobileTextStyles[size]
+  const regular = p.theme.textStyles[size]
+  if (opt === 'px') {
+    return asPx(needsMQ(mobile, regular) && matchesMobile(p) ? mobile : regular)
+  } else if (opt === 'em') {
+    const needsQuery = mobile.lineHeight !== regular.lineHeight
+    const style = needsQuery && matchesMobile(p) ? mobile : regular
+    return `${style.lineHeight}em`
+  } else if (typeof opt === 'function') {
+    const mob = opt(parseFloat(mobile.lineHeight), parseFloat(mobile.fontSize), p)
+    const reg = opt(parseFloat(regular.lineHeight), parseFloat(regular.fontSize), p)
+    if (mob === reg) return mob
+    return `${mob} ${mediaGTE(p, 'medium')} { ${reg} }`
+  } else {
+    const mob = `${opt}: ${asPx(mobile)};`
+    if (!needsMQ(mobile, regular)) return mob
+    return `${mob} ${mediaGTE(p, 'medium')} { ${opt}: ${asPx(regular)}; }`
+  }
+}
+export const lineHeight = wrap(_lineHeight)

--- a/modules/cactus-theme/src/index.ts
+++ b/modules/cactus-theme/src/index.ts
@@ -1,0 +1,4 @@
+import defaultTheme from './theme'
+export * from './helpers/index'
+export * from './theme'
+export default defaultTheme

--- a/modules/cactus-theme/src/theme.ts
+++ b/modules/cactus-theme/src/theme.ts
@@ -781,7 +781,7 @@ function fromTwoColor({
   secondary,
 }: TwoColorGeneratorOptions): [CactusTheme['colors'], CactusTheme['colorStyles']] {
   const primaryRgb = hexToRgb(primary)
-  const secondaryRgb = hexToRgb(secondary)
+  const secondaryRgb = hexToRgb(secondary || '')
   const [primaryHue, primarySaturation, primaryLightness] = rgbToHsl(...primaryRgb)
   const [secondaryHue, secondarySaturation, secondaryLightness] = rgbToHsl(...secondaryRgb)
   const isSecondaryWhite = secondaryLightness === 100

--- a/modules/cactus-theme/tests/__snapshots__/exports.test.ts.snap
+++ b/modules/cactus-theme/tests/__snapshots__/exports.test.ts.snap
@@ -2,7 +2,23 @@
 
 exports[`@repay/cactus-i18n should match snapshot of exports 1`] = `
 Array [
-  "generateTheme",
   "default",
+  "generateTheme",
+  "isResponsiveTouchDevice",
+  "borderSize",
+  "border",
+  "radius",
+  "insetBorder",
+  "mediaGTE",
+  "mediaLT",
+  "breakpoint",
+  "color",
+  "colorStyle",
+  "space",
+  "iconSize",
+  "fontSize",
+  "textStyle",
+  "boxShadow",
+  "shadow",
 ]
 `;

--- a/modules/cactus-theme/tests/__snapshots__/exports.test.ts.snap
+++ b/modules/cactus-theme/tests/__snapshots__/exports.test.ts.snap
@@ -18,6 +18,7 @@ Array [
   "iconSize",
   "fontSize",
   "textStyle",
+  "lineHeight",
   "boxShadow",
   "shadow",
 ]

--- a/modules/cactus-theme/tests/border-helpers.test.ts
+++ b/modules/cactus-theme/tests/border-helpers.test.ts
@@ -1,0 +1,115 @@
+import { border, borderSize, insetBorder, radius } from '../src/helpers/borders'
+import defaultTheme, { CactusColor, generateTheme } from '../src/theme'
+import { defaultProps, expectCurry, expectMemo } from './helpers'
+
+const thin = defaultProps
+const thick = { theme: generateTheme({ primaryHue: 200, shape: 'square', border: 'thick' }) }
+
+const square = thick
+const intermediate = thin
+const round = { theme: generateTheme({ primaryHue: 50, shape: 'round' }) }
+
+const altColor = round
+
+describe('helper: borderSize', () => {
+  test('should curry args', () => {
+    expectCurry(borderSize, [], '1px')
+    expectCurry(borderSize, [{ thin: 'I prefer "slim"', thick: 'no, you are' }], 'I prefer "slim"')
+  })
+
+  test('gets default border thickness', () => {
+    expect(borderSize(thin)).toBe('1px')
+    expect(borderSize(thick)).toBe('2px')
+  })
+
+  test('gets custom value from options', () => {
+    const opts = { thin: 3.1415, thick: 'tau is better' }
+    expect(borderSize(thin, opts)).toBe(3.1415)
+    expect(borderSize(thick, opts)).toBe('tau is better')
+  })
+})
+
+describe('helper: border', () => {
+  const simpleBorder = `1px solid ${defaultTheme.colors.lightContrast}`
+
+  test('should curry args', () => {
+    expectCurry(border, ['lightContrast'], simpleBorder)
+  })
+
+  test('should memoize colors', () => {
+    expectMemo(
+      border,
+      { lightContrast: simpleBorder },
+      {
+        key: 'lightContrast',
+        value: `1px solid ${altColor.theme.colors.lightContrast}`,
+        ...altColor,
+      }
+    )
+  })
+
+  test('allows fallback color', () => {
+    expect(border(defaultProps, 'success')).toBe(`1px solid ${defaultTheme.colors.success}`)
+    expect(border(defaultProps, 'orange')).toBe('1px solid orange')
+  })
+
+  test('gets custom thickness from options', () => {
+    const opts = { thin: '1%', thick: '1em' }
+    expect(border(thin, 'green', opts)).toBe('1% solid green')
+    expect(border(thick, 'green', opts)).toBe('1em solid green')
+  })
+})
+
+describe('helper: radius', () => {
+  test('should curry args', () => {
+    expectCurry(radius, [12], '5px')
+  })
+
+  test('should memoize radii', () => {
+    expectMemo(radius, { 8: '4px', 20: '8px' }, { key: 8, value: '0px', ...square })
+  })
+
+  test('gets radius by theme shape', () => {
+    expect(radius(round, 17)).toBe('17px')
+    expect(radius(intermediate, 17)).toBe('7px')
+    expect(radius(square, 17)).toBe('0px')
+  })
+
+  test('allows custom intermediate scale factor', () => {
+    expect(radius(square, 17, 0.9)).toBe('0px')
+    expect(radius(round, 17, 0.9)).toBe('17px')
+    expect(radius(intermediate, 17, 0.9)).toBe('16px')
+    expect(radius(intermediate, 17, 1.5)).toBe('26px')
+    expect(radius(intermediate, 17, 0.1)).toBe('2px')
+  })
+})
+
+describe('helper: insetBorder', () => {
+  const $ = (c: string, h: string, v: string, s: string) =>
+    `box-shadow: inset ${h} ${v} 0 ${s} ${c}`
+  const _ = (c: CactusColor, h: string, v: string, s: string, p = defaultProps) =>
+    $(p.theme.colors[c], h, v, s)
+
+  test('should curry args', () => {
+    expectCurry(insetBorder, ['lightContrast'], _('lightContrast', '0', '0', '1px'))
+    expectCurry(insetBorder, ['green', 'bottom', { thin: '3px' }], $('green', '0', '-3px', '0'))
+  })
+
+  test('allows fallback color', () => {
+    expect(insetBorder(defaultProps, 'success')).toBe(_('success', '0', '0', '1px'))
+    expect(insetBorder(defaultProps, 'orange')).toBe($('orange', '0', '0', '1px'))
+  })
+
+  test('should change offsets according to direction', () => {
+    expect(insetBorder(defaultProps, 'red', 'top')).toBe($('red', '0', '1px', '0'))
+    expect(insetBorder(defaultProps, 'red', 'bottom')).toBe($('red', '0', '-1px', '0'))
+    expect(insetBorder(defaultProps, 'red', 'left')).toBe($('red', '1px', '0', '0'))
+    expect(insetBorder(defaultProps, 'red', 'right')).toBe($('red', '-1px', '0', '0'))
+  })
+
+  test('gets custom thickness from options', () => {
+    const opts = { thin: '1%', thick: '1em' }
+    expect(insetBorder(thin, 'green', undefined, opts)).toBe($('green', '0', '0', '1%'))
+    expect(insetBorder(thick, 'green', 'right', opts)).toBe($('green', '-1em', '0', '0'))
+  })
+})

--- a/modules/cactus-theme/tests/border-helpers.test.ts
+++ b/modules/cactus-theme/tests/border-helpers.test.ts
@@ -86,7 +86,7 @@ describe('helper: radius', () => {
 
 describe('helper: insetBorder', () => {
   const $ = (c: string, h: string, v: string, s: string) =>
-    `box-shadow: inset ${h} ${v} 0 ${s} ${c}`
+    `box-shadow: inset ${h} ${v} 0 ${s} ${c};`
   const _ = (c: CactusColor, h: string, v: string, s: string, p = defaultProps) =>
     $(p.theme.colors[c], h, v, s)
 

--- a/modules/cactus-theme/tests/breakpoint-helpers.test.ts
+++ b/modules/cactus-theme/tests/breakpoint-helpers.test.ts
@@ -28,17 +28,17 @@ describe('helper: mediaGTE', () => {
 
 describe('helper: mediaLT', () => {
   test('should curry args', () => {
-    expectCurry(mediaLT, ['extraLarge'], '@media screen and (not (min-width: 1440px))')
+    expectCurry(mediaLT, ['extraLarge'], '@media not screen and (min-width: 1440px)')
   })
 
   test('should memoize screen sizes', () => {
     expectMemo(
       mediaLT,
       {
-        small: '@media screen and (not (min-width: 768px))',
-        medium: '@media screen and (not (min-width: 1024px))',
+        small: '@media not screen and (min-width: 768px)',
+        medium: '@media not screen and (min-width: 1024px)',
       },
-      { key: 'medium', value: '@media screen and (not (min-width: 500px))', ...altBP }
+      { key: 'medium', value: '@media not screen and (min-width: 500px)', ...altBP }
     )
   })
 })

--- a/modules/cactus-theme/tests/breakpoint-helpers.test.ts
+++ b/modules/cactus-theme/tests/breakpoint-helpers.test.ts
@@ -1,0 +1,68 @@
+import { breakpoint, mediaGTE, mediaLT } from '../src/helpers/breakpoints'
+import { generateTheme } from '../src/theme'
+import { defaultProps, expectCurry, expectMemo } from './helpers'
+
+const altBP = {
+  theme: generateTheme({
+    primaryHue: 200,
+    breakpoints: { small: '20rem', medium: '500px', large: '80rem', extraLarge: '1200px' },
+  }),
+}
+
+describe('helper: mediaGTE', () => {
+  test('should curry args', () => {
+    expectCurry(mediaGTE, ['large'], '@media screen and (min-width: 1200px)')
+  })
+
+  test('should memoize screen sizes', () => {
+    expectMemo(
+      mediaGTE,
+      {
+        small: '@media screen and (min-width: 768px)',
+        medium: '@media screen and (min-width: 1024px)',
+      },
+      { key: 'small', value: '@media screen and (min-width: 20rem)', ...altBP }
+    )
+  })
+})
+
+describe('helper: mediaLT', () => {
+  test('should curry args', () => {
+    expectCurry(mediaLT, ['extraLarge'], '@media screen and (not (min-width: 1440px))')
+  })
+
+  test('should memoize screen sizes', () => {
+    expectMemo(
+      mediaLT,
+      {
+        small: '@media screen and (not (min-width: 768px))',
+        medium: '@media screen and (not (min-width: 1024px))',
+      },
+      { key: 'medium', value: '@media screen and (not (min-width: 500px))', ...altBP }
+    )
+  })
+})
+
+describe('helper: breakpoint', () => {
+  test('should curry args', () => {
+    expectCurry(breakpoint, ['large'], '1200px')
+  })
+
+  test('should accept index or name', () => {
+    const small = breakpoint(defaultProps, 'small')
+    expect(small).toBe('768px')
+    expect(breakpoint(defaultProps, 0)).toBe(small)
+
+    const medium = breakpoint(defaultProps, 'medium')
+    expect(medium).toBe('1024px')
+    expect(breakpoint(defaultProps, 1)).toBe(medium)
+
+    const large = breakpoint(defaultProps, 'large')
+    expect(large).toBe('1200px')
+    expect(breakpoint(defaultProps, 2)).toBe(large)
+
+    const extraLarge = breakpoint(defaultProps, 'extraLarge')
+    expect(extraLarge).toBe('1440px')
+    expect(breakpoint(defaultProps, 3)).toBe(extraLarge)
+  })
+})

--- a/modules/cactus-theme/tests/color-helpers.test.ts
+++ b/modules/cactus-theme/tests/color-helpers.test.ts
@@ -1,0 +1,72 @@
+import { color, colorStyle } from '../src/helpers/colors'
+import { CactusColor, ColorStyle, ColorVariant, generateTheme } from '../src/theme'
+import { defaultProps, expectCurry, expectMemo } from './helpers'
+
+const altColor = { theme: generateTheme({ primaryHue: 50 }) }
+
+describe('helper: color', () => {
+  test('should curry args', () => {
+    expectCurry(color, ['warning'], defaultProps.theme.colors.warning)
+  })
+
+  test('should memoize colors', () => {
+    const memo: CactusColor[] = [
+      'base',
+      'callToAction',
+      'lightContrast',
+      'darkestContrast',
+      'white',
+      'lightGray',
+      'mediumGray',
+      'success',
+      'error',
+    ]
+    const colors = memo.reduce((c, key) => {
+      c[key] = defaultProps.theme.colors[key]
+      return c
+    }, {} as Record<CactusColor, string>)
+    expectMemo(color, colors, {
+      key: 'base',
+      value: altColor.theme.colors.base,
+      ...altColor,
+    })
+  })
+})
+
+describe('helper: colorStyle', () => {
+  test('should curry args', () => {
+    expectCurry<[ColorVariant], ColorStyle>(
+      colorStyle,
+      ['warning'],
+      defaultProps.theme.colorStyles.warning
+    )
+    expectCurry<['red', 'black'], ColorStyle>(colorStyle, ['red', 'black'], {
+      color: 'red',
+      backgroundColor: 'black',
+    })
+  })
+
+  test('should memoize color styles', () => {
+    const memo: ColorVariant[] = ['base', 'callToAction', 'standard', 'success', 'error', 'disable']
+    const colors = memo.reduce((c, key) => {
+      c[key] = defaultProps.theme.colorStyles[key]
+      return c
+    }, {} as Record<ColorVariant, ColorStyle>)
+    expectMemo(colorStyle, colors, {
+      key: 'base',
+      value: altColor.theme.colorStyles.base,
+      ...altColor,
+    })
+  })
+
+  test('should accept two colors', () => {
+    expect(colorStyle(defaultProps, 'green', 'callToAction')).toEqual({
+      color: 'green',
+      backgroundColor: defaultProps.theme.colors.callToAction,
+    })
+    expect(colorStyle(defaultProps, 'darkContrast', 'blue')).toEqual({
+      color: defaultProps.theme.colors.darkContrast,
+      backgroundColor: 'blue',
+    })
+  })
+})

--- a/modules/cactus-theme/tests/exports.test.ts
+++ b/modules/cactus-theme/tests/exports.test.ts
@@ -1,4 +1,4 @@
-import * as cactusThemeExports from '../src/theme'
+import * as cactusThemeExports from '../src/index'
 
 describe('@repay/cactus-i18n', (): void => {
   test('should match snapshot of exports', (): void => {

--- a/modules/cactus-theme/tests/helpers.ts
+++ b/modules/cactus-theme/tests/helpers.ts
@@ -1,0 +1,30 @@
+import { HelperFunc } from '../src/helpers/base'
+import defaultTheme from '../src/theme'
+
+export const defaultProps = { theme: defaultTheme }
+
+export const expectCurry = <A extends any[], R>(fn: HelperFunc<A, R>, args: A, result: R): void => {
+  const curried = fn(...args)
+  const fromProps = fn(defaultProps, ...args)
+  const fromTheme = fn(defaultTheme, ...args)
+  expect(typeof curried).toBe('function')
+  expect(curried(defaultProps)).toEqual(result)
+  expect(fromProps).toEqual(result)
+  expect(fromTheme).toEqual(result)
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const expectMemo = (fn: any, expectedMemos: any, extra?: any): void => {
+  const keys = Object.keys(expectedMemos).sort()
+  expect(Object.keys(fn).sort()).toEqual(keys)
+  for (const key of keys) {
+    expect(fn[key]).toBe(fn(key))
+    expect(fn(defaultProps, key)).toEqual(expectedMemos[key])
+  }
+  // This is to show it's the FUNCTION that's memoized, not the result.
+  if (extra) {
+    const extraVal = fn[extra.key](extra)
+    expect(extraVal).toBe(extra.value)
+    expect(extraVal).not.toBe(expectedMemos[extra.key])
+  }
+}

--- a/modules/cactus-theme/tests/shadow-helpers.test.ts
+++ b/modules/cactus-theme/tests/shadow-helpers.test.ts
@@ -6,18 +6,18 @@ const withShadow = defaultProps
 const noShadow = { theme: generateTheme({ primaryHue: 200, boxShadows: false }) }
 
 const _ = (size: string, c: CactusColor = 'lightCallToAction') =>
-  `box-shadow: ${size} ${defaultProps.theme.colors[c]}`
+  `box-shadow: ${size} ${defaultProps.theme.colors[c]};`
 
 describe('helper: boxShadow', () => {
   test('should curry args', () => {
     expectCurry(boxShadow, [1], _('0px 3px 8px'))
-    expectCurry(boxShadow, [0, 'gray'], 'box-shadow: 0px 0px 3px gray')
+    expectCurry(boxShadow, [0, 'gray'], 'box-shadow: 0px 0px 3px gray;')
   })
 
   test('allows fallback color', () => {
     // This helper ignores the `boxShadows` setting.
     expect(boxShadow(noShadow, 2, 'mediumGray')).toBe(_('0px 9px 24px', 'mediumGray'))
-    expect(boxShadow(noShadow, 3, 'orange')).toBe('box-shadow: 0px 12px 24px orange')
+    expect(boxShadow(noShadow, 3, 'orange')).toBe('box-shadow: 0px 12px 24px orange;')
   })
 })
 
@@ -33,11 +33,11 @@ describe('helper: shadow', () => {
   test('allows fallback: border color', () => {
     expect(shadow(withShadow, '4px', 'lightContrast')).toBe(_('4px'))
     expect(shadow(noShadow, '4px', 'lightContrast')).toBe(
-      `border: 1px solid ${defaultProps.theme.colors.lightContrast}`
+      `border: 1px solid ${defaultProps.theme.colors.lightContrast};`
     )
 
     expect(shadow(withShadow, 5, 'rgb(1, 2, 3)')).toBe(_('0px 45px 48px'))
-    expect(shadow(noShadow, 5, 'rgb(1, 2, 3)')).toBe(`border: 1px solid rgb(1, 2, 3)`)
+    expect(shadow(noShadow, 5, 'rgb(1, 2, 3)')).toBe(`border: 1px solid rgb(1, 2, 3);`)
   })
 
   test('allows fallback: CSS property', () => {
@@ -54,11 +54,11 @@ describe('helper: shadow', () => {
   test('allows fallback: style function', () => {
     const fn1 = (p: typeof defaultProps) => `2px dotted ${p.theme.colors.base}`
     expect(shadow(withShadow, 0, fn1)).toBe(_('0px 0px 3px'))
-    expect(shadow(noShadow, 0, fn1)).toBe(`border: 2px dotted ${noShadow.theme.colors.base}`)
+    expect(shadow(noShadow, 0, fn1)).toBe(`border: 2px dotted ${noShadow.theme.colors.base};`)
 
-    const fn2 = () => 'ouline: 1px dotted orange'
+    const fn2 = () => 'ouline: 1px dotted orange;'
     expect(shadow(withShadow, 1, fn2)).toBe(_('0px 3px 8px'))
-    expect(shadow(noShadow, 1, fn2)).toBe('ouline: 1px dotted orange')
+    expect(shadow(noShadow, 1, fn2)).toBe('ouline: 1px dotted orange;')
 
     const fn3 = (p: typeof defaultProps) => ({ backgroundColor: p.theme.colors.lightContrast })
     expect(shadow(withShadow, 'once', fn3)).toBe(_('once'))

--- a/modules/cactus-theme/tests/shadow-helpers.test.ts
+++ b/modules/cactus-theme/tests/shadow-helpers.test.ts
@@ -1,0 +1,69 @@
+import { boxShadow, shadow } from '../src/helpers/shadows'
+import { CactusColor, generateTheme } from '../src/theme'
+import { defaultProps, expectCurry } from './helpers'
+
+const withShadow = defaultProps
+const noShadow = { theme: generateTheme({ primaryHue: 200, boxShadows: false }) }
+
+const _ = (size: string, c: CactusColor = 'lightCallToAction') =>
+  `box-shadow: ${size} ${defaultProps.theme.colors[c]}`
+
+describe('helper: boxShadow', () => {
+  test('should curry args', () => {
+    expectCurry(boxShadow, [1], _('0px 3px 8px'))
+    expectCurry(boxShadow, [0, 'gray'], 'box-shadow: 0px 0px 3px gray')
+  })
+
+  test('allows fallback color', () => {
+    // This helper ignores the `boxShadows` setting.
+    expect(boxShadow(noShadow, 2, 'mediumGray')).toBe(_('0px 9px 24px', 'mediumGray'))
+    expect(boxShadow(noShadow, 3, 'orange')).toBe('box-shadow: 0px 12px 24px orange')
+  })
+})
+
+describe('helper: shadow', () => {
+  test('should curry args', () => {
+    expectCurry(shadow, [4], _('0px 30px 42px'))
+  })
+
+  test('allows custom shadow size', () => {
+    expect(shadow(withShadow, 'hello')).toBe(_('hello'))
+  })
+
+  test('allows fallback: border color', () => {
+    expect(shadow(withShadow, '4px', 'lightContrast')).toBe(_('4px'))
+    expect(shadow(noShadow, '4px', 'lightContrast')).toBe(
+      `border: 1px solid ${defaultProps.theme.colors.lightContrast}`
+    )
+
+    expect(shadow(withShadow, 5, 'rgb(1, 2, 3)')).toBe(_('0px 45px 48px'))
+    expect(shadow(noShadow, 5, 'rgb(1, 2, 3)')).toBe(`border: 1px solid rgb(1, 2, 3)`)
+  })
+
+  test('allows fallback: CSS property', () => {
+    expect(shadow(withShadow, 2, 'outline: 1px solid black')).toBe(_('0px 9px 24px'))
+    expect(shadow(noShadow, 2, 'outline: 1px solid black')).toBe('outline: 1px solid black')
+  })
+
+  test('allows fallback: CSS object', () => {
+    const obj = { outline: '2px dotted cyan', outlineOffset: '2px' }
+    expect(shadow(withShadow, 4, obj)).toBe(_('0px 30px 42px'))
+    expect(shadow(noShadow, 4, obj)).toBe(obj)
+  })
+
+  test('allows fallback: style function', () => {
+    const fn1 = (p: typeof defaultProps) => `2px dotted ${p.theme.colors.base}`
+    expect(shadow(withShadow, 0, fn1)).toBe(_('0px 0px 3px'))
+    expect(shadow(noShadow, 0, fn1)).toBe(`border: 2px dotted ${noShadow.theme.colors.base}`)
+
+    const fn2 = () => 'ouline: 1px dotted orange'
+    expect(shadow(withShadow, 1, fn2)).toBe(_('0px 3px 8px'))
+    expect(shadow(noShadow, 1, fn2)).toBe('ouline: 1px dotted orange')
+
+    const fn3 = (p: typeof defaultProps) => ({ backgroundColor: p.theme.colors.lightContrast })
+    expect(shadow(withShadow, 'once', fn3)).toBe(_('once'))
+    expect(shadow(noShadow, 'once', fn3)).toEqual({
+      backgroundColor: noShadow.theme.colors.lightContrast,
+    })
+  })
+})

--- a/modules/cactus-theme/tests/size-helpers.test.ts
+++ b/modules/cactus-theme/tests/size-helpers.test.ts
@@ -1,5 +1,8 @@
-import { fontSize, iconSize, space, textStyle } from '../src/helpers/sizes'
-import { expectCurry, expectMemo } from './helpers'
+/**
+ * @jest-environment jsdom
+ */
+import { fontSize, iconSize, lineHeight, space, textStyle } from '../src/helpers/sizes'
+import { defaultProps, expectCurry, expectMemo } from './helpers'
 
 describe('helper: space', () => {
   test('should curry args', () => {
@@ -30,6 +33,44 @@ describe('helper: fontSize', () => {
 
   test('should memoize font sizes', () => {
     expectMemo(fontSize, { body: 'font-size: 18px;', small: 'font-size: 15px;' })
+  })
+})
+
+describe('helper: lineHeight', () => {
+  const realMedia = window.matchMedia
+  const query = `@media screen and (min-width: ${defaultProps.theme.breakpoints[1]})`
+  const useMobile: any = () => ({ matches: false })
+  const useNormal: any = () => ({ matches: true })
+  const custom = (l: number, f: number) => `min-height: ${(f / l).toFixed(2)}px;`
+
+  test('should curry args', () => {
+    window.matchMedia = useMobile
+    expectCurry(lineHeight, ['h1'], '46.65px')
+    expectCurry(lineHeight, ['h1', 'em'], '1.5em')
+  })
+
+  test('should change per screen size', () => {
+    window.matchMedia = useNormal
+    expect(lineHeight(defaultProps, 'h1')).toBe('55.9875px')
+    expect(lineHeight(defaultProps, 'h1', 'em')).toBe('1.5em')
+  })
+
+  test('should render property', () => {
+    expect(lineHeight(defaultProps, 'body', 'height')).toBe('height: 27px;')
+    expect(lineHeight(defaultProps, 'h1', 'height')).toBe(
+      `height: 46.65px; ${query} { height: 55.9875px; }`
+    )
+  })
+
+  test('should render custom func', () => {
+    expect(lineHeight(defaultProps, 'body', custom)).toBe('min-height: 12.00px;')
+    expect(lineHeight(defaultProps, 'h1', custom)).toBe(
+      `min-height: 20.73px; ${query} { min-height: 24.88px; }`
+    )
+  })
+
+  afterEach(() => {
+    window.matchMedia = realMedia
   })
 })
 

--- a/modules/cactus-theme/tests/size-helpers.test.ts
+++ b/modules/cactus-theme/tests/size-helpers.test.ts
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 import { fontSize, iconSize, lineHeight, space, textStyle } from '../src/helpers/sizes'
 import { defaultProps, expectCurry, expectMemo } from './helpers'
 
@@ -37,40 +34,20 @@ describe('helper: fontSize', () => {
 })
 
 describe('helper: lineHeight', () => {
-  const realMedia = window.matchMedia
   const query = `@media screen and (min-width: ${defaultProps.theme.breakpoints[1]})`
-  const useMobile: any = () => ({ matches: false })
-  const useNormal: any = () => ({ matches: true })
-  const custom = (l: number, f: number) => `min-height: ${(f / l).toFixed(2)}px;`
+  const custom = (l: string) => `::before { content: '${l}'; }`
 
   test('should curry args', () => {
-    window.matchMedia = useMobile
-    expectCurry(lineHeight, ['h1'], '46.65px')
-    expectCurry(lineHeight, ['h1', 'em'], '1.5em')
-  })
-
-  test('should change per screen size', () => {
-    window.matchMedia = useNormal
-    expect(lineHeight(defaultProps, 'h1')).toBe('55.9875px')
-    expect(lineHeight(defaultProps, 'h1', 'em')).toBe('1.5em')
-  })
-
-  test('should render property', () => {
-    expect(lineHeight(defaultProps, 'body', 'height')).toBe('height: 27px;')
-    expect(lineHeight(defaultProps, 'h1', 'height')).toBe(
-      `height: 46.65px; ${query} { height: 55.9875px; }`
-    )
+    expectCurry(lineHeight, ['h1', 'h'], `h: 46.65px; ${query} { h: 55.9875px; }`)
+    expectCurry(lineHeight, ['h1', 'h', 'em'], 'h: 1.5em;')
   })
 
   test('should render custom func', () => {
-    expect(lineHeight(defaultProps, 'body', custom)).toBe('min-height: 12.00px;')
+    expect(lineHeight(defaultProps, 'body', custom)).toBe(`::before { content: '27px'; }`)
     expect(lineHeight(defaultProps, 'h1', custom)).toBe(
-      `min-height: 20.73px; ${query} { min-height: 24.88px; }`
+      `::before { content: '46.65px'; } ${query} { ::before { content: '55.9875px'; } }`
     )
-  })
-
-  afterEach(() => {
-    window.matchMedia = realMedia
+    expect(lineHeight(defaultProps, 'h1', custom, 'em')).toBe(`::before { content: '1.5em'; }`)
   })
 })
 

--- a/modules/cactus-theme/tests/size-helpers.test.ts
+++ b/modules/cactus-theme/tests/size-helpers.test.ts
@@ -1,0 +1,55 @@
+import { fontSize, iconSize, space, textStyle } from '../src/helpers/sizes'
+import { expectCurry, expectMemo } from './helpers'
+
+describe('helper: space', () => {
+  test('should curry args', () => {
+    expectCurry(space, [1], '2px')
+  })
+
+  test('should memoize sizes', () => {
+    expectMemo(space, { 2: '4px', 3: '8px', 4: '16px', 5: '24px', 7: '40px' })
+  })
+})
+
+describe('helper: iconSize', () => {
+  test('should curry args', () => {
+    expectCurry(iconSize, ['small'], '16px')
+  })
+})
+
+describe('helper: fontSize', () => {
+  const h2 = `
+    font-size: 25.92px;
+    @media screen and (min-width: 1024px) {
+      font-size: 31.104px;
+    }
+  `
+  test('should curry args', () => {
+    expectCurry(fontSize, ['h2'], h2)
+  })
+
+  test('should memoize font sizes', () => {
+    expectMemo(fontSize, { body: 'font-size: 18px;', small: 'font-size: 15px;' })
+  })
+})
+
+describe('helper: textStyle', () => {
+  const h3 = `
+    font-size: 21.6px;
+    line-height: 1.5;
+    @media screen and (min-width: 1024px) {
+      font-size: 25.92px;
+      line-height: 1.5;
+    }
+  `
+  test('should curry args', () => {
+    expectCurry(textStyle, ['h3'], h3)
+  })
+
+  test('should memoize text styles', () => {
+    expectMemo(textStyle, {
+      body: { fontSize: '18px', lineHeight: '1.5' },
+      small: { fontSize: '15px', lineHeight: '1.6' },
+    })
+  })
+})

--- a/modules/cactus-theme/tests/theme.test.ts
+++ b/modules/cactus-theme/tests/theme.test.ts
@@ -1,7 +1,6 @@
 import Color from 'color'
 
-import { CactusTheme } from '../dist/theme'
-import cactusTheme, { generateTheme } from '../src/theme'
+import cactusTheme, { CactusTheme, ColorVariant, generateTheme } from '../src/theme'
 
 function themeAccessibility(themeName: string, theme: CactusTheme): void {
   describe(`${themeName} meets basic accessibility contrast thresholds`, (): void => {
@@ -22,8 +21,7 @@ function themeAccessibility(themeName: string, theme: CactusTheme): void {
         new Color(theme.colors.callToAction).contrast(new Color('#FFFFFF'))
       ).toBeGreaterThanOrEqual(4.5)
     })
-
-    Object.keys(theme.colorStyles).forEach((name): void => {
+    ;(Object.keys(theme.colorStyles) as ColorVariant[]).forEach((name): void => {
       if (name !== 'disable') {
         test(`colorStyle ${name}`, (): void => {
           expect(

--- a/modules/cactus-theme/tsconfig.build.json
+++ b/modules/cactus-theme/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/modules/cactus-theme/tsconfig.json
+++ b/modules/cactus-theme/tsconfig.json
@@ -1,11 +1,10 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
     "outDir": "dist",
-    "declaration": true,
-    "types": []
+    "rootDir": ".",
+    "types": ["react", "jest", "node"]
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src", "tests"],
   "exclude": ["**/node_modules", "dist"]
 }


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-664

I added all the helpers from channels + cactus-web, although the API is more like what I did in channels. I even added a couple of new ones, so we pretty much cover every theme attribute.

If anyone can think of a better name for the media query helpers than `mediaGTE` and `mediaLT`, that'd be great: I really don't like those names, but couldn't think of anything better that wasn't several words long.

Last thing to be aware of is that I changed some things about the build/Typescript config. It worked within the repo, but I don't know much about JS packaging, so hopefully it'll still work after it's deployed. Make sure you do `yarn cleanup` before testing, though, to get rid of the old build code.

Finally, if you want to see the new helpers in action, I made a branch where I applied most of them at least once: https://github.com/repaygithub/cactus/compare/cactus-664-theme-helpers...verify-664?w=1