### PR TITLE
CACTUS-738: change Tag close icon to button

### DIFF
--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -213,7 +213,7 @@ IconButton.propTypes = {
   variant: PropTypes.oneOf(['standard', 'action', 'danger', 'warning', 'success', 'dark']),
   disabled: PropTypes.bool,
   label: (props: IconButtonProps, propName: string, componentName: string): Error | null => {
-    if (!props.label && !props['aria-labelledby']) {
+    if (!props.label && !props['aria-label'] && !props['aria-labelledby']) {
       return new Error(
         `One of props 'label' or 'aria-labelledby' was not specified in ${componentName}.`
       )
@@ -224,24 +224,7 @@ IconButton.propTypes = {
     }
     return null
   },
-  'aria-labelledby': (
-    props: IconButtonProps,
-    propName: string,
-    componentName: string
-  ): Error | null => {
-    if (!props['aria-labelledby'] && !props.label) {
-      return new Error(
-        `One of props 'label' or 'aria-labelledby' was not specified in ${componentName}.`
-      )
-    } else if (props['aria-labelledby'] && typeof props['aria-labelledby'] !== 'string') {
-      return new Error(
-        `Invalid prop 'aria-labelledby' of type '${typeof props[
-          'aria-labelledby'
-        ]}' supplied to '${componentName}', expected 'string'.`
-      )
-    }
-    return null
-  },
+  'aria-labelledby': PropTypes.string,
   display: PropTypes.oneOf(['flex', 'inline-flex']),
   inverse: PropTypes.bool,
 }

--- a/modules/cactus-web/src/Tag/Tag.mdx
+++ b/modules/cactus-web/src/Tag/Tag.mdx
@@ -59,6 +59,32 @@ import { Tag } from '@repay/cactus-web'
 </Tag>
 ```
 
+### Close Button
+
+The visibility of the close button is controlled by either passing a handler to
+`onCloseIconClick` or the `closeOption` prop. Passing a handler is equivalent to
+`closeOption={true}`, but if you want the close button without using an actual
+`<button>` element, you can pass `closeOption="no-button"`.
+
+If you need to identify which tag of several was clicked, you can make it simpler
+by giving the tag an ID: then the close button will have an `aria-controls` attribute
+with the tag's ID in it. For example:
+
+```jsx
+const TagList = () => {
+  const [tags, setTags] = useState(['one', 'two'])
+  const onClose = (e) => {
+    const id = e.currentTarget.getAttribute('aria-controls')
+    setTags(tags.filter((t) => t !== id))
+  }
+  return (
+    <>
+      {tags.map((t) => <Tag key={t} id={t} onCloseIconClick={onClose}>{t}</Tag>)}
+    </>
+  )
+}
+```
+
 ## Properties
 
 <PropsTable of={Tag} />

--- a/modules/cactus-web/src/Tag/Tag.story.tsx
+++ b/modules/cactus-web/src/Tag/Tag.story.tsx
@@ -6,41 +6,45 @@ import { Action, actions, Story } from '../helpers/storybook'
 const options = [
   {
     label: 'this',
-    id: '1',
+    id: 'tag-1',
   },
   {
     label: 'is',
-    id: '2',
+    id: 'tag-2',
   },
   {
     label: 'an',
-    id: '3',
+    id: 'tag-3',
   },
   {
     label: 'example',
-    id: '4',
+    id: 'tag-4',
   },
 ]
 
 export default {
   title: 'Tag',
   component: Tag,
-  argTypes: actions('onCloseIconClick'),
+  argTypes: {
+    ...actions('onCloseIconClick'),
+    closeOption: { options: ['none', 'button', 'no-button'], mapping: { none: false } },
+  },
 } as const
 
-type TagStory = Story<typeof Tag, { onCloseIconClick: Action<void> }>
+type TagStory = Story<typeof Tag, { onCloseIconClick: Action<React.MouseEvent> }>
 export const WithCloseOption: TagStory = ({ closeOption, onCloseIconClick }) => {
   const [values, setValues] = React.useState(options)
 
-  const deleteTag = (id: string) =>
-    closeOption
-      ? onCloseIconClick.wrap(() => setValues(values.filter((e) => e.id !== id)))
-      : undefined
+  const onClose = (event: React.MouseEvent) => {
+    const removeId = event.currentTarget.getAttribute('aria-controls')
+    setValues(values.filter((v) => v.id !== removeId))
+  }
+  const deleteTag = closeOption ? onCloseIconClick.wrap(onClose) : undefined
   return (
     <Flex justifyContent="center" alignItems="flex-start" flexDirection="column">
       <div>
         {values.map((e) => (
-          <Tag closeOption={closeOption} id={e.id} key={e.id} onCloseIconClick={deleteTag(e.id)}>
+          <Tag closeOption={closeOption} id={e.id} key={e.id} onCloseIconClick={deleteTag}>
             {e.label}
           </Tag>
         ))}
@@ -53,5 +57,5 @@ export const WithCloseOption: TagStory = ({ closeOption, onCloseIconClick }) => 
     </Flex>
   )
 }
-WithCloseOption.args = { closeOption: true }
+WithCloseOption.args = { closeOption: 'button' }
 WithCloseOption.storyName = 'With close option'

--- a/modules/cactus-web/src/Tag/Tag.test.tsx
+++ b/modules/cactus-web/src/Tag/Tag.test.tsx
@@ -14,18 +14,32 @@ describe('component: Tag', () => {
 
     expect(getByText('Test label')).toBeInTheDocument()
   })
-  test('Close icon is present', () => {
-    const onClick = jest.fn()
+
+  test('Close button is present', () => {
     const { container } = render(
       <StyleProvider>
-        <Tag closeOption onCloseIconClick={onClick}>
+        <Tag id="tag-one" closeOption>
           Test label
         </Tag>
       </StyleProvider>
     )
 
-    const icon = container.querySelector('svg')
-    expect(icon).toHaveAttribute('data-role', 'close')
+    const icon = container.querySelector('button')
+    expect(icon).toHaveAttribute('aria-controls', 'tag-one')
+  })
+
+  test('Close icon is present', () => {
+    const { container } = render(
+      <StyleProvider>
+        <Tag id="tag-one" closeOption="no-button">
+          Test label
+        </Tag>
+      </StyleProvider>
+    )
+
+    const icon = container.querySelector('span[aria-controls]')
+    expect(icon).toHaveAttribute('aria-controls', 'tag-one')
+    expect(icon).toHaveAttribute('aria-label', 'close')
   })
 
   test('Close icon is not present', () => {

--- a/modules/cactus-web/src/Tag/Tag.tsx
+++ b/modules/cactus-web/src/Tag/Tag.tsx
@@ -1,16 +1,17 @@
 import { NavigationClose } from '@repay/cactus-icons'
-import { TextStyle } from '@repay/cactus-theme'
+import { color, colorStyle, lineHeight, radius, space, textStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { CSSObject, FlattenSimpleInterpolation } from 'styled-components'
+import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { radius, textStyle } from '../helpers/theme'
+import { IconButton } from '../IconButton/IconButton'
 
+const closeTypes = ['no-button', 'button'] as const
 interface TagProps extends MarginProps, React.HTMLAttributes<HTMLSpanElement> {
-  closeOption?: boolean
+  closeOption?: boolean | typeof closeTypes[number]
   children: React.ReactNode
-  onCloseIconClick?: () => void
+  onCloseIconClick?: React.MouseEventHandler<HTMLElement>
 }
 
 const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
@@ -18,8 +19,17 @@ const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
     return (
       <span ref={ref} {...props}>
         <span className="value-tag__label">{children}</span>
-        {(closeOption || typeof onCloseIconClick === 'function') && (
-          <NavigationClose data-role="close" onClick={onCloseIconClick} />
+        {(!!closeOption || typeof onCloseIconClick === 'function') && (
+          <IconButton
+            as={closeOption === 'no-button' ? 'span' : undefined}
+            iconSize="tiny"
+            marginLeft="12px"
+            aria-label="close"
+            aria-controls={props.id}
+            onClick={onCloseIconClick}
+          >
+            <NavigationClose />
+          </IconButton>
         )}
       </span>
     )
@@ -27,40 +37,32 @@ const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
 )
 
 export const Tag = styled(TagBase)`
-  ${(p) => p.theme.colorStyles.standard};
+  ${colorStyle('standard')};
   box-sizing: border-box;
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'small')};
-  padding: 0 8px 0 8px;
-  border: 1px solid ${(p): string => p.theme.colors.lightContrast};
+  ${textStyle('small')};
+  padding: 0 ${space(3)};
+  border: 1px solid ${color('lightContrast')};
   border-radius: ${radius(8)};
