### PR TITLE
Fix a Docker error in the integration tests

### DIFF
--- a/actions/integration-tests/Dockerfile
+++ b/actions/integration-tests/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM node
+FROM node:14
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
The Docker image in the CI pipeline seems to be pulling a weird version of node that's causing issues.  This ensures that we use some flavor of node v14.