### PR TITLE
CACTUS-782 Input refs

### DIFF
--- a/modules/cactus-web/src/CheckBox/CheckBox.story.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.story.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 
 import { CheckBox } from '../'
-import { actions, HIDE_CONTROL, Story } from '../helpers/storybook'
+import { actions, Story, STRING } from '../helpers/storybook'
 
 export default {
   title: 'CheckBox',
   component: CheckBox,
   argTypes: {
-    id: HIDE_CONTROL,
+    id: STRING,
     ...actions('onChange', 'onFocus', 'onBlur'),
   },
-  args: { id: 'test', disabled: false },
+  args: { disabled: false },
 } as const
 
 export const BasicUsage: Story<typeof CheckBox> = (args) => <CheckBox name="kaneki" {...args} />

--- a/modules/cactus-web/src/CheckBox/CheckBox.test.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.test.tsx
@@ -67,6 +67,17 @@ describe('component: CheckBox', (): void => {
     expect(onFocus).not.toHaveBeenCalled()
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByTestId } = render(
+      <StyleProvider>
+        <CheckBox data-testid="inreffable" defaultChecked ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByTestId('inreffable')).toBe(ref.current)
+    expect(ref.current).toBeChecked()
+  })
+
   describe('with theme customization', (): void => {
     test('should have 2px border', (): void => {
       const theme = generateTheme({ primaryHue: 200, border: 'thick' })

--- a/modules/cactus-web/src/CheckBox/CheckBox.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.tsx
@@ -1,42 +1,23 @@
 import { StatusCheck } from '@repay/cactus-icons'
-import { BorderSize } from '@repay/cactus-theme'
+import { border, borderSize, color, shadow } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { boxShadow } from '../helpers/theme'
 
 export interface CheckBoxProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
-  id: string
+  id?: string
 }
-
-interface StyledCheckBoxProps {
-  disabled?: boolean
-}
-
-const borderMap: { [K in BorderSize]: ReturnType<typeof css> } = {
-  thin: css`
-    border: 1px solid;
-    svg {
-      margin: 1px;
-    }
-  `,
-  thick: css`
-    border: 2px solid;
-  `,
-}
-
-const getBorder = (borderSize: BorderSize): ReturnType<typeof css> => borderMap[borderSize]
 
 const CheckBoxBase = React.forwardRef<HTMLInputElement, CheckBoxProps>((props, ref) => {
   const componentProps = omitMargins<CheckBoxProps>(props)
-  const { disabled, id, className, ...checkBoxProps } = componentProps
+  const { id, className, ...checkBoxProps } = componentProps
   return (
     <label className={className} htmlFor={id}>
-      <HiddenCheckBox id={id} ref={ref} disabled={disabled} {...checkBoxProps} />
-      <StyledCheckBox aria-hidden={true} disabled={disabled}>
+      <HiddenCheckBox id={id} ref={ref} {...checkBoxProps} />
+      <StyledCheckBox aria-hidden={true}>
         <StatusCheck />
       </StyledCheckBox>
     </label>
@@ -51,22 +32,20 @@ const HiddenCheckBox = styled.input.attrs({ type: 'checkbox' as string })`
   position: absolute;
 `
 
-const StyledCheckBox = styled.span<StyledCheckBoxProps>`
+const StyledCheckBox = styled.span`
   display: inline-block;
   box-sizing: border-box;
   width: 16px;
   height: 16px;
-  ${(p): ReturnType<typeof css> => getBorder(p.theme.border)}
-  border-color: ${(p): string =>
-    p.disabled ? p.theme.colors.lightGray : p.theme.colors.darkestContrast};
-  background: ${(p): string => (p.disabled ? p.theme.colors.lightGray : 'none')};
-  border-radius: 1px;
+  border: ${border('darkestContrast')};
+  background-color: transparent;
   svg {
     visibility: hidden;
     display: block;
-    color: ${(p): string => p.theme.colors.white};
+    color: ${color('white')};
     width: 12px;
     height: 12px;
+    margin: ${borderSize({ thin: '1px', thick: '0' }) as any};
   }
 `
 
@@ -78,28 +57,29 @@ export const CheckBox = styled(CheckBoxBase)`
   height: 16px;
   line-height: 16px;
   cursor: ${(p): string => (p.disabled ? 'cursor' : 'pointer')};
-  input:checked ~ span {
-    border-color: ${(p): string | undefined =>
-      !p.disabled ? p.theme.colors.callToAction : undefined};
-    background-color: ${(p): string | undefined =>
-      !p.disabled ? p.theme.colors.callToAction : undefined};
-  }
 
   input:checked ~ span {
+    border-color: ${color('callToAction')};
+    background-color: ${color('callToAction')};
     svg {
       visibility: visible;
     }
   }
 
   input:focus ~ span {
-    ${(p): string => boxShadow(p.theme, 1)};
+    ${shadow(1)};
+  }
+
+  input:disabled ~ span {
+    border-color: ${color('lightGray')};
+    background-color: ${color('lightGray')};
   }
 
   ${margin}
 `
 
 CheckBox.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   disabled: PropTypes.bool,
 }
 

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
@@ -66,6 +66,17 @@ describe('component: CheckBoxField', (): void => {
     expect(checkField).toHaveStyle('flex-basis: 0')
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByLabelText } = render(
+      <StyleProvider>
+        <CheckBoxField label="Oui" defaultChecked ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByLabelText('Oui')).toBe(ref.current)
+    expect(ref.current).toBeChecked()
+  })
+
   test('should trigger onChange event', (): void => {
     const box: any = {}
     const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['name', 'checked'])))

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
@@ -9,11 +9,11 @@ import { FlexItemProps } from '../helpers/styled'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 
-export interface CheckBoxFieldProps extends Omit<CheckBoxProps, 'id' | 'disabled'>, FlexItemProps {
+export interface CheckBoxFieldProps extends CheckBoxProps, FlexItemProps {
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
-  name: string
+  name?: string
   disabled?: boolean
 }
 
@@ -44,7 +44,7 @@ CheckBoxField.propTypes = {
   label: PropTypes.node.isRequired,
   labelProps: PropTypes.object,
   id: PropTypes.string,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   disabled: PropTypes.bool,
 }
 

--- a/modules/cactus-web/src/RadioButton/RadioButton.story.tsx
+++ b/modules/cactus-web/src/RadioButton/RadioButton.story.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
 
 import { RadioButton } from '../'
-import { actions, Story } from '../helpers/storybook'
+import { actions, Story, STRING } from '../helpers/storybook'
 
 export default {
   title: 'RadioButton',
   component: RadioButton,
-  argTypes: actions('onChange', 'onFocus', 'onBlur'),
-  args: { id: 'radio', name: 'radio', disabled: false },
+  argTypes: {
+    id: STRING,
+    ...actions('onChange', 'onFocus', 'onBlur'),
+  },
+  args: { name: 'radio', disabled: false },
 } as const
 
 export const BasicUsage: Story<typeof RadioButton> = (args) => <RadioButton {...args} />
@@ -17,7 +20,7 @@ export const MultipleRadioButtons: MultiStory = ({ id, values, ...args }) => (
   <div>
     {values.map((value, i) => (
       <div key={i}>
-        <RadioButton {...args} value={value} id={id + i} />
+        <RadioButton {...args} value={value} id={id && id + i} />
       </div>
     ))}
   </div>

--- a/modules/cactus-web/src/RadioButton/RadioButton.test.tsx
+++ b/modules/cactus-web/src/RadioButton/RadioButton.test.tsx
@@ -17,6 +17,17 @@ describe('component: RadioButton', (): void => {
     expect(styles.margin).toBe('16px')
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByTestId } = render(
+      <StyleProvider>
+        <RadioButton data-testid="inreffable" name="ref" defaultChecked ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByTestId('inreffable')).toBe(ref.current)
+    expect(ref.current).toBeChecked()
+  })
+
   test('should trigger onChange event', (): void => {
     const onChange = jest.fn()
     const { getByLabelText } = render(

--- a/modules/cactus-web/src/RadioButton/RadioButton.tsx
+++ b/modules/cactus-web/src/RadioButton/RadioButton.tsx
@@ -1,13 +1,13 @@
+import { color, shadow } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { boxShadow } from '../helpers/theme'
 
 export interface RadioButtonProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
-  id: string
+  id?: string
   name: string
   disabled?: boolean
 }
@@ -18,11 +18,11 @@ interface StyledRadioButtonProps extends React.HTMLProps<HTMLSpanElement> {
 
 const RadioButtonBase = React.forwardRef<HTMLInputElement, RadioButtonProps>((props, ref) => {
   const componentProps = omitMargins(props) as Omit<RadioButtonProps, keyof MarginProps>
-  const { disabled, id, className, ...radioButtonProps } = componentProps
+  const { id, className, ...radioButtonProps } = componentProps
   return (
     <label className={className} htmlFor={id}>
-      <HiddenRadioButton ref={ref} id={id} disabled={disabled} {...radioButtonProps} />
-      <StyledRadioButton aria-hidden={true} disabled={disabled} />
+      <HiddenRadioButton ref={ref} id={id} {...radioButtonProps} />
+      <StyledRadioButton aria-hidden={true} />
     </label>
   )
 })
@@ -41,8 +41,8 @@ const StyledRadioButton = styled.span<StyledRadioButtonProps>`
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background-color: ${(p): string => (p.disabled ? p.theme.colors.lightGray : 'transparent')};
-  border: 2px solid ${(p): string => (p.disabled ? p.theme.colors.lightGray : p.theme.colors.base)};
+  background-color: transparent;
+  border: 2px solid ${color('base')};
 
   ::after {
     position: absolute;
@@ -51,8 +51,7 @@ const StyledRadioButton = styled.span<StyledRadioButtonProps>`
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background-color: ${(p): string =>
-      p.disabled ? p.theme.colors.lightGray : p.theme.colors.callToAction};
+    background-color: ${color('callToAction')};
     margin: 2px 2px;
     box-sizing: border-box;
   }
@@ -68,24 +67,29 @@ export const RadioButton = styled(RadioButtonBase)`
   cursor: ${(p): string => (p.disabled ? 'cursor' : 'pointer')};
 
   input:checked ~ span {
-    border-color: ${(p): string | undefined =>
-      !p.disabled ? p.theme.colors.callToAction : undefined};
-    background-color: transparent;
-  }
-
-  input:checked ~ span::after {
-    display: block;
+    border-color: ${color('callToAction')};
+    &::after {
+      display: block;
+    }
   }
 
   input:focus ~ span {
-    ${(p): string => boxShadow(p.theme, 1)}
+    ${shadow(1)}
+  }
+
+  input:disabled ~ span {
+    background-color: ${color('lightGray')};
+    border-color: ${color('lightGray')};
+    &::after {
+      background-color: ${color('lightGray')};
+    }
   }
 
   ${margin}
 `
 
 RadioButton.propTypes = {
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   name: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
 }

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.test.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.test.tsx
@@ -102,4 +102,15 @@ describe('component: RadioButtonField', (): void => {
     expect(radioField).toHaveStyle('flex-shrink: 0')
     expect(radioField).toHaveStyle('flex-basis: 0')
   })
+
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByLabelText } = render(
+      <StyleProvider>
+        <RadioButtonField name="yes" label="Oui" defaultChecked ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByLabelText('Oui')).toBe(ref.current)
+    expect(ref.current).toBeChecked()
+  })
 })

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
@@ -9,7 +9,7 @@ import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import RadioButton, { RadioButtonProps } from '../RadioButton/RadioButton'
 
-export interface RadioButtonFieldProps extends Omit<RadioButtonProps, 'id'>, FlexItemProps {
+export interface RadioButtonFieldProps extends RadioButtonProps, FlexItemProps {
   label: React.ReactNode
   name: string
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>

--- a/modules/cactus-web/src/TextArea/TextArea.story.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.story.tsx
@@ -1,12 +1,17 @@
 import React from 'react'
 
 import { Flex, TextArea } from '../'
-import { actions, HIDE_CONTROL, Story } from '../helpers/storybook'
+import { actions, HIDE_CONTROL, SPACE, Story, STRING } from '../helpers/storybook'
 
 export default {
   title: 'TextArea',
   component: TextArea,
-  argTypes: actions('onChange', 'onFocus', 'onBlur'),
+  argTypes: {
+    margin: SPACE,
+    height: STRING,
+    width: STRING,
+    ...actions('onChange', 'onFocus', 'onBlur'),
+  },
 } as const
 
 export const BasicUsage: Story<typeof TextArea> = (args) => <TextArea {...args} />

--- a/modules/cactus-web/src/TextArea/TextArea.test.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.test.tsx
@@ -18,6 +18,17 @@ describe('component: TextArea', (): void => {
     expect(styles.marginLeft).toBe('24px')
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLTextAreaElement>()
+    const { getByTestId } = render(
+      <StyleProvider>
+        <TextArea data-testid="textArea" defaultValue="something" ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByTestId('textArea')).toBe(ref.current)
+    expect(ref.current).toHaveValue('something')
+  })
+
   test('should trigger onChange handler', (): void => {
     const onChange = jest.fn()
     const { getByPlaceholderText } = render(
@@ -57,7 +68,7 @@ describe('component: TextArea', (): void => {
       expect(styles.borderRadius).toBe('8px')
     })
 
-    test('should have 1px border radius', (): void => {
+    test('should have 0px border radius', (): void => {
       const theme = generateTheme({ primaryHue: 200, shape: 'square' })
       const { getByTestId } = render(
         <StyleProvider theme={theme}>
@@ -66,7 +77,7 @@ describe('component: TextArea', (): void => {
       )
       const textArea = getByTestId('textArea')
       const styles = window.getComputedStyle(textArea)
-      expect(styles.borderRadius).toBe('1px')
+      expect(styles.borderRadius).toBe('0px')
     })
   })
 })

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -1,27 +1,26 @@
-import { CactusTheme } from '@repay/cactus-theme'
+import { border, color, colorStyle, mediaGTE, radius, textStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { FlattenInterpolation, ThemeProps } from 'styled-components'
-import { margin, MarginProps } from 'styled-system'
+import styled from 'styled-components'
+import { compose, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
 import { textFieldStatusMap } from '../helpers/status'
-import { border, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
-export interface TextAreaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    MarginProps {
+type AreaElementProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'height' | 'width'>
+export interface TextAreaProps extends AreaElementProps, MarginProps, HeightProps, WidthProps {
   disabled?: boolean
   status?: Status | null
-  width?: string
-  height?: string
   resize?: boolean
 }
 
-const displayStatus = (
-  props: TextAreaProps
-): FlattenInterpolation<ThemeProps<CactusTheme>> | string => {
+interface AreaProps extends TextAreaProps {
+  $height: string
+  $width: string
+}
+
+const displayStatus = (props: AreaProps) => {
   if (props.status && !props.disabled) {
     return textFieldStatusMap[props.status]
   } else {
@@ -29,58 +28,64 @@ const displayStatus = (
   }
 }
 
-const Area = styled.textarea<TextAreaProps>`
-  border: ${(p) => border(p.theme, p.disabled ? 'lightGray' : 'darkContrast')};
+const Area = styled.textarea<AreaProps>`
+  border: ${border('darkContrast')};
   border-radius: ${radius(8)};
   min-height: 100px;
-  ${(p): string => p.theme.mediaQueries.small} {
+  ${mediaGTE('small')} {
     min-width: 336px;
   }
   box-sizing: border-box;
-  ${(p) => textStyle(p.theme, 'body')}
+  ${textStyle('body')}
   padding: 8px 16px;
   outline: none;
-  background-color: ${(p): string => p.theme.colors.white};
-  height: ${(p): string => p.height || 'auto'};
-  width: ${(p): string => p.width || 'auto'};
+  ${colorStyle('standard')};
+  height: ${(p) => p.$height};
+  width: ${(p) => p.$width};
   display: block;
-  resize: ${(p): string => (p.resize ? 'vertical' : 'none')};
+  resize: ${(p) => (p.resize ? 'vertical' : 'none')};
 
   &:first-line {
     padding-right: 15px;
   }
 
   &:focus {
-    border-color: ${(p): string => p.theme.colors.callToAction};
+    border-color: ${color('callToAction')};
   }
 
   &:disabled {
     cursor: not-allowed;
-    ${(p) => p.theme.colorStyles.disable};
+    border-color: ${color('lightGray')};
+    ${colorStyle('disable')};
   }
 
   &:disabled::placeholder {
-    color: ${(p): string => p.theme.colors.mediumGray};
+    color: ${color('mediumGray')};
     font-style: oblique;
   }
   ${displayStatus}
 `
 
-const TextAreaBase = (props: TextAreaProps): React.ReactElement => {
-  const { className, ...rest } = omitMargins(props)
+const TextAreaBase = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  (props: TextAreaProps, ref) => {
+    const { className, height, width, ...rest } = omitMargins(props)
 
-  return (
-    <div className={className}>
-      <Area {...rest} />
-    </div>
-  )
-}
+    return (
+      <div className={className}>
+        <Area {...rest} ref={ref} $height={control(height)} $width={control(width)} />
+      </div>
+    )
+  }
+)
+const control = (val: unknown) => (val ? '100%' : 'auto')
 
 export const TextArea = styled(TextAreaBase)`
   position: relative;
   display: block;
 
-  ${margin}
+  &&& {
+    ${compose(margin, height, width)}
+  }
 `
 
 TextArea.propTypes = {

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.test.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.test.tsx
@@ -136,6 +136,17 @@ describe('component: TextAreaField', (): void => {
     expect(container.firstElementChild).toHaveStyle('flex-basis: 0')
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLTextAreaElement>()
+    const { getByLabelText } = render(
+      <StyleProvider>
+        <TextAreaField name="with-ref" label="Arreff Them!" defaultValue="something" ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByLabelText('Arreff Them!')).toBe(ref.current)
+    expect(ref.current).toHaveValue('something')
+  })
+
   test('should trigger onChange handler', (): void => {
     const onChange = jest.fn()
     const { getByPlaceholderText } = render(

--- a/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
+++ b/modules/cactus-web/src/TextAreaField/TextAreaField.tsx
@@ -8,61 +8,64 @@ import TextArea, { TextAreaProps } from '../TextArea/TextArea'
 
 interface TextAreaFieldProps extends FieldProps, Omit<TextAreaProps, 'name' | 'status'> {}
 
-const TextAreaFieldBase = (props: TextAreaFieldProps): React.ReactElement => {
-  const {
-    label,
-    labelProps,
-    success,
-    warning,
-    error,
-    tooltip,
-    tooltipProps,
-    name,
-    id,
-    disabled,
-    autoTooltip,
-    disableTooltip,
-    alignTooltip,
-    ...textAreaProps
-  } = props
-  const styleProps = extractFieldStyleProps(textAreaProps)
+const TextAreaFieldBase = React.forwardRef<HTMLTextAreaElement, TextAreaFieldProps>(
+  (props: TextAreaFieldProps, ref) => {
+    const {
+      label,
+      labelProps,
+      success,
+      warning,
+      error,
+      tooltip,
+      tooltipProps,
+      name,
+      id,
+      disabled,
+      autoTooltip,
+      disableTooltip,
+      alignTooltip,
+      ...textAreaProps
+    } = props
+    const styleProps = extractFieldStyleProps(textAreaProps)
 
-  return (
-    <AccessibleField
-      disabled={disabled}
-      id={id}
-      name={name}
-      label={label}
-      labelProps={labelProps}
-      success={success}
-      warning={warning}
-      error={error}
-      tooltip={tooltip}
-      tooltipProps={tooltipProps}
-      autoTooltip={autoTooltip}
-      disableTooltip={disableTooltip}
-      alignTooltip={alignTooltip}
-      {...styleProps}
-    >
-      {({
-        fieldId,
-        status,
-        ariaDescribedBy,
-        disabled: accessibilityDisabled,
-      }): React.ReactElement => (
-        <TextArea
-          disabled={accessibilityDisabled}
-          id={fieldId}
-          width="100%"
-          status={status}
-          aria-describedby={ariaDescribedBy}
-          name={name}
-          {...textAreaProps}
-        />
-      )}
-    </AccessibleField>
-  )
-}
+    return (
+      <AccessibleField
+        disabled={disabled}
+        id={id}
+        name={name}
+        label={label}
+        labelProps={labelProps}
+        success={success}
+        warning={warning}
+        error={error}
+        tooltip={tooltip}
+        tooltipProps={tooltipProps}
+        autoTooltip={autoTooltip}
+        disableTooltip={disableTooltip}
+        alignTooltip={alignTooltip}
+        {...styleProps}
+      >
+        {({
+          fieldId,
+          status,
+          ariaDescribedBy,
+          disabled: accessibilityDisabled,
+        }): React.ReactElement => (
+          <TextArea
+            disabled={accessibilityDisabled}
+            id={fieldId}
+            width="100%"
+            status={status}
+            aria-describedby={ariaDescribedBy}
+            name={name}
+            {...textAreaProps}
+            ref={ref}
+          />
+        )}
+      </AccessibleField>
+    )
+  }
+)
 
 export const TextAreaField = styled(TextAreaFieldBase)`
   position: relative;

--- a/modules/cactus-web/src/TextInput/TextInput.story.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.story.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 
 import { Flex, TextInput } from '../'
-import { actions, HIDE_CONTROL, Story } from '../helpers/storybook'
+import { actions, HIDE_CONTROL, Story, STRING } from '../helpers/storybook'
 
 export default {
   title: 'TextInput',
   component: TextInput,
   argTypes: {
+    width: STRING,
     status: { options: ['success', 'warning', 'error'] },
     ...actions('onChange', 'onFocus', 'onBlur'),
   },

--- a/modules/cactus-web/src/TextInput/TextInput.test.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.test.tsx
@@ -30,6 +30,17 @@ describe('component: TextInput', (): void => {
     expect(styles.marginTop).toBe('16px')
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByTestId } = render(
+      <StyleProvider>
+        <TextInput data-testid="with-ref" defaultValue="sentinel" ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByTestId('with-ref')).toBe(ref.current)
+    expect(ref.current).toHaveValue('sentinel')
+  })
+
   test('should trigger onChange handler', (): void => {
     const onChange = jest.fn()
     const { getByPlaceholderText } = render(
@@ -71,7 +82,7 @@ describe('component: TextInput', (): void => {
       expect(styles.borderRadius).toBe('8px')
     })
 
-    test('should have 1px border radius', (): void => {
+    test('should have 0px border radius', (): void => {
       const theme = generateTheme({ primaryHue: 200, shape: 'square' })
       const { getByPlaceholderText } = render(
         <StyleProvider theme={theme}>
@@ -82,7 +93,7 @@ describe('component: TextInput', (): void => {
       const textInput = getByPlaceholderText('Do I wanna know?')
       const styles = window.getComputedStyle(textInput)
 
-      expect(styles.borderRadius).toBe('1px')
+      expect(styles.borderRadius).toBe('0px')
     })
   })
 })

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -1,18 +1,25 @@
-import defaultTheme, { ColorStyle, TextStyleCollection } from '@repay/cactus-theme'
+import defaultTheme, {
+  border,
+  color,
+  colorStyle,
+  radius,
+  textStyle,
+  TextStyleCollection,
+} from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
-import { margin, MarginProps } from 'styled-system'
+import { compose, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
 import { textFieldStatusMap } from '../helpers/status'
-import { border, radius, textStyle } from '../helpers/theme'
 import { Status, StatusPropType } from '../StatusMessage/StatusMessage'
 
 type TextStyleKey = keyof TextStyleCollection
 export const textStyles = Object.keys(defaultTheme.textStyles) as TextStyleKey[]
 
-export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
+type InputElementProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'width'>
+export interface TextInputProps extends InputElementProps, MarginProps, WidthProps {
   /** !important */
   disabled?: boolean
   status?: Status | null
@@ -20,6 +27,7 @@ export interface TextInputProps extends React.InputHTMLAttributes<HTMLInputEleme
 }
 
 interface InputProps {
+  $width: string
   disabled?: boolean
   status?: Status | null
   textStyle?: TextStyleKey
@@ -35,11 +43,11 @@ const displayStatus = (props: TextInputProps) => {
 
 const TextInputBase = React.forwardRef<HTMLInputElement, TextInputProps>(
   (props: TextInputProps, forwardRef): React.ReactElement => {
-    const { className, ...rest } = omitMargins(props)
+    const { className, width: widthProp, ...rest } = omitMargins(props)
 
     return (
       <div className={className}>
-        <Input ref={forwardRef} {...rest} />
+        <Input ref={forwardRef} {...rest} $width={widthProp ? '100%' : 'auto'} />
       </div>
     )
   }
@@ -47,29 +55,30 @@ const TextInputBase = React.forwardRef<HTMLInputElement, TextInputProps>(
 
 const Input = styled.input<InputProps>`
   box-sizing: border-box;
-  border: ${(p) => border(p.theme, p.disabled ? 'lightGray' : 'darkContrast')};
+  border: ${border('darkContrast')};
   border-radius: ${radius(20)};
   outline: none;
   padding: 3px 28px 3px 15px;
-  ${(p) => textStyle(p.theme, p.textStyle || 'body')};
-  width: ${(p): string | number => p.width || 'auto'};
-  background-color: ${(p): string => p.theme.colors.white};
+  ${(p) => textStyle(p, p.textStyle || 'body')};
+  ${colorStyle('standard')}
+  width: ${(p) => p.$width};
 
   &:disabled {
     cursor: not-allowed;
-    border-color: ${(p): string => p.theme.colors.lightGray};
-    ${(p): ColorStyle => p.theme.colorStyles.disable};
+    border-color: ${color('lightGray')};
+    ${colorStyle('disable')}
   }
 
   &:disabled::placeholder {
-    color: ${(p): string => p.theme.colors.mediumGray};
+    color: ${color('mediumGray')};
   }
+
   &:focus {
-    border-color: ${(p): string => p.theme.colors.callToAction};
+    border-color: ${color('callToAction')};
   }
 
   &::placeholder {
-    color: ${(p): string => p.theme.colors.mediumContrast};
+    color: ${color('mediumContrast')};
     font-style: oblique;
   }
 
@@ -78,7 +87,9 @@ const Input = styled.input<InputProps>`
 
 export const TextInput = styled(TextInputBase)`
   box-sizing: border-box;
-  ${margin}
+  &&& {
+    ${compose(margin, width)}
+  }
 `
 
 TextInput.propTypes = {

--- a/modules/cactus-web/src/TextInputField/TextInputField.test.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.test.tsx
@@ -131,6 +131,17 @@ describe('component: TextInputField', (): void => {
     expect(container.firstElementChild).toHaveStyle('flex-basis: 0')
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByLabelText } = render(
+      <StyleProvider>
+        <TextInputField defaultValue="with-ref" name="reflected" label="Referred" ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByLabelText('Referred')).toBe(ref.current)
+    expect(ref.current).toHaveValue('with-ref')
+  })
+
   test('should trigger onChange handler', (): void => {
     const onChange = jest.fn()
     const { getByPlaceholderText } = render(

--- a/modules/cactus-web/src/TextInputField/TextInputField.tsx
+++ b/modules/cactus-web/src/TextInputField/TextInputField.tsx
@@ -8,61 +8,64 @@ import { TextInput, TextInputProps } from '../TextInput/TextInput'
 
 interface TextInputFieldProps extends FieldProps, Omit<TextInputProps, 'name' | 'status'> {}
 
-const TextInputFieldBase = (props: TextInputFieldProps): React.ReactElement => {
-  const {
-    id,
-    name,
-    label,
-    labelProps,
-    success,
-    warning,
-    error,
-    tooltip,
-    tooltipProps,
-    disabled,
-    autoTooltip,
-    disableTooltip,
-    alignTooltip,
-    ...inputProps
-  } = props
-  const styleProps = extractFieldStyleProps(inputProps)
+const TextInputFieldBase = React.forwardRef<HTMLInputElement, TextInputFieldProps>(
+  (props: TextInputFieldProps, ref) => {
+    const {
+      id,
+      name,
+      label,
+      labelProps,
+      success,
+      warning,
+      error,
+      tooltip,
+      tooltipProps,
+      disabled,
+      autoTooltip,
+      disableTooltip,
+      alignTooltip,
+      ...inputProps
+    } = props
+    const styleProps = extractFieldStyleProps(inputProps)
 
-  return (
-    <AccessibleField
-      disabled={disabled}
-      id={id}
-      name={name}
-      label={label}
-      labelProps={labelProps}
-      success={success}
-      warning={warning}
-      error={error}
-      tooltip={tooltip}
-      tooltipProps={tooltipProps}
-      autoTooltip={autoTooltip}
-      disableTooltip={disableTooltip}
-      alignTooltip={alignTooltip}
-      {...styleProps}
-    >
-      {({
-        fieldId,
-        status,
-        ariaDescribedBy,
-        disabled: accessibilityDisabled,
-      }): React.ReactElement => (
-        <TextInput
-          {...inputProps}
-          disabled={accessibilityDisabled}
-          id={fieldId}
-          width="100%"
-          status={status}
-          name={name}
-          aria-describedby={ariaDescribedBy}
-        />
-      )}
-    </AccessibleField>
-  )
-}
+    return (
+      <AccessibleField
+        disabled={disabled}
+        id={id}
+        name={name}
+        label={label}
+        labelProps={labelProps}
+        success={success}
+        warning={warning}
+        error={error}
+        tooltip={tooltip}
+        tooltipProps={tooltipProps}
+        autoTooltip={autoTooltip}
+        disableTooltip={disableTooltip}
+        alignTooltip={alignTooltip}
+        {...styleProps}
+      >
+        {({
+          fieldId,
+          status,
+          ariaDescribedBy,
+          disabled: accessibilityDisabled,
+        }): React.ReactElement => (
+          <TextInput
+            ref={ref}
+            {...inputProps}
+            disabled={accessibilityDisabled}
+            id={fieldId}
+            width="100%"
+            status={status}
+            name={name}
+            aria-describedby={ariaDescribedBy}
+          />
+        )}
+      </AccessibleField>
+    )
+  }
+)
 
 export const TextInputField = styled(TextInputFieldBase)`
   position: relative;

--- a/modules/cactus-web/src/Toggle/Toggle.test.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.test.tsx
@@ -23,6 +23,17 @@ describe('component: Toggle', (): void => {
     expect(style.marginBottom).toBe('16px')
   })
 
+  test('should support ref prop', () => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByTestId } = render(
+      <StyleProvider>
+        <Toggle data-testid="toggle" defaultChecked ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByTestId('toggle')).toBe(ref.current)
+    expect(ref.current).toBeChecked()
+  })
+
   test('should trigger onChange event', (): void => {
     const box: any = {}
     const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['id', 'checked'])))

--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -1,11 +1,11 @@
 import { NavigationClose, StatusCheck } from '@repay/cactus-icons'
+import { boxShadow, color, shadow } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { extractMargins } from '../helpers/omit'
-import { boxShadow } from '../helpers/theme'
 
 export interface ToggleProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
   checked?: boolean
@@ -19,8 +19,8 @@ export const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
       <Wrapper {...marginProps} className={className} role="none">
         <Checkbox {...props} role="switch" aria-checked={props.checked} ref={ref} />
         <Switch aria-hidden />
-        <StyledX aria-hidden />
-        <StyledCheck aria-hidden />
+        <StyledX aria-hidden color="white" />
+        <StyledCheck aria-hidden color="white" />
       </Wrapper>
     )
   }
@@ -51,7 +51,6 @@ const StyledX = styled(NavigationClose)`
   position: absolute;
   top: 7px;
   right: 9px;
-  color: ${(p): string => p.theme.colors.white};
   opacity: 1;
   transition: opacity 0.3s;
   input:checked ~ & {
@@ -65,7 +64,6 @@ const StyledCheck = styled(StatusCheck)`
   position: absolute;
   top: 5px;
   left: 6px;
-  color: ${(p): string => p.theme.colors.white};
   opacity: 0;
   transition: opacity 0.3s;
   input:checked ~ & {
@@ -89,15 +87,15 @@ const Switch = styled.div`
   width: 100%;
   height: 100%;
   border-radius: 13px;
-  background-color: ${(p) => p.theme.colors.error};
+  background-color: ${color('error')};
   cursor: pointer;
   input:disabled ~ & {
-    background-color: ${(p) => p.theme.colors.lightGray};
+    background-color: ${color('lightGray')};
     cursor: cursor;
   }
 
   input:focus ~ & {
-    ${(p): string => boxShadow(p.theme, 1)};
+    ${shadow(1)};
   }
 
   ::after {
@@ -109,8 +107,8 @@ const Switch = styled.div`
     left: 0;
     position: absolute;
     transition: left 0.3s;
-    background-color: ${(p): string => p.theme.colors.white};
-    box-shadow: 0 0 3px ${(p): string => p.theme.colors.darkestContrast};
+    background-color: ${color('white')};
+    ${boxShadow(0, 'darkestContrast')};
   }
 
   input:checked ~ & {
@@ -120,7 +118,7 @@ const Switch = styled.div`
   }
 
   input:checked:not(:disabled) ~ & {
-    background-color: ${(p): string => p.theme.colors.success};
+    background-color: ${color('success')};
   }
 `
 

--- a/modules/cactus-web/src/ToggleField/ToggleField.test.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.test.tsx
@@ -25,6 +25,17 @@ describe('component: ToggleField', (): void => {
     expect(getByLabelText('Show me the money').id).toContain('show-me-the-money')
   })
 
+  test('should support ref prop', (): void => {
+    const ref = React.createRef<HTMLInputElement>()
+    const { getByLabelText } = render(
+      <StyleProvider>
+        <ToggleField label="Show me the money" name="show-me-the-money" defaultChecked ref={ref} />
+      </StyleProvider>
+    )
+    expect(getByLabelText('Show me the money')).toBe(ref.current)
+    expect(ref.current).toBeChecked()
+  })
+
   test('should trigger onChange event with next value', (): void => {
     const box: any = {}
     const onChange = jest.fn((e) => Object.assign(box, pick(e.target, ['name', 'checked'])))


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-782

Individual commit messages have a bit more info, but the short story is that I did four main things:
- Added ref support where it didn't already exist.
- Added tests to prove that the refs are assigned to the correct element and that Typescript has the correct type.
- Refactored the styles with the theme helpers.
  - On TextInput and TextArea, I changed how the width/height props are applied so that the resulting element is actually the correct dimension, not just visually so.
  - On CheckBox and RadioButton I also moved the disabled styles so we wouldn't have to pass that prop to the visible psuedo input.
- Made `id` optional on CheckBox and RadioButton, and `name` optional on Checkbox, since there's no reason for it to be required. (Not related to the ticket at all, of course, I just got annoyed when writing the tests and Typescript told me I had to add an `id`...)