### PR TITLE
CACTUS-664: change shadow fallback to outline

### DIFF
--- a/docs/Theme/Style Helpers.md
+++ b/docs/Theme/Style Helpers.md
@@ -159,9 +159,9 @@ If `theme.boxShadows` is false, the fallback is returned instead:
 - Else it's returned as-is.
 
 ```
-shadow(0, 'lightContrast') // = 'border: 1px solid [theme.colors.lightContrast]'
-shadow(0, border('red', { thin: '2px' })) // = 'border: 2px solid red'
-shadow(0, 'outline: 1px solid green') // = 'outline: 1px solid green'
+shadow(0, 'lightContrast') // = 'outline: 1px solid [theme.colors.lightContrast]'
+shadow(0, border('red', { thin: '2px' })) // = 'outline: 2px solid red'
+shadow(0, 'border: 1px solid green') // = 'border: 1px solid green'
 shadow(0, { margin: '2px' }) // = { margin: '2px' }
 ```
 

--- a/modules/cactus-theme/src/helpers/shadows.ts
+++ b/modules/cactus-theme/src/helpers/shadows.ts
@@ -26,7 +26,7 @@ export const boxShadow = wrap(_boxShadow)
  * `fallback` can be a function that takes the props object, or a string, or a CSS object.
  * If it's a string that does not contain ':', it's assumed to be a border color.
  * Similarly, if the function returns a string with no ':', it's automatically added
- * to a `border:` property declaration.
+ * to an `outline:` property declaration.
  */
 const _shadow = (
   props: ThemeProps,
@@ -43,7 +43,7 @@ const _shadow = (
     // Assume string fallbacks are border colors.
     value = border(props, fallback)
   }
-  // If no CSS property is specified, assume `border` as the closest analogue of box shadows.
-  return isCssValue(value) ? `border: ${value};` : value
+  // If no CSS property is specified, assume `outline` as the closest analogue of box shadows.
+  return isCssValue(value) ? `outline: ${value};` : value
 }
 export const shadow = wrap(_shadow)

--- a/modules/cactus-theme/tests/shadow-helpers.test.ts
+++ b/modules/cactus-theme/tests/shadow-helpers.test.ts
@@ -30,19 +30,19 @@ describe('helper: shadow', () => {
     expect(shadow(withShadow, 'hello')).toBe(_('hello'))
   })
 
-  test('allows fallback: border color', () => {
+  test('allows fallback: outline color', () => {
     expect(shadow(withShadow, '4px', 'lightContrast')).toBe(_('4px'))
     expect(shadow(noShadow, '4px', 'lightContrast')).toBe(
-      `border: 1px solid ${defaultProps.theme.colors.lightContrast};`
+      `outline: 1px solid ${defaultProps.theme.colors.lightContrast};`
     )
 
     expect(shadow(withShadow, 5, 'rgb(1, 2, 3)')).toBe(_('0px 45px 48px'))
-    expect(shadow(noShadow, 5, 'rgb(1, 2, 3)')).toBe(`border: 1px solid rgb(1, 2, 3);`)
+    expect(shadow(noShadow, 5, 'rgb(1, 2, 3)')).toBe(`outline: 1px solid rgb(1, 2, 3);`)
   })
 
   test('allows fallback: CSS property', () => {
-    expect(shadow(withShadow, 2, 'outline: 1px solid black')).toBe(_('0px 9px 24px'))
-    expect(shadow(noShadow, 2, 'outline: 1px solid black')).toBe('outline: 1px solid black')
+    expect(shadow(withShadow, 2, 'border: 1px solid black')).toBe(_('0px 9px 24px'))
+    expect(shadow(noShadow, 2, 'border: 1px solid black')).toBe('border: 1px solid black')
   })
 
   test('allows fallback: CSS object', () => {
@@ -54,7 +54,7 @@ describe('helper: shadow', () => {
   test('allows fallback: style function', () => {
     const fn1 = (p: typeof defaultProps) => `2px dotted ${p.theme.colors.base}`
     expect(shadow(withShadow, 0, fn1)).toBe(_('0px 0px 3px'))
-    expect(shadow(noShadow, 0, fn1)).toBe(`border: 2px dotted ${noShadow.theme.colors.base};`)
+    expect(shadow(noShadow, 0, fn1)).toBe(`outline: 2px dotted ${noShadow.theme.colors.base};`)
 
     const fn2 = () => 'ouline: 1px dotted orange;'
     expect(shadow(withShadow, 1, fn2)).toBe(_('0px 3px 8px'))


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-664

I was working on Calendar when I noticed that even when I set the `border-radius` to the same values for the outer and inner divs, they didn't line up when I turned box shadows off. Turns out `border-radius` is the outer radius, which means the inner radius changes when you add a border. As such, outline is a closer analogue of box-shadow, because it does not affect the dimensions of the container in any way.

This is just my personal opinion, though, so feel free to reject the PR if you disagree.