### PR TITLE
CACTUS-755 :: DateInput initialFocus

### DIFF
--- a/modules/cactus-web/src/Calendar/Grid.tsx
+++ b/modules/cactus-web/src/Calendar/Grid.tsx
@@ -13,19 +13,20 @@ import { useValue } from '../helpers/react'
 
 export type CalendarDate = string | Date
 export type CalendarValue = CalendarDate | string[] | Date[] | null
+export type InitialFocus =
+  | CalendarDate
+  | {
+      year?: number
+      month?: number
+      day?: number
+    }
 interface WeekdayLabel {
   long: string
   short: string
 }
 
 export interface FocusProps {
-  initialFocus?:
-    | CalendarDate
-    | {
-        year?: number
-        month?: number
-        day?: number
-      }
+  initialFocus?: InitialFocus
   month?: number
   year?: number
 }

--- a/modules/cactus-web/src/DateInput/DateInput.test.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.test.tsx
@@ -141,6 +141,44 @@ describe('component: DateInput', (): void => {
       expect(getByLabelText('day of month')).toHaveProperty('value', '')
     })
 
+    test.each([
+      { initFocus: '2019-09-16', repr: 'string' },
+      { initFocus: new Date(2019, 8, 16), repr: 'date' },
+      { initFocus: { year: 2019, month: 8, day: 16 }, repr: 'object' },
+    ])('Initially focus a date using $repr', async ({ initFocus }) => {
+      const { getByLabelText, getByRole } = render(
+        <StyleProvider>
+          <DateInput name="date-input" id="date-input" initialFocus={initFocus} />
+        </StyleProvider>
+      )
+
+      userEvent.click(getByLabelText('Open date picker'))
+
+      await animationRender()
+
+      expect(getByRole('button', { name: 'September' })).toBeInTheDocument()
+      expect(getByRole('button', { name: '2019' })).toBeInTheDocument()
+      expect(getByLabelText('Monday, September 16, 2019')).toHaveFocus()
+    })
+
+    test('Ignore initialFocus if value is already set', async () => {
+      const value = new Date(2022, 2, 3)
+      const initFocus = new Date(2019, 8, 16)
+      const { getByLabelText, getByRole } = render(
+        <StyleProvider>
+          <DateInput name="date-input" id="date-input" value={value} initialFocus={initFocus} />
+        </StyleProvider>
+      )
+
+      userEvent.click(getByLabelText('Open date picker'))
+
+      await animationRender()
+
+      expect(getByRole('button', { name: 'March' })).toBeInTheDocument()
+      expect(getByRole('button', { name: '2022' })).toBeInTheDocument()
+      expect(getByLabelText('Thursday, March 3, 2022')).toHaveFocus()
+    })
+
     test('Ignores value prop when NaN', () => {
       const { getByLabelText, rerender } = render(
         <StyleProvider>

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -11,7 +11,7 @@ import styled from 'styled-components'
 import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import Calendar, { CalendarLabels, MonthChange } from '../Calendar/Calendar'
-import { CalendarDate, CalendarValue } from '../Calendar/Grid'
+import { CalendarDate, CalendarValue, InitialFocus } from '../Calendar/Grid'
 import Flex from '../Flex/Flex'
 import FocusLock from '../FocusLock/FocusLock'
 import { keyDownAsClick, preventAction } from '../helpers/a11y'
@@ -342,6 +342,7 @@ export interface DateInputProps
   /** When */
   value?: string | Date | null | number
   defaultValue?: string | Date | null
+  initialFocus?: InitialFocus
   /**
    * Required when value is a string, then when events are called with the value they will be
    * this format. Date will always be displayed based on locale preferences.
@@ -437,6 +438,11 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
     id: PropTypes.string.isRequired,
     status: StatusPropType,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.instanceOf(Date)]),
+    initialFocus: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.instanceOf(Date),
+      PropTypes.shape({ year: PropTypes.number, month: PropTypes.number, day: PropTypes.number }),
+    ]),
     format: function (props: any): Error | null {
       if (props.format) {
         if (typeof props.format !== 'string') {
@@ -876,6 +882,7 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
       type,
       isValidDate,
       disabled,
+      initialFocus,
     } = this.props
     const formatArray = parseFormat(value.getLocaleFormat())
     let isFirstInput = true
@@ -959,9 +966,10 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
             onKeyDown={this.handlePortalKeydown}
           >
             <PopupCalendar
-              month={this.state.focusMonth}
-              year={this.state.focusYear}
+              month={selectedValue ? this.state.focusMonth : undefined}
+              year={selectedValue ? this.state.focusYear : undefined}
               value={selectedValue}
+              initialFocus={initialFocus}
               onChange={this.handleCalendarChange}
               onMonthChange={this.handleMonthYearChange}
               disabled={disabled}


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-755

### Testing

1. Open the `DateInput` "Basic Usage" story and open up the calendar. Make sure it initially focuses on the current day.
2. Now use the `initialFocus` control to set a date to initially focus on. Open the calendar and make sure the correct date is focused.
3. Set a value in the `DateInput`, then open the calendar again (keeping the `initalFocus` value) and make sure the value you set is initially focused instead of the date in the `initialFocus` prop.