### PR TITLE
CACTUS-677 Tooltip Color

### DIFF
--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -12,7 +12,7 @@ import { styledUnpoly, styledWithClass } from '../helpers/styled'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import StatusMessage, { Status } from '../StatusMessage/StatusMessage'
-import { Tooltip } from '../Tooltip/Tooltip'
+import { Tooltip, TooltipProps } from '../Tooltip/Tooltip'
 
 export type TooltipAlignment = 'left' | 'right'
 interface AccessibleProps {
@@ -35,6 +35,7 @@ interface CommonProps {
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor' | 'id'>
   tooltip?: React.ReactNode
+  tooltipProps?: Omit<TooltipProps, 'label' | 'id'>
   error?: React.ReactNode
   warning?: React.ReactNode
   success?: React.ReactNode
@@ -124,6 +125,7 @@ function AccessibleFieldBase(props: InnerProps) {
     name,
     success,
     tooltip,
+    tooltipProps,
     warning,
     onBlur,
     onFocus,
@@ -185,6 +187,7 @@ function AccessibleFieldBase(props: InnerProps) {
         <FieldLabel {...$labelProps}>{label}</FieldLabel>
         {tooltip && (
           <Tooltip
+            {...tooltipProps}
             label={tooltip}
             id={tooltipId}
             maxWidth={maxWidth}
@@ -258,6 +261,7 @@ AccessibleField.propTypes = {
   warning: PropTypes.node,
   error: PropTypes.node,
   tooltip: PropTypes.node,
+  tooltipProps: PropTypes.object,
   disabled: PropTypes.bool,
   autoTooltip: PropTypes.bool,
   disableTooltip: PropTypes.bool,

--- a/modules/cactus-web/src/DateInputField/DateInputField.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.tsx
@@ -19,6 +19,7 @@ function DateInputFieldBase(props: DateInputFieldProps): React.ReactElement {
     label,
     labelProps,
     tooltip,
+    tooltipProps,
     success,
     warning,
     error,
@@ -45,6 +46,7 @@ function DateInputFieldBase(props: DateInputFieldProps): React.ReactElement {
       label={label}
       labelProps={labelProps}
       tooltip={tooltip}
+      tooltipProps={tooltipProps}
       error={invalidDate ? invalidDateLabel : error}
       warning={!invalidDate && warning}
       success={!invalidDate && success}
@@ -87,18 +89,15 @@ DateInputField.propTypes = {
   name: PropTypes.string.isRequired,
   className: PropTypes.string,
   id: PropTypes.string,
-  success: PropTypes.string,
-  warning: PropTypes.string,
-  error: PropTypes.string,
-  tooltip: PropTypes.string,
+  success: PropTypes.node,
+  warning: PropTypes.node,
+  error: PropTypes.node,
+  tooltip: PropTypes.node,
+  tooltipProps: PropTypes.object,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   invalidDateLabel: PropTypes.node,
-}
-
-DateInputField.defaultProps = {
-  labelProps: {},
 }
 
 export default DateInputField

--- a/modules/cactus-web/src/FileInputField/FileInputField.story.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.story.tsx
@@ -9,6 +9,7 @@ export default {
   argTypes: {
     value: HIDE_CONTROL,
     labelProps: HIDE_CONTROL,
+    tooltipProps: HIDE_CONTROL,
     isOpen: HIDE_CONTROL,
     multiple: { control: 'boolean' },
     accept: { control: 'array' },

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -17,6 +17,7 @@ const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
     labelProps,
     id,
     tooltip,
+    tooltipProps,
     name,
     success,
     warning,
@@ -36,6 +37,7 @@ const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
       label={label}
       labelProps={labelProps}
       tooltip={tooltip}
+      tooltipProps={tooltipProps}
       success={success}
       warning={warning}
       error={error}
@@ -77,6 +79,7 @@ FileInputFieldBase.propTypes = {
   label: PropTypes.node.isRequired,
   labelProps: PropTypes.object,
   tooltip: PropTypes.node,
+  tooltipProps: PropTypes.object,
 }
 
 export default FileInputField

--- a/modules/cactus-web/src/SelectField/SelectField.story.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.story.tsx
@@ -59,6 +59,7 @@ CustomStyles.argTypes = {
   autoTooltip: HIDE_CONTROL,
   alignTooltip: HIDE_CONTROL,
   labelProps: HIDE_CONTROL,
+  tooltipProps: HIDE_CONTROL,
   id: HIDE_CONTROL,
   name: HIDE_CONTROL,
 }

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -22,6 +22,7 @@ const SelectFieldBase: SelectFieldType = (props): React.ReactElement => {
     label,
     labelProps,
     tooltip,
+    tooltipProps,
     success,
     warning,
     error,
@@ -41,6 +42,7 @@ const SelectFieldBase: SelectFieldType = (props): React.ReactElement => {
       label={label}
       labelProps={labelProps}
       tooltip={tooltip}
+      tooltipProps={tooltipProps}
       success={success}
       warning={warning}
       error={error}
@@ -83,7 +85,6 @@ export const SelectField = styled(SelectFieldBase)`
   }
 `
 
-// @ts-ignore
 SelectField.propTypes = {
   label: PropTypes.node.isRequired,
   labelProps: PropTypes.object,
@@ -92,10 +93,11 @@ SelectField.propTypes = {
   options: Select.propTypes.options,
   className: PropTypes.string,
   id: PropTypes.string,
-  success: PropTypes.string,
-  warning: PropTypes.string,
-  error: PropTypes.string,
-  tooltip: PropTypes.string,
+  success: PropTypes.node,
+  warning: PropTypes.node,
+  error: PropTypes.node,
+  tooltip: PropTypes.node,
+  tooltipProps: PropTypes.object,
 }
 
 export default SelectField

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -16,6 +16,7 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
     warning,
     error,
     tooltip,
+    tooltipProps,
     name,
     id,
     disabled,
@@ -37,6 +38,7 @@ const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
       warning={warning}
       error={error}
       tooltip={tooltip}
+      tooltipProps={tooltipProps}
       autoTooltip={autoTooltip}
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
@@ -70,19 +72,12 @@ TextAreaField.propTypes = {
   label: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,
   labelProps: PropTypes.object,
-  success: PropTypes.string,
-  warning: PropTypes.string,
-  error: PropTypes.string,
-  tooltip: PropTypes.string,
+  success: PropTypes.node,
+  warning: PropTypes.node,
+  error: PropTypes.node,
+  tooltip: PropTypes.node,
+  tooltipProps: PropTypes.object,
   value: PropTypes.string,
-}
-
-TextAreaField.defaultProps = {
-  success: undefined,
-  warning: undefined,
-  error: undefined,
-  tooltip: undefined,
-  labelProps: {},
 }
 
 export default TextAreaField

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -18,6 +18,7 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
     warning,
     error,
     tooltip,
+    tooltipProps,
     disabled,
     autoTooltip,
     disableTooltip,
@@ -37,6 +38,7 @@ const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
       warning={warning}
       error={error}
       tooltip={tooltip}
+      tooltipProps={tooltipProps}
       autoTooltip={autoTooltip}
       disableTooltip={disableTooltip}
       alignTooltip={alignTooltip}
@@ -70,18 +72,11 @@ TextInputField.propTypes = {
   label: PropTypes.node.isRequired,
   name: PropTypes.string.isRequired,
   labelProps: PropTypes.object,
-  success: PropTypes.string,
-  warning: PropTypes.string,
-  error: PropTypes.string,
-  tooltip: PropTypes.string,
-}
-
-TextInputField.defaultProps = {
-  error: undefined,
-  labelProps: {},
-  success: undefined,
-  tooltip: undefined,
-  warning: undefined,
+  success: PropTypes.node,
+  warning: PropTypes.node,
+  error: PropTypes.node,
+  tooltip: PropTypes.node,
+  tooltipProps: PropTypes.object,
 }
 
 export default TextInputField

--- a/modules/cactus-web/src/Tooltip/Tooltip.story.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.story.tsx
@@ -1,12 +1,16 @@
+import cactusTheme from '@repay/cactus-theme'
 import React from 'react'
 
 import { Flex, Tooltip } from '../'
 import { HIDE_CONTROL, Story, STRING } from '../helpers/storybook'
 
+const themeColors = Object.keys(cactusTheme.colors)
+
 export default {
   title: 'Tooltip',
   component: Tooltip,
   argTypes: {
+    color: { options: themeColors },
     label: STRING,
     ariaLabel: HIDE_CONTROL,
     position: HIDE_CONTROL,
@@ -16,7 +20,7 @@ export default {
 } as const
 
 export const BasicUsage: Story<typeof Tooltip> = (args) => (
-  <Flex flexDirection="column">
+  <Flex flexDirection="column" alignItems="flex-start">
     <Tooltip {...args} />
     <Tooltip disabled label="disabled" />
   </Flex>


### PR DESCRIPTION
UAT: https://repayonline.atlassian.net/browse/CACTUS-677

I basically just added `tooltipProps` wherever I saw `labelProps`. Note that I also fixed some of the prop types, which were incorrect for `error`, `warning`, `success`, and `tooltip`, and removed some pointless defaults.