### PR TITLE
CACTUS-821 :: Saturation Multiplier 

### DIFF
--- a/docs/Theme/README.md
+++ b/docs/Theme/README.md
@@ -53,14 +53,15 @@ If only a `primary` color is provided or the secondary color is white, the theme
 
 Whether you generate a theme using a primary hue or with primary and secondary hex values, there are several other optional keys you can set in the options object:
 
-| Attr                | Type                                       | Required | Description                                                                        |
-| ------------------- | ------------------------------------------ | -------- | ---------------------------------------------------------------------------------- |
-| `border`            | `thin` \| `thick`                          | N        | Specifies theme border thickness. Thin is 1px and thick is 2px. Default is thin.   |
-| `shape`             | `round` \| `intermediate` \| `square`      | N        | Specifies general component shape. Default is intermediate.                        |
-| `font`              | `Helvetica Neue` \| `Helvetica` \| `Arial` | N        | Defines application font. Default is Helvetica.                                    |
-| `boxShadows`        | Boolean                                    | N        | Enabled/disables box shadows on cactus-web components. Enabled by default.         |
-| `grayscaleContrast` | Boolean                                    | N        | Enables/disables usage of grayscale colors for lightContrast. Disabled by default. |
-| `breakpoints`       | Object shape defined below                 | N        | Define custom breakpoints for your application.                                    |
+| Attr                   | Type                                       | Required | Description                                                                        |
+| -------------------    | ------------------------------------------ | -------- | ---------------------------------------------------------------------------------- |
+| `border`               | `thin` \| `thick`                          | N        | Specifies theme border thickness. Thin is 1px and thick is 2px. Default is thin.   |
+| `shape`                | `round` \| `intermediate` \| `square`      | N        | Specifies general component shape. Default is intermediate.                        |
+| `font`                 | `Helvetica Neue` \| `Helvetica` \| `Arial` | N        | Defines application font. Default is Helvetica.                                    |
+| `boxShadows`           | Boolean                                    | N        | Enabled/disables box shadows on cactus-web components. Enabled by default.         |
+| `grayscaleContrast`    | Boolean                                    | N        | Enables/disables usage of grayscale colors for lightContrast. Disabled by default. |
+| `breakpoints`          | Object shape defined below                 | N        | Define custom breakpoints for your application.                                    |
+| `saturationMultiplier` | Number between 0 and 1 inclusive.          | N        | Sets the saturation level for the Base, CTA and contrast colors of the theme.      |
 
 The `breakpoints` option should have the following form:
 

--- a/modules/cactus-theme/src/theme.ts
+++ b/modules/cactus-theme/src/theme.ts
@@ -215,9 +215,8 @@ function getLightCallToAction(ctaParams: number[]): string {
   return getHslString([lightCTAHue, lightCTASaturation, lightCTALightness])
 }
 
