### PR TITLE
CACTUS-729 ::  Can't Clear DateInput

### DIFF
--- a/modules/cactus-web/src/DateInput/DateInput.story.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.story.tsx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/react/types-6-0'
 import { Page } from 'puppeteer'
 import React, { ReactElement, useState } from 'react'
 
-import { DateInput, Flex, StatusMessage } from '../'
+import { Button, DateInput, Flex, StatusMessage } from '../'
 
 const eventLoggers = {
   onChange: (e: any) => console.log(`onChange '${e.target.name}': ${e.target.value}`),

--- a/modules/cactus-web/src/DateInput/DateInput.story.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.story.tsx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/react/types-6-0'
 import { Page } from 'puppeteer'
 import React, { ReactElement, useState } from 'react'
 
-import { Button, DateInput, Flex, StatusMessage } from '../'
+import { DateInput, Flex, StatusMessage } from '../'
 
 const eventLoggers = {
   onChange: (e: any) => console.log(`onChange '${e.target.name}': ${e.target.value}`),

--- a/modules/cactus-web/src/DateInput/DateInput.test.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.test.tsx
@@ -116,6 +116,27 @@ describe('component: DateInput', (): void => {
 
       expect(handleChange).toHaveBeenCalledTimes(7)
     })
+    test('Clear the value when it is controlled by string', () => {
+      const { getByLabelText, rerender } = render(
+        <StyleProvider>
+          <DateInput name="date-input" id="date-input" value="2019-09-16" format="YYYY-MM-dd" />
+        </StyleProvider>
+      )
+
+      expect(getByLabelText('year')).toHaveProperty('value', '2019')
+      expect(getByLabelText('month')).toHaveProperty('value', '09')
+      expect(getByLabelText('day of month')).toHaveProperty('value', '16')
+
+      rerender(
+        <StyleProvider>
+          <DateInput name="date-input" id="date-input" value="" format="YYYY-MM-dd" />
+        </StyleProvider>
+      )
+
+      expect(getByLabelText('year')).toHaveProperty('value', '')
+      expect(getByLabelText('month')).toHaveProperty('value', '')
+      expect(getByLabelText('day of month')).toHaveProperty('value', '')
+    })
   })
 
   describe('using inputs', (): void => {

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -378,6 +378,7 @@ export interface DateInputProps
 
 interface DateInputState {
   value: PartialDate
+  prevValue: string | Date | null | undefined
   focusMonth: number
   focusYear: number
   locale: string
@@ -406,8 +407,10 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
 
     const initValue = props.value === undefined ? props.defaultValue : props.value
     const value = PartialDate.from(initValue, { format, locale, type })
+    const prevValue = props.value
     this.state = {
       value,
+      prevValue,
       focusMonth: value.getMonth(),
       focusYear: value.getYear(),
       type,
@@ -497,6 +500,10 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
         updates.focusMonth = value.getMonth()
         updates.focusYear = value.getYear()
       }
+    }
+    if (!props.value && props.value !== state.prevValue) {
+      updates = updates || {}
+      updates.value = PartialDate.from(null, { type: state.value.getType() })
     }
 
     return updates


### PR DESCRIPTION
[CACTUS-729](https://repayonline.atlassian.net/browse/CACTUS-719)
### PR description:
Basically, I put a new logic into the `getDerivedStateFromProps` method for clearing the input when the `value` prop is passed with a falsy value.  Then I wrote a new test case to cover that. 

If you want you could open DateInput.story.tsx file and modify the story `ControlledWithString` with the following 
```typescript
export const ControlledWithString = (): ReactElement => {
  const [value, setValue] = React.useState<Date | string | null>('2019-09-16')
  return (
    <>
      <DateInput
        disabled={boolean('disabled', false)}
        id="date-input-with-string-value"
        name={text('name', 'date-input-with-string-value')}
        value={value}
        format="YYYY-MM-dd"
        onChange={(e) => setValue(e.target.value)}
      />
      <Button ml={3} onClick={() => setValue(null)}>
        Clear Value
      </Button>
    </>
  )
}
```
and make sure that when you click on `Clear Value` the DateInput displays its placeholder. 

### Other steps for testing: 

- [x] `cd modules/cactus-web && yarn test:focus "./modules/cactus-web/src/DateInput/"`  Make sure all the test are in green ✅ .
- [x] Run the Storybook app and play with the different `DateInput` stories. Not only with the `Controlled with the string` one. Especially clearing the values and setting new dates.   
- [x] Test the Stories on IE11 and Firefox too.  