### PR TITLE
CACTUS-726 Input Status Styles

### DIFF
--- a/modules/cactus-web/src/ColorPicker/ColorPicker.story.tsx
+++ b/modules/cactus-web/src/ColorPicker/ColorPicker.story.tsx
@@ -9,6 +9,7 @@ export default {
   component: ColorPicker,
   argTypes: {
     value: HIDE_CONTROL,
+    status: { options: ['success', 'warning', 'error'] },
     ...actions('onChange', 'onFocus', 'onBlur'),
   },
   args: {

--- a/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
+++ b/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
@@ -1,9 +1,10 @@
 import { DescriptivePalette } from '@repay/cactus-icons'
+import { border, boxShadow, color as themeColor, colorStyle, radius } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { ColorChangeHandler, CustomPicker, HSLColor, HSVColor } from 'react-color'
 import { EditableInput, Hue, Saturation } from 'react-color/lib/components/common'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 import tinycolor from 'tinycolor2'
 
@@ -14,7 +15,8 @@ import { CactusChangeEvent, CactusEventTarget, CactusFocusEvent } from '../helpe
 import { usePositioning } from '../helpers/positionPopover'
 import positionPortal from '../helpers/positionPortal'
 import { SemiControlled } from '../helpers/react'
-import { border, popupBoxShadow, popupShape, radius } from '../helpers/theme'
+import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
+import { popupBoxShadow, popupShape } from '../helpers/theme'
 import usePopup, { TogglePopup } from '../helpers/usePopup'
 import IconButton from '../IconButton/IconButton'
 import TextButton from '../TextButton/TextButton'
@@ -27,8 +29,9 @@ if (typeof document !== 'undefined' && document?.body && !document.contains) {
 interface BaseProps
   extends MarginProps,
     Omit<React.HTMLAttributes<HTMLDivElement>, 'color' | 'onChange' | 'onFocus' | 'onBlur'> {
-  name: string
-  id: string
+  name?: string
+  id?: string
+  status?: Status | null
   phrases?: Partial<Phrases>
   disabled?: boolean
 }
@@ -127,20 +130,20 @@ const PickerDialog = styled(({ handleClose, color, setColor, phrases, ...props }
   z-index: 1000;
   width: 320px;
   padding: 16px;
-  background-color: ${(p): string => p.theme.colors.white};
-  ${(p): ReturnType<typeof css> => popupShape('dialog', p.theme.shape)}
-  ${(p): ReturnType<typeof css> => popupBoxShadow(p.theme)}
+  background-color: ${themeColor('white')};
+  ${(p) => popupShape('dialog', p.theme.shape)}
+  ${(p) => popupBoxShadow(p.theme)}
   overflow: hidden;
   outline: none;
 
   input {
-    border: ${(p) => border(p.theme, 'darkestContrast')};
+    border: ${border('darkestContrast')};
     border-radius: ${radius(20)};
     height: 32px;
     outline: none;
     padding: 0px 15px 0px 15px;
     &:focus {
-      border: ${(p) => border(p.theme, 'callToAction')};
+      border: ${border('callToAction')};
     }
   }
 
@@ -159,13 +162,15 @@ const PickerDialog = styled(({ handleClose, color, setColor, phrases, ...props }
   }
 `
 
-const InputWrapper = styled.div`
+const InputWrapper = styled.div<{ status?: Status | null }>`
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border: ${(p) => border(p.theme, 'darkestContrast')};
+  background-color: ${themeColor('white')};
+  border: ${border('darkestContrast')};
   border-radius: ${radius(20)};
+  ${getStatusStyles}
   height: 36px;
   outline: none;
   padding: 0 16px 0 12px;
@@ -173,7 +178,7 @@ const InputWrapper = styled.div`
   ${margin}
 
   &:focus-within {
-    border-color: ${(p): string => p.theme.colors.callToAction};
+    border-color: ${themeColor('callToAction')};
   }
 
   input.hex-borderless {
@@ -185,14 +190,14 @@ const InputWrapper = styled.div`
     width: 5em;
 
     :disabled {
-      color: ${(p) => p.theme.colorStyles.disable.color};
+      ${colorStyle('disable')}
     }
   }
 
   &[aria-disabled] {
     cursor: not-allowed;
-    border-color: ${(p) => p.theme.colors.lightGray};
-    background-color: ${(p) => p.theme.colorStyles.disable.backgroundColor};
+    ${colorStyle('disable')}
+    border-color: ${themeColor('lightGray')};
   }
 `
 
@@ -215,8 +220,8 @@ const Pointer = styled.div<{ $type: 'hue' | 'saturation'; $hsl: HSLColor }>`
   height: 32px;
   border-radius: 50%;
   background-color: transparent;
-  border: 8px solid ${(p) => p.theme.colors.white};
-  box-shadow: 0 0 3px ${(p) => p.theme.colors.mediumGray};
+  border: 8px solid ${themeColor('white')};
+  ${boxShadow(0, 'mediumGray')};
   ${(p) => {
     // Adjust pointer translation based on where the pointer is at so it
     // doesn't leave the hue/saturation element visually
@@ -242,7 +247,7 @@ const SaturationPointer: React.FC<PointerProps> = ({ hsl = blackHsl }) => {
 }
 
 // These do their own styling, so we have to convert theme radius to a prop.
-const StyledHue = styled(Hue).attrs((p) => ({ radius: radius(20)(p) }))``
+const StyledHue = styled(Hue).attrs((p) => ({ radius: radius(p, 20) }))``
 const StyledSaturation = StyledHue.withComponent(Saturation)
 
 const PickerBase: React.FC<CustomPickerProps> = (props) => {
@@ -398,10 +403,11 @@ export class ColorPicker extends React.Component<ColorPickerProps, ColorState> {
   static displayName = 'ColorPicker'
 
   static propTypes = {
-    name: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
+    name: PropTypes.string,
+    id: PropTypes.string,
     format: PropTypes.oneOf<Format>(['hex', 'hsl', 'hsv', 'rgb']),
     value: colorType,
+    status: StatusPropType,
     phrases: PropTypes.shape({
       colorLabel: PropTypes.string,
       hexLabel: PropTypes.string,

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -37,7 +37,7 @@ import getLocale from '../helpers/locale'
 import { getDataProps } from '../helpers/omit'
 import { usePositioning } from '../helpers/positionPopover'
 import positionPortal from '../helpers/positionPortal'
-import { Status } from '../helpers/status'
+import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
 import IconButton from '../IconButton/IconButton'
 
 interface DateInputPhrasesType extends Partial<CalendarLabels> {
@@ -206,6 +206,7 @@ const InputWrapper = styled.div`
   align-items: center;
   border: ${border('darkestContrast')};
   border-radius: ${radius(20)};
+  ${getStatusStyles}
   height: 35px;
   outline: none;
   overflow: hidden;
@@ -434,6 +435,7 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
   public static propTypes = {
     name: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
+    status: StatusPropType,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]),
     format: function (props: any): Error | null {
       if (props.format) {
@@ -888,6 +890,7 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
         <Flex alignItems="flex-start" justifyContent="center" flexDirection="column">
           <InputWrapper
             className={className}
+            status={this.props.status}
             role="group"
             ref={this._inputWrapper}
             aria-describedby={ariaDescribedBy}

--- a/modules/cactus-web/src/FileInput/FileInput.story.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.story.tsx
@@ -14,6 +14,7 @@ export default {
     accept: { control: 'array' },
     buttonText: STRING,
     prompt: STRING,
+    status: { options: ['success', 'warning', 'error'] },
     ...actions('onChange', 'onBlur', 'onFocus'),
   },
   args: {

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -5,6 +5,7 @@ import {
   NotificationError,
   StatusCheck,
 } from '@repay/cactus-icons'
+import { border, color, colorStyle, radius, textStyle } from '@repay/cactus-theme'
 import PropTypes, { Validator } from 'prop-types'
 import React, { useRef } from 'react'
 import styled, { css } from 'styled-components'
@@ -21,7 +22,7 @@ import {
 } from '../helpers/events'
 import { omitProps, split } from '../helpers/omit'
 import { useRenderTrigger } from '../helpers/react'
-import { border, radius, textStyle } from '../helpers/theme'
+import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
 import useId from '../helpers/useId'
 import { IconButton } from '../IconButton/IconButton'
 import Spinner from '../Spinner/Spinner'
@@ -50,6 +51,7 @@ type InputProps = Pick<
 
 interface CommonProps extends MarginProps, MaxWidthProps, WidthProps, InputProps, WrapperProps {
   name: string
+  status?: Status | null
   accept?: string[]
   labels?: FileInfoLabels
   buttonText?: React.ReactNode
@@ -205,6 +207,7 @@ class FileInput extends React.Component<FileInputProps, FileInputState> {
   static displayName = 'FileInput'
   static propTypes = {
     name: PropTypes.string.isRequired,
+    status: StatusPropType,
     accept: PropTypes.arrayOf(PropTypes.string),
     disabled: PropTypes.bool,
     labels: PropTypes.shape({
@@ -351,23 +354,23 @@ const EmptyPrompts = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${(p) => p.theme.colors.mediumContrast};
+  color: ${color('mediumContrast')};
 `
 
 const fileBoxColors = {
   unloaded: css`
-    border-color: ${(p) => p.theme.colors.mediumContrast};
+    border-color: ${color('mediumContrast')};
   `,
   loading: css`
-    background-color: ${(p) => p.theme.colors.lightContrast};
+    background-color: ${color('lightContrast')};
   `,
   loaded: css`
-    border-color: ${(p) => p.theme.colors.success};
-    background-color: ${(p) => p.theme.colors.successLight};
+    border-color: ${color('success')};
+    background-color: ${color('successLight')};
   `,
   error: css`
-    border-color: ${(p) => p.theme.colors.error};
-    background-color: ${(p) => p.theme.colors.errorLight};
+    border-color: ${color('error')};
+    background-color: ${color('errorLight')};
   `,
 }
 
@@ -380,14 +383,14 @@ const FileBox = styled.div<{ $status: FileStatus }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: ${(p) => p.theme.colors.darkestContrast};
-  border: ${(p) => border(p.theme, 'lightContrast')};
+  color: ${color('darkestContrast')};
+  border: ${border('lightContrast')};
   ${(p) => fileBoxColors[p.$status]};
 
   &[aria-disabled] {
-    color: ${(p) => p.theme.colors.mediumGray};
-    border: ${(p) => border(p.theme, 'mediumGray')};
-    background-color: ${(p) => p.theme.colors.lightGray};
+    color: ${color('mediumGray')};
+    border: ${border('mediumGray')};
+    background-color: ${color('lightGray')};
   }
 
   span {
@@ -634,13 +637,11 @@ const FileInputBase = (props: InnerInputProps): React.ReactElement => {
 }
 
 const InnerFileInput = styled(FileInputBase).withConfig(
-  omitProps<InnerInputProps>(margin, width, maxWidth)
+  omitProps<InnerInputProps>(margin, width, maxWidth, 'status')
 )`
-  ${(p) => textStyle(p.theme, 'body')};
-  ${(p) => p.theme.colorStyles.standard};
   box-sizing: border-box;
   border-radius: ${radius(8)};
-  border: 2px dotted ${(p) => p.theme.colors.darkestContrast};
+  border: 2px dotted ${color('darkestContrast')};
   min-width: 300px;
   max-width: 100%;
   min-height: 100px;
@@ -648,13 +649,13 @@ const InnerFileInput = styled(FileInputBase).withConfig(
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  ${(p) => textStyle(p.theme, 'body')};
+  ${textStyle('body')};
 
   ${(p) =>
     !!p.files.length &&
     `
     flex-direction: column;
-    border-color: ${p.theme.colors.callToAction};
+    border-color: ${color(p, 'callToAction')};
     padding: 0 8px;
 
     ${TextButton} {
@@ -663,12 +664,15 @@ const InnerFileInput = styled(FileInputBase).withConfig(
     }
   `}
 
+  ${getStatusStyles}
+  ${colorStyle('standard')};
+
   &[aria-disabled] {
     border-style: solid;
-    border-color: ${(p) => p.theme.colors.lightGray};
-    background-color: ${(p) => p.theme.colors.lightGray};
+    border-color: ${color('lightGray')};
+    background-color: ${color('lightGray')};
     * {
-      color: ${(p) => p.theme.colors.mediumGray};
+      color: ${color('mediumGray')};
     }
   }
 

--- a/modules/cactus-web/src/FileInputField/FileInputField.tsx
+++ b/modules/cactus-web/src/FileInputField/FileInputField.tsx
@@ -49,6 +49,7 @@ const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
       {({
         fieldId,
         labelId,
+        status,
         name: accessibilityName,
         ariaDescribedBy,
         disabled: accessibilityDisabled,
@@ -56,6 +57,7 @@ const FileInputFieldBase = (props: FileInputFieldProps): React.ReactElement => {
         <FileInput
           {...rest}
           id={fieldId}
+          status={status}
           name={accessibilityName}
           disabled={accessibilityDisabled}
           aria-labelledby={labelId}

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -20,7 +20,7 @@ import { omitMargins } from '../helpers/omit'
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
 import { isPurelyEqual, useMergedRefs } from '../helpers/react'
 import { useScrollTrap } from '../helpers/scroll'
-import { Status, StatusPropType, textFieldStatusMap } from '../helpers/status'
+import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
 import { boxShadow, fontSize, isResponsiveTouchDevice, radius, textStyle } from '../helpers/theme'
 import Tag from '../Tag/Tag'
 import TextButton from '../TextButton/TextButton'
@@ -86,14 +86,6 @@ export interface SelectProps
 }
 
 type SelectPropsWithTheme = SelectProps & { theme: CactusTheme }
-
-const displayStatus: any = (props: SelectPropsWithTheme): ReturnType<typeof css> | string => {
-  if (props.status && !props.disabled) {
-    return textFieldStatusMap[props.status]
-  } else {
-    return ''
-  }
-}
 
 function isElement(el?: any): el is HTMLElement {
   return el && el.nodeType === 1
@@ -1572,7 +1564,7 @@ const Select = styled(SelectWithTheme)`
   ${styledSystemWidth}
   ${SelectTrigger} {
     background-color: ${(p) => p.theme.colors.white};
-    ${displayStatus}
+    ${getStatusStyles}
   }
 `
 

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { compose, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { Status, StatusPropType, textFieldStatusMap } from '../helpers/status'
+import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
 
 type AreaElementProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'height' | 'width'>
 export interface TextAreaProps extends AreaElementProps, MarginProps, HeightProps, WidthProps {
@@ -17,14 +17,6 @@ export interface TextAreaProps extends AreaElementProps, MarginProps, HeightProp
 interface AreaProps extends TextAreaProps {
   $height: string
   $width: string
-}
-
-const displayStatus = (props: AreaProps) => {
-  if (props.status && !props.disabled) {
-    return textFieldStatusMap[props.status]
-  } else {
-    return ''
-  }
 }
 
 const Area = styled.textarea<AreaProps>`
@@ -62,7 +54,7 @@ const Area = styled.textarea<AreaProps>`
     color: ${color('mediumGray')};
     font-style: oblique;
   }
-  ${displayStatus}
+  ${getStatusStyles}
 `
 
 const TextAreaBase = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -12,7 +12,7 @@ import styled from 'styled-components'
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { Status, StatusPropType, textFieldStatusMap } from '../helpers/status'
+import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
 
 type TextStyleKey = keyof TextStyleCollection
 export const textStyles = Object.keys(defaultTheme.textStyles) as TextStyleKey[]
@@ -30,14 +30,6 @@ interface InputProps {
   disabled?: boolean
   status?: Status | null
   textStyle?: TextStyleKey
-}
-
-const displayStatus = (props: TextInputProps) => {
-  if (props.status && !props.disabled) {
-    return textFieldStatusMap[props.status]
-  } else {
-    return ''
-  }
 }
 
 const TextInputBase = React.forwardRef<HTMLInputElement, TextInputProps>(
@@ -81,7 +73,7 @@ const Input = styled.input<InputProps>`
     font-style: oblique;
   }
 
-  ${displayStatus}
+  ${getStatusStyles}
 `
 
 export const TextInput = styled(TextInputBase)`

--- a/modules/cactus-web/src/helpers/status.ts
+++ b/modules/cactus-web/src/helpers/status.ts
@@ -1,22 +1,23 @@
+import { CactusTheme, color } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import { css } from 'styled-components'
+import { CSSObject } from 'styled-components'
 
-export type Status = 'success' | 'warning' | 'error'
-export const StatusPropType = PropTypes.oneOf<Status>(['success', 'warning', 'error'])
+const statuses = ['success', 'warning', 'error'] as const
+export type Status = typeof statuses[number]
+type StatusBackground = 'successLight' | 'warningLight' | 'errorLight'
+export const StatusPropType = PropTypes.oneOf<Status>(statuses)
 
-type StatusMap = { [K in Status]: ReturnType<typeof css> }
+interface StatusProps {
+  theme: CactusTheme
+  status?: Status | null
+  disabled?: boolean
+}
 
-export const textFieldStatusMap: StatusMap = {
-  success: css`
-    border-color: ${(p): string => p.theme.colors.success};
-    background: ${(p): string => p.theme.colors.successLight};
-  `,
-  warning: css`
-    border-color: ${(p): string => p.theme.colors.warning};
-    background: ${(p): string => p.theme.colors.warningLight};
-  `,
-  error: css`
-    border-color: ${(p): string => p.theme.colors.error};
-    background: ${(p): string => p.theme.colors.errorLight};
-  `,
+export const getStatusStyles = (p: StatusProps): CSSObject | undefined => {
+  if (!p.disabled && statuses.includes(p.status as any)) {
+    return {
+      borderColor: color(p, p.status as Status),
+      backgroundColor: color(p, `${p.status}Light` as StatusBackground),
+    }
+  }
 }


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-726

As is becoming a habit, individual commit messages may have a few extra details.

Incidentally, although I'm relatively sure that DateInput and FileInput don't need `id`/`name` to be required any more than ColorPicker, they're significantly more complex and I didn't want to make that change and then be proven wrong (nor did I want to comb through the code to verify a change that has nothing to do with this ticket).