-  margin-right: 2px;
+  margin-right: ${space(1)};
   display: inline-block;
-  height: 24px;
-  ${(p): CSSObject | undefined => (p.hidden ? { visibility: 'hidden' } : undefined)}
-
-  ${NavigationClose} {
-    appearance: none;
-    cursor: pointer;
-    background-color: transparent;
-    border: none;
-    font-size: 8px;
+  ${(p) => p.hidden && 'visibility: hidden;'}
+  ${lineHeight('small', 'height')};
+  ${IconButton} {
     padding: 4px;
-    margin-left: 12px;
-    vertical-align: -3px;
   }
+
   ${margin}
 `
 
 Tag.propTypes = {
   id: PropTypes.string,
-  closeOption: PropTypes.bool,
+  closeOption: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(closeTypes)]),
   children: PropTypes.node.isRequired,
   hidden: PropTypes.bool,
   onCloseIconClick: PropTypes.func,
 }
 
 Tag.defaultProps = {
-  id: 'tag-id',
   closeOption: false,
   hidden: false,
 }


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-738

I kind of recycled the `closeOption` prop for setting it to not be a button, since the name seemed to fit, and I could add an option to it while still being backwards compatible. Other changes:

- Fixed some prop types, including removing a completely redundant one from `IconButton`.
- Removed the `data-role="close"` prop, which seems to have been basically a hack to make implementing the `Select` component easier.
- In its place, added the `aria-controls` prop; fulfills basically the same purpose in terms of CSS queries, but also gives an easier reference to the tag, making it easier to share a single handler for multiple tags.

IE sucks as usual.