### PR TITLE
CACTUS-806: change how-to-docs from formik to final-form

### DIFF
--- a/docs/Forms/README.md
+++ b/docs/Forms/README.md
@@ -35,7 +35,7 @@ but it has customization features and handles prop forwarding a bit differently:
 - Each of these can be configured project-wide, or overridden on a per-render basis.
 
 More info on those, along with the two new components `FieldSpy` and `DependentField`,
-is in the <a to='./api-documentation/'>API documentation</a>.
+is in the <a to='./api-documentation/'>API documentation</a>. Specific examples on how to use these components with along with Cactus Web is in the <a to='/how-tos/forms/'>how-to guide</a>.
 
 ### Patching React Final Form
 

--- a/docs/How-tos/Forms.md
+++ b/docs/How-tos/Forms.md
@@ -14,7 +14,7 @@ Cactus Form also has an optional setup step using [patch-package](https://www.np
 
 ## Using React Final Form
 
-The basic Final Form library is very flexible, and I highly recommend going through the docs to understand what it's capable of. However, the majority of use cases can be covered by the components in React Final Form and Cactus Form.
+The basic Final Form library is very flexible, and we highly recommend going through the docs to understand what it's capable of. However, the majority of use cases can be covered by the components in React Final Form and Cactus Form.
 
 To make a form you start with the [Form](https://final-form.org/docs/react-final-form/api/Form) component,
 which creates both a form and a React context that allows you to access it from any descendants.

--- a/docs/How-tos/Forms.md
+++ b/docs/How-tos/Forms.md
@@ -1,259 +1,202 @@
-# How to Write Cactus Forms Using Formik
+# How to Write Cactus Forms Using Final Form
 
-Collecting data using forms is one of the most basic functions of a website. <a to='/components/'>@repay/cactus-web</a> provides several styled form inputs, as well as a few custom inputs that emulate built-in HTML inputs. This guide will show you the basics of combining these input components with a common forms library, [Formik](https://formik.org/).
+Collecting data using forms is one of the most basic functions of a website. <a to='/components/'>@repay/cactus-web</a> provides several styled form inputs, as well as a few custom inputs that emulate built-in HTML inputs. This guide will show you the basics of combining these input components with a common forms library, [Final Form](https://final-form.org/).
+
+Because Final Form is framework-agnostic, there's [another library](https://final-form.org/react) for the React-specific parts. Besides the official React Final Form library, we have our own addition in <a to='/forms/'>@repay/cactus-form</a> that's more specifically suited to working with Cactus Web.
 
 Before starting, you should have an application, and know how to add a page or component. The examples used will be based on an app like those created by the [@repay/create-ui](https://github.com/repaygithub/ui-tools/tree/master/modules/create-repay-ui) package; see <a to='/tutorials/responsive-web-design/'>this tutorial</a> for an example with starting a new project.
 
 ### Installation
 
-Installation is simple enough, just add the latest verstion of "formik" to the `dependencies` list in your package.json (or however you add dependencies in your particular project).
+Installation is simple enough, just add the latest version of "final-form", "react-final-form", and "@repay/cactus-form" to the `dependencies` list in your package.json (or however you add dependencies in your particular project).
 
-## Using Formik
+Cactus Form also has an optional setup step using [patch-package](https://www.npmjs.com/package/patch-package), described in more depth in the library documentation.
 
-There are two basic ways of using Formik: with components, and with hooks. We won't be getting into all the arguments and subtleties since those are well-covered in the Formik documentation, just covering enough to show how it works with `@repay/cactus-web` components.
+## Using React Final Form
 
-Creating a form is simple by either method:
+The basic Final Form library is very flexible, and I highly recommend going through the docs to understand what it's capable of. However, the majority of use cases can be covered by the components in React Final Form and Cactus Form.
+
+To make a form you start with the [Form](https://final-form.org/docs/react-final-form/api/Form) component,
+which creates both a form and a React context that allows you to access it from any descendants.
+Once the form is created, there are a variety of hooks and components that can be used to implement the functionality.
+We won't be getting into all the arguments and subtleties since those are well-covered in the documentation,
+just covering enough to show how it works with Cactus components.
+
+Creating a form is simple:
 
 ```jsx
-import { Formik, useFormik }
+import { Field } from '@repay/cactus-form'
+import { Button } from '@repay/cactus-web'
+import { Form } from 'react-final-form'
 import React from 'react'
 
-import { TextInputField } from '@repay/cactus-web'
-
-const TestFormComponent = (props) => (
-  <Formik {...props}>
-    {({ handleSubmit, handleChange, values, touched, errors }) => (
+const TestForm = (props) => (
+  <Form {...props}>
+    {({ handleSubmit, invalid, error }) => (
       <form onSubmit={handleSubmit}>
-        <TextInputField
-          id="text-input"
-          name="mytext"
-          value={values.mytext}
-          label="Enter some text"
-          error={touched.mytext && errors.mytext}
-          onChange={handleChange}
-        />
+        {error && (<Alert status="error">{error}</Alert>)}
+        <Field id="text-input" name="mytext" label="Enter some text" />
+        <Field type="checkbox" name="mycb" label="Check me (or don't)" />
+        <Button type="submit" disabled={invalid}>Save</Button>
       </form>
     )}
-  </Formik>
+  </Form>
 )
+```
 
-const TestFormHook = (props) => {
-  const { handleSubmit, handleChange, values, touched, errors } = useFormik(props)
-  return (
-    <form onSubmit={handleSubmit}>
-      <TextInputField
-        name="mytext"
-        value={values.mytext}
-        label="Enter some text"
-        error={touched.mytext && errors.mytext}
-        onChange={handleChange}
-      />
-    </form>
-  )
+The Cactus Form version of `Field` automatically maps `type` to Cactus Web components:
+the example above will render a `TextInputField` and a `CheckBoxField`,
+but this behavior is customizable in a number of ways, covered more in the docs.
+Field also automatically adds `value`, `checked`, `onChange`, and `onBlur` props to the field.
+
+If the default components don't quite do what you need, you can fall back to
+hooks that give you greater control over how to interact with Final Form.
+In particular, `useForm` gives you access to the basic Final Form API with significant customization options.
+
+```
+import { useField, useForm } from 'react-final-form'
+
+const CustomField = (props) => {
+  const { input, meta } = useField(props.name, props)
+  if (meta.error) {
+    return <Alert status="error">All is lost, no hope of recovery.</Alert>
+  }
+  return <FieldLike {...props} {...input} touched={meta.touched} />
+}
+
+const SuperCustomField = (props) => {
+  const form = useForm()
+  const [state, setState] = React.useState()
+  React.useEffect(() => {
+    const listener = (state) => {
+      props.doSomeCustomLogic(state)
+      form.mutators.updateSomeOtherFormState(state.value)
+      setState(state)
+    }
+    return form.registerField(props.name, listener, props.subscription, props)
+  }, [props.name])
+  if (!state) return null
+  return <FieldLike {...state} />
 }
 ```
 
-The main difference between the two is depth: `useFormik` does everything locally, while the `Formik` component (which in fact utilizes the hook internally) creates a React context which allows access to the formik helpers within sub-components via the `useFormikContext` hook (or `FormikConsumer` component).
+## Final Form & Cactus
 
-Finally, there are two other helper components we'll be using within a Formik context:
+Cactus has two basic kinds of field components: regular HTML inputs that have simply been styled using `@repay/cactus-theme`, and custom components that mimic regular HTML inputs. These are the styled inputs and their default mapping in Cactus Form:
 
-- `Form` creates a `<form>` element and automatically adds the `handleSubmit` and `handleReset` event handlers.
-- `Field` creates an element and automatically adds the `name`, `value`, `handleChange`, and `handleBlur` props.
-
-## Formik & Cactus
-
-Cactus has two basic kinds of field components: regular HTML inputs that have simply been styled using `@repay/cactus-theme`, and custom components that mimic regular HTML inputs. The former can be used pretty much like any other input with Formik (and there are plenty of examples in their docs):
-
-- `CheckBox`/`CheckBoxField`
-- `RadioButton`/`RadioButtonField`
+- `CheckBox`/`CheckBoxField` (type="checkbox")
+- `CheckBoxCard`
+- `RadioButton`/`RadioButtonField` (type="radio")
+- `RadioCard`
 - `TextArea`/`TextAreaField`
-- `TextInput`/`TextInputField`
-- `Toggle`/`ToggleField`
+- `TextInput`/`TextInputField` (default/type="text")
+- `Toggle`/`ToggleField` (type="boolean")
 
-The custom components are these:
+And these are the custom components:
 
 - `ColorPicker`
-- `DateInput`/`DateInputField`
-- `FileInput`/`FileInputField`
-- `RadioGroup`
-- `Select`/`SelectField`
+- `DateInput`/`DateInputField` (type="date"/"time"/"datetime")
+- `FileInput`/`FileInputField` (type="file")
+- `RadioGroup`/`RadioCard.Group`
+- `Select`/`SelectField` (type="select"/"multiSelect")
 
-`CheckBoxGroup` isn't really a field, though it behaves a bit like one so we'll cover it as well.
+`CheckBoxGroup`/`CheckBoxCard.Group` is a special case, since it's not a single field, but we'll cover it separately.
 
 ### Field Examples
 
-For the rest of these examples, I'll be omitting the form boilerplate for brevity; assume a similar basic Formik setup like the following (we'll mostly be referencing the `formik` variable in the examples):
+Almost all of our components work out-of-the-box with the Cactus Form `Field` component.
+You can either rely on the default mapping, configure your own, or explicitly pass the field you want to use;
+just replace where you'd normally call the Cactus field component with Field,
+and props are forwarded to the underlying component, including children.
 
 ```jsx
-import { Field, Form, Formik }
-import React from 'react'
+import { Field } from '@repay/cactus-form'
 
-import { Button, [example component] } from '@repay/cactus-web'
-
-const logValues = (values) => console.log(values)
-
-const TestForm = (props) => (
-  <Formik onSubmit={logValues} initialValues={{}} {...props}>
-    {(formik) => (
-      <Form>
-        [example components]
-        <Button type="submit>Submit</Button>
-      </Form>
-    )}
-  </Formik>
-)
-```
-
-#### TextAreaField, TextInputField
-
-These are as basic as it gets; you can use them directly, or through the `Field` helper component.
-
-```jsx
-<TextAreaField
-  name="largeText"
-  label="Lots of Text"
-  onChange={formik.handleChange}
-  value={formik.values.largeText}
-  error={formik.errors.largeText}
-/>
-<Field
-  as={TextInputField}
-  name="smallText"
-  label="One line"
-  error={formik.errors.smallText}
-/>
-```
-
-#### CheckBoxField, RadioButtonField, ToggleField
-
-These three are similar to the other basic fields, but there's an important difference: their value is determined by the `checked` prop, not the `value` prop.
-In order for Formik to set the values appropriately when using `Field`, you must set the `type` prop so it knows how to set the `checked` prop.
-
-```jsx
-<Field
-  as={CheckBoxField}
-  type="checkbox"
-  name="ready"
-  label="Are you Ready?"
-/>
-<Field
-  as={ToggleField}
-  type="checkbox"
-  name="set"
-  label="Are you Set?"
-/>
-<RadioButtonField
-  name="yesOrNo"
-  value="yes"
-  label="Yes!"
-  checked={formik.values.yesOrNo === 'yes'}
-  onChange={formik.handleChange}
-/>
-<Field
-  as={RadioButtonField}
-  type="radio"
-  name="yesOrNo"
-  value="no"
-  label="No!!"
-/>
-```
-
-With checkboxes (including Toggle) you can provide a non-boolean value (similar to how radio buttons work, but in a "choose one or more" kind of use case). In that case, Formik sets the value as a list and the `checked` prop based on whether or not the value is in the list. **Note:** on some browsers, at least, checkboxes have a default value; thus, it's recommended you _not_ use the basic `formik.handleChange` function because it will incorrectly turn the checkbox value into a list. Either use the `Field` helper, which handles the default value correctly, or write a custom change handler using `formik.setFieldValue`.
-
-#### CheckBoxGroup
-
-Since CheckBoxGroup isn't really a field, the `Field` helper doesn't work well with it. It _can_ be used to wrap the individual checkboxes, especially if they all have different names and/or boolean values. However, if **all** the checkboxes have non-boolean values, you only need to pass the change/blur handlers at the top level (even if they have different names).
-
-```jsx
-<CheckBoxGroup
-  name="zeroOrMore"
-  label="Choose Zero or More"
-  onChange={formik.handleChange}
-  onBlur={formik.handleBlur}
->
-  <CheckBoxGroup.Item
-    name="zeroOrMore"
-    label="Zero"
-    value="zero"
-    checked={formik.values.zeroOrMore?.includes?.('zero')}
-  />
-  {/* In real code you probably shouldn't mix these methods. */}
-  <Field
-    as={CheckBoxGroup.Item}
-    type="checkbox"
-    name="conjunction"
-    label="OR"
-  />
-  <CheckBoxGroup.Item
-    name="zeroOrMore"
-    label="More"
-    value="more"
-    checked={formik.values.zeroOrMore?.includes?.('more')}
-  />
-</CheckBoxGroup>
-```
-
-If all the child checkboxes have different names _and_ boolean values, you can take a different shortcut to set the `checked` prop:
-
-```jsx
-<CheckBoxGroup
-  name="shortcuts"
-  label="Shortcuts"
-  onChange={(e) => formik.setFieldValue(e.target.name, e.target.checked)}
-  checked={formik.values}
->
-  <CheckBoxGroup.Item name="one" label="One" />
-  <CheckBoxGroup.Item name="two" label="Two" />
-</CheckBoxGroup>
-```
-
-#### ColorPicker, DateInputField, FileInputField, RadioGroup, SelectField
-
-These fields are all custom components rather than styled HTML elements, but their `onChange`/`value` props are designed to work with Formik as if they were regular text inputs. The important thing is to _not_ set the `type` prop: with no type prop, Formik will just take `event.target.value` from the change event, and pass it as-is to the component's `value` prop.
-
-```jsx
-{/* Note that AccessibleField forwards `name` to its child. */}
-<AccessibleField
-  name="surprise"
-  label="Color Me Surprised"
-  error={formik.errors.surprise}
->
-  <Field as={ColorPicker} />
-</AccessibleField>
-<DateInputField
-  name="when"
-  label="When was it?"
-  onChange={formik.handleChange}
-  value={formik.values.when}
-  error={formik.errors.when}
-/>
-<Field
-  as={FileInputField}
-  name="theFiles"
-  label="Add the Files"
-  error={formik.errors.theFiles}
-/>
-<SelectField
-  name="chooseOne"
-  label="Choose One"
-  options={['chosen', 'value', 'options']}
-  onChange={formik.handleChange}
-  value={formik.values.chooseOne}
-/>
-<Field
-  as={RadioGroup}
-  name="chooseOneAgain"
-  label="Choose Another One"
-  error={formik.errors.chooseOneAgain}
->
-  <RadioGroup.Button label="English" value="English" />
-  <RadioGroup.Button label="French" value="French" />
-  <RadioGroup.Button label="German" value="German" />
+<Field as={RadioCard.Group} name="radios" label="Some radio buttons">
+  <RadioCard value="ham">Ham Radio</RadioCard>
+  <RadioCard value="transistor">Transistor Radio</RadioCard>
 </Field>
+<Field
+  type="select"
+  multiple
+  name="selection"
+  label="Select Something(s)"
+  options={['option1', 'variant2', 'type3']}
+/>
+```
+
+The basic React Final Form `Field` component does not directly support custom components:
+they have to be explicitly rendered, which is why we recommend Cactus Form.
+
+```jsx
+import { Field as CactusField } from '@repay/cactus-form'
+import { Field } from 'react-final-form'
+
+<Field name="myfield" subscription={{ value: true, error: true }}>
+  {({ input, meta }) => (
+    <TextInputField {...input} error={meta.error} label="My Field" />
+  )}
+</Field>
+// which is roughly the same as
+<CactusField name="myfield" label="My Field" type="text" />
+```
+
+### Radio Buttons, Checkboxes & Toggles
+
+React Final Form has some special behavior around radio buttons and checkboxes
+that needs to be mentioned, due to the addition of the `checked` prop.
+While radio groups work out-of-the-box, a single radio button or checkbox needs a slight adjustment:
+
+```jsx
+<Field as={RadioButtonField} type="radio" {...rest} />
+<Field as={CheckBoxField} type="checkbox" {...rest} />
+<Field as={ToggleField} type="checkbox" {...rest} />
+```
+
+Even if you explicitly tell it which component to use, you _also_ must pass the `type` prop
+to tell final form that `checked` is needed, and how to calculate it.
+The corollary is that you should _never_ pass the `type` prop to a radio or checkbox _group_,
+because those work using the `value` prop like a generic input instead of `checked`.
+
+### Checkbox Groups
+
+Checkbox groups are the trickiest field types, because they can be used in two different ways:
+
+```jsx
+// Creates form values like -> { cbgroup: ["one", "three"] }
+<Field as={CheckBoxGroup} name="cbgroup" label="Array Of Strings">
+  <CheckBoxGroup.Item value="one" label="Uno" />
+  <CheckBoxGroup.Item value="two" label="Dos" />
+  <CheckBoxGroup.Item value="three" label="Tres" />
+</Field>
+
+// Creates form values like -> { uno: true, dos: false, tres: true }
+<CheckBoxCard.Group label="Several Unrelated Booleans">
+  <Field as={CheckBoxCard} type="checkbox" name="uno">One</Field>
+  <Field as={CheckBoxCard} type="checkbox" name="dos">Two</Field>
+  <Field as={CheckBoxCard} type="checkbox" name="tres">Three</Field>
+</CheckBoxCard.Group>
+```
+
+Note that you need as many Field components as there are unique names.
+
+The array group variant will only work if you do the optional patch-package step
+when installing `@repay/cactus-form`.
+However, even if you don't use the patch you can still support checkbox arrays with more verbose code:
+
+```jsx
+// CheckBoxGroup forwards `name` to all its children, so you don't have to repeat it.
+<CheckBoxGroup name="cbgroup" label="Array Of Strings">
+  <Field as={CheckBoxGroup.Item} type="checkbox" value="one" label="Uno" />
+  <Field as={CheckBoxGroup.Item} type="checkbox" value="two" label="Dos" />
+  <Field as={CheckBoxGroup.Item} type="checkbox" value="three" label="Tres" />
+</CheckBoxGroup>
 ```
 
 ### Further Reading
 
-- [Formik Documentation](https://formik.org/docs/tutorial)
+- [Final Form Documentation](https://final-form.org/docs/final-form/getting-started)
+- [React Final Form Documentation](https://final-form.org/docs/react-final-form/getting-started)
 - <a to='/components/'>@repay/cactus-web Documentation</a>
+- <a to='/forms/'>@repay/cactus-form Documentation</a>
 - [Example app w/ form (UI Config page)](https://github.com/repaygithub/cactus/tree/master/examples/mock-ebpp)


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-806

Since Cactus Form is specifically designed with the Cactus Web fields in mind, the fields section is a bit shorter now.