-function getSaturation(satPercentage: number, saturationFactor: number): number {
-  const saturation = satPercentage * 0.01 * saturationFactor
-  return Number((saturation * 100).toFixed(2))
+function getSaturation(satPercentage: number, saturationFactor: number = 1): number {
+  return Number((satPercentage * saturationFactor).toFixed(2))
 }
 
 function fromHue({

--- a/modules/cactus-theme/src/theme.ts
+++ b/modules/cactus-theme/src/theme.ts
@@ -184,6 +184,7 @@ const status: StatusColors = {
 }
 
 interface SharedGeneratorOptions {
+  saturationMultiplier?: number
   border?: BorderSize
   shape?: Shape
   font?: Font
@@ -214,22 +215,28 @@ function getLightCallToAction(ctaParams: number[]): string {
   return getHslString([lightCTAHue, lightCTASaturation, lightCTALightness])
 }
 
+function getSaturation(satPercentage: number, saturationFactor: number): number {
+  const saturation = satPercentage * 0.01 * saturationFactor
+  return Number((saturation * 100).toFixed(2))
+}
+
 function fromHue({
   primaryHue,
+  saturationMultiplier = 1,
 }: HueGeneratorOptions): [CactusTheme['colors'], CactusTheme['colorStyles']] {
   /** Core colors */
-  const base = `hsl(${primaryHue}, 96%, 11%)`
+  const base = `hsl(${primaryHue}, ${getSaturation(96, saturationMultiplier)}%, 11%)`
   const baseText = `hsl(0, 0%, 100%)`
-  const ctaParams = [primaryHue, 96, 35]
+  const ctaParams = [primaryHue, getSaturation(96, saturationMultiplier), 35]
   const callToAction = getHslString(ctaParams)
   const callToActionText = `hsl(0, 0%, 100%)`
   const lightCallToAction = getLightCallToAction(ctaParams)
 
   /** Contrasts */
-  const lightContrast = `hsl(${primaryHue}, 29%, 90%)`
-  const mediumContrast = `hsl(${primaryHue}, 18%, 45%)`
-  const darkContrast = `hsl(${primaryHue}, 9%, 35%)`
-  const darkestContrast = `hsl(${primaryHue}, 10%, 20%)`
+  const lightContrast = `hsl(${primaryHue}, ${getSaturation(29, saturationMultiplier)}%, 90%)`
+  const mediumContrast = `hsl(${primaryHue}, ${getSaturation(18, saturationMultiplier)}%, 45%)`
+  const darkContrast = `hsl(${primaryHue}, ${getSaturation(9, saturationMultiplier)}%, 35%)`
+  const darkestContrast = `hsl(${primaryHue}, ${getSaturation(10, saturationMultiplier)}%, 20%)`
 
   return [
     {
@@ -362,14 +369,17 @@ interface Color {
   rgb: [number, number, number]
 }
 
-function fromTwoWhite(primaryHue: number): [CactusTheme['colors'], CactusTheme['colorStyles']] {
+function fromTwoWhite(
+  primaryHue: number,
+  saturationMultiplier: number
+): [CactusTheme['colors'], CactusTheme['colorStyles']] {
   /** Contrasts */
-  const lightContrast = `hsl(${primaryHue}, 29%, 90%)`
-  const mediumContrast = `hsl(${primaryHue}, 18%, 45%)`
-  const darkContrast = `hsl(${primaryHue}, 9%, 35%)`
-  const darkestContrast = `hsl(${primaryHue}, 10%, 20%)`
+  const lightContrast = `hsl(${primaryHue}, ${getSaturation(29, saturationMultiplier)}%, 90%)`
+  const mediumContrast = `hsl(${primaryHue}, ${getSaturation(18, saturationMultiplier)}%, 45%)`
+  const darkContrast = `hsl(${primaryHue}, ${getSaturation(9, saturationMultiplier)}%, 35%)`
+  const darkestContrast = `hsl(${primaryHue}, ${getSaturation(10, saturationMultiplier)}%, 20%)`
 
-  const ctaParams = [244, 48, 26]
+  const ctaParams = [244, getSaturation(48, saturationMultiplier), 26]
   const callToAction = getHslString(ctaParams)
   const lightCallToAction = getLightCallToAction(ctaParams)
   const callToActionText = white
@@ -495,17 +505,20 @@ function fromTwoWhite(primaryHue: number): [CactusTheme['colors'], CactusTheme['
 
 function fromWhiteSecondary(
   primary: Color,
-  secondary: Color
+  secondary: Color,
+  saturationMultiplier: number
 ): [CactusTheme['colors'], CactusTheme['colorStyles']] {
   /** Core colors */
-  const base = `hsl(${primary.hue}, ${primary.saturation}%, ${primary.lightness}%)`
+  const base = `hsl(${primary.hue}, ${getSaturation(primary.saturation, saturationMultiplier)}%, ${
+    primary.lightness
+  }%)`
   const contrastHue = secondary.lightness === 100 ? primary.hue : secondary.hue
 
   /** Contrasts */
-  const lightContrast = `hsl(${contrastHue}, 29%, 90%)`
-  const mediumContrast = `hsl(${contrastHue}, 18%, 45%)`
-  const darkContrast = `hsl(${contrastHue}, 9%, 35%)`
-  const darkestContrast = `hsl(${contrastHue}, 10%, 20%)`
+  const lightContrast = `hsl(${contrastHue}, ${getSaturation(29, saturationMultiplier)}%, 90%)`
+  const mediumContrast = `hsl(${contrastHue}, ${getSaturation(18, saturationMultiplier)}%, 45%)`
+  const darkContrast = `hsl(${contrastHue}, ${getSaturation(9, saturationMultiplier)}%, 35%)`
+  const darkestContrast = `hsl(${contrastHue}, ${getSaturation(10, saturationMultiplier)}%, 20%)`
 
   const baseText = isDark(...primary.rgb) ? white : darkestContrast
 
@@ -513,7 +526,11 @@ function fromWhiteSecondary(
   const updatedSecondaryHue = primary.lightness !== 0 ? primary.hue : 244
   const updatedSecondarySaturation = primary.lightness > 21 ? 98 : 96
   const updatedSecondaryLightness = primary.lightness > 21 ? 10 : 35
-  const ctaParams = [updatedSecondaryHue, updatedSecondarySaturation, updatedSecondaryLightness]
+  const ctaParams = [
+    updatedSecondaryHue,
+    getSaturation(updatedSecondarySaturation, saturationMultiplier),
+    updatedSecondaryLightness,
+  ]
   const callToAction = getHslString(ctaParams)
   const callToActionText = white
   const lightCallToAction = getLightCallToAction(ctaParams)
@@ -639,20 +656,27 @@ function fromWhiteSecondary(
 
 function fromTwoNonWhite(
   primary: Color,
-  secondary: Color
+  secondary: Color,
+  saturationMultiplier: number
 ): [CactusTheme['colors'], CactusTheme['colorStyles']] {
   /** Core colors */
-  const base = `hsl(${primary.hue}, ${primary.saturation}%, ${primary.lightness}%)`
+  const base = `hsl(${primary.hue}, ${getSaturation(primary.saturation, saturationMultiplier)}%, ${
+    primary.lightness
+  }%)`
 
   /** Contrasts */
-  const lightContrast = `hsl(${primary.hue}, 29%, 90%)`
-  const mediumContrast = `hsl(${primary.hue}, 18%, 45%)`
-  const darkContrast = `hsl(${primary.hue}, 9%, 35%)`
-  const darkestContrast = `hsl(${primary.hue}, 10%, 20%)`
+  const lightContrast = `hsl(${primary.hue}, ${getSaturation(29, saturationMultiplier)}%, 90%)`
+  const mediumContrast = `hsl(${primary.hue}, ${getSaturation(18, saturationMultiplier)}%, 45%)`
+  const darkContrast = `hsl(${primary.hue}, ${getSaturation(9, saturationMultiplier)}%, 35%)`
+  const darkestContrast = `hsl(${primary.hue}, ${getSaturation(10, saturationMultiplier)}%, 20%)`
 
   const baseText = isDark(...primary.rgb) ? white : darkestContrast
 
-  const ctaParams = [secondary.hue, secondary.saturation, secondary.lightness]
+  const ctaParams = [
+    secondary.hue,
+    getSaturation(secondary.saturation, saturationMultiplier),
+    secondary.lightness,
+  ]
   const callToAction = getHslString(ctaParams)
   const callToActionText = isDark(...secondary.rgb) ? white : darkestContrast
   const lightCallToAction = getLightCallToAction(ctaParams)
@@ -779,6 +803,7 @@ function fromTwoNonWhite(
 function fromTwoColor({
   primary,
   secondary,
+  saturationMultiplier = 1,
 }: TwoColorGeneratorOptions): [CactusTheme['colors'], CactusTheme['colorStyles']] {
   const primaryRgb = hexToRgb(primary)
   const secondaryRgb = hexToRgb(secondary || '')
@@ -802,16 +827,16 @@ function fromTwoColor({
 
   // both colors are undefined or white
   if (primaryLightness === 100 && isSecondaryWhite) {
-    return fromTwoWhite(primaryHue)
+    return fromTwoWhite(primaryHue, saturationMultiplier)
   }
 
   // primary is non-black and secondary is white
   if (isSecondaryWhite) {
-    return fromWhiteSecondary(primaryColor, secondaryColor)
+    return fromWhiteSecondary(primaryColor, secondaryColor, saturationMultiplier)
   }
 
   // both primary and secondary are non-white colors
-  return fromTwoNonWhite(primaryColor, secondaryColor)
+  return fromTwoNonWhite(primaryColor, secondaryColor, saturationMultiplier)
 }
 
 export type GeneratorOptions = HueGeneratorOptions | TwoColorGeneratorOptions
@@ -826,6 +851,7 @@ const repayOptions: GeneratorOptions = {
   shape: 'intermediate',
   font: 'Helvetica',
   boxShadows: true,
+  saturationMultiplier: 1,
 }
 
 const makeTextStyles = (fontSizes: FontSizeObject): TextStyleCollection => ({

--- a/modules/cactus-theme/src/theme.ts
+++ b/modules/cactus-theme/src/theme.ts
@@ -215,7 +215,7 @@ function getLightCallToAction(ctaParams: number[]): string {
   return getHslString([lightCTAHue, lightCTASaturation, lightCTALightness])
 }
 
-function getSaturation(satPercentage: number, saturationFactor: number = 1): number {
+function getSaturation(satPercentage: number, saturationFactor = 1): number {
   return Number((satPercentage * saturationFactor).toFixed(2))
 }
 

--- a/modules/cactus-theme/tests/theme.test.ts
+++ b/modules/cactus-theme/tests/theme.test.ts
@@ -119,6 +119,23 @@ describe('@repay/cactus-theme', (): void => {
 
   themeAccessibility('primary theme', generateTheme({ primaryHue: 200 }))
 
+  test('Generaste a theme with primaryHue and saturation Multiplier', () => {
+    const theme = generateTheme({ primaryHue: 200, saturationMultiplier: 0.2 })
+    expect(theme.colors).toMatchObject({
+      base: 'hsl(200, 19.2%, 11%)',
+      callToAction: 'hsl(200, 19.2%, 35%)',
+      lightCallToAction: 'hsl(200, 5%, 81%)',
+      ...expectedActionColors,
+    })
+    expect(theme.colorStyles).toMatchObject({
+      ...expectedActionStyles,
+      lightCallToAction: {
+        backgroundColor: 'hsl(200, 5%, 81%)',
+        color: 'hsl(200, 2%, 20%)',
+      },
+    })
+  })
+
   test('generates a grayscale theme with primaryHue', (): void => {
     const theme = generateTheme({ primaryHue: 200, grayscaleContrast: true })
     expect(theme.colors).toMatchObject({
@@ -162,6 +179,23 @@ describe('@repay/cactus-theme', (): void => {
     })
   })
 
+  test('generates a theme when primary color and saturation multiplier are provided ', (): void => {
+    const theme = generateTheme({ primary: '#012537', saturationMultiplier: 0.5 })
+    expect(theme).toMatchObject({
+      colors: {
+        lightContrast: 'hsl(200, 14.5%, 90%)',
+        callToAction: 'hsl(200, 48%, 35%)',
+        lightCallToAction: 'hsl(200, 20%, 81%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        lightCallToAction: { backgroundColor: 'hsl(200, 20%, 81%)', color: 'hsl(200, 5%, 20%)' },
+        lightContrast: { backgroundColor: 'hsl(200, 14.5%, 90%)' },
+        ...expectedActionStyles,
+      },
+    })
+  })
+
   test('generates a theme when two colors are provided', (): void => {
     const theme = generateTheme({ primary: '#012537', secondary: ' #0000FF' })
     expect(theme).toMatchObject({
@@ -174,6 +208,26 @@ describe('@repay/cactus-theme', (): void => {
       colorStyles: {
         ...expectedActionStyles,
         lightCallToAction: { backgroundColor: 'hsl(240, 68%, 85%)', color: 'hsl(200, 10%, 20%)' },
+      },
+    })
+  })
+
+  test('Saturation Multiplier when two colors are provided to the theme', () => {
+    const theme = generateTheme({
+      primary: '#012537',
+      secondary: ' #0000FF',
+      saturationMultiplier: 0.5,
+    })
+    expect(theme).toMatchObject({
+      colors: {
+        base: 'hsl(200, 48%, 11%)',
+        callToAction: 'hsl(240, 50%, 50%)',
+        lightCallToAction: 'hsl(240, 30%, 85%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        ...expectedActionStyles,
+        lightCallToAction: { backgroundColor: 'hsl(240, 30%, 85%)', color: 'hsl(200, 5%, 20%)' },
       },
     })
   })
@@ -270,6 +324,22 @@ describe('@repay/cactus-theme', (): void => {
       colorStyles: {
         ...expectedActionStyles,
         lightCallToAction: { backgroundColor: 'hsl(244, 15%, 78%)', color: 'hsl(0, 10%, 20%)' },
+      },
+    })
+  })
+
+  test('generates a white theme when invalid colors and a saturation multiplier are provided', (): void => {
+    const theme = generateTheme({ primary: '', saturationMultiplier: 0.5 })
+    expect(theme).toMatchObject({
+      colors: {
+        base: 'hsl(0, 0%, 100%)',
+        callToAction: 'hsl(244, 24%, 26%)',
+        lightCallToAction: 'hsl(244, 5%, 78%)',
+        ...expectedActionColors,
+      },
+      colorStyles: {
+        ...expectedActionStyles,
+        lightCallToAction: { backgroundColor: 'hsl(244, 5%, 78%)', color: 'hsl(0, 5%, 20%)' },
       },
     })
   })

--- a/modules/cactus-web/cactus-addon/register.jsx
+++ b/modules/cactus-web/cactus-addon/register.jsx
@@ -33,6 +33,7 @@ class Panel extends React.Component {
       shape: 'intermediate',
       font: 'Helvetica',
       boxShadows: true,
+      saturationMultiplier: 1,
     },
     backgroundInverse: false,
     borderBox: false,
@@ -77,6 +78,7 @@ class Panel extends React.Component {
       font: values.font,
       boxShadows: values.boxShadows,
       grayscaleContrast: values.grayscaleContrast,
+      saturationMultiplier: values.saturationMultiplier,
       ...colors,
     })
   }
@@ -143,6 +145,29 @@ class Panel extends React.Component {
                 </label>
               </div>
             </div>
+          </Form.Field>
+          <Form.Field>
+            <label htmlFor="saturationMultiplier">Saturation Multiplier</label>
+            <input
+              type="range"
+              id="saturationMultiplier"
+              name="saturationMultiplier"
+              min="0"
+              max="1"
+              step="0.01"
+              value={values.saturationMultiplier}
+              onChange={this.handleSimpleThemeChange}
+            />
+            <input
+              type="text"
+              id="saturationMultiplier-text"
+              name="saturationMultiplier"
+              value={values.saturationMultiplier}
+              onChange={({ currentTarget }) =>
+                this.handleThemeChange('saturationMultiplier', parseInt(currentTarget.value))
+              }
+              style={{ width: '32px', marginLeft: '8px' }}
+            />
           </Form.Field>
           {values.type === THEME_TYPES.use_hue ? (
             <Form.Field>


### PR DESCRIPTION
[CACTUS-821](https://repayonline.atlassian.net/browse/CACTUS-821)

This is my current approach on this:
I created the `saturationMultiplier` variable and added to the theme object. Set 1 as default and multiplied that factor with every saturation value of the `hsl` representations of the following colors: 
 
- Base
- CTA
- CTA light
- Contrast light
- Contrast Medium
- Contrast Dark
- Contrast Darkest

I added one range control for that Saturation Multiplier into the `Cactus Theme` addon in the Storybook app of the `cactus-web` module. So you can run the storybook app and test that. 

Don't forget to add the current version of the `theme` package using `yalc`. 