### PR TITLE
CACTUS-753: fix styled-system `propTypes`

### DIFF
--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -147,10 +147,9 @@ export const Alert = styled(AlertBase).withConfig(
   }
 `
 
-// @ts-ignore
 Alert.propTypes = {
-  status: PropTypes.oneOf(['error', 'warning', 'info', 'success']),
-  type: PropTypes.oneOf(['general', 'push']),
+  status: PropTypes.oneOf<Status>(['error', 'warning', 'info', 'success']),
+  type: PropTypes.oneOf<Type>(['general', 'push']),
   onClose: PropTypes.func,
   className: PropTypes.string,
   children: PropTypes.node,

--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -241,8 +241,6 @@ ButtonFR.propTypes = {
   inverse: PropTypes.bool,
   loading: PropTypes.bool,
   loadingText: PropTypes.string,
-  // @ts-ignore
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
 }
 
 ButtonFR.defaultProps = {

--- a/modules/cactus-web/src/Flex/Flex.tsx
+++ b/modules/cactus-web/src/Flex/Flex.tsx
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components'
 import { flexbox, FlexboxProps } from 'styled-system'
 
 import { Box, BoxProps } from '../Box/Box'
+import { isIE } from '../helpers/constants'
 
 interface FlexBoxProps extends BoxProps, Omit<FlexboxProps, 'justifySelf'> {}
 
@@ -22,8 +23,8 @@ export const Flex = styled(Box)<FlexBoxProps>`
   display: flex;
   ${flexbox}
 
-  ${(p): ReturnType<typeof css> | undefined => {
-    if (p.justifyContent === 'space-evenly' && /MSIE|Trident/.test(window.navigator.userAgent)) {
+  ${(p) => {
+    if (isIE && p.justifyContent === 'space-evenly') {
       return css`
         justify-content: space-between;
         &:before,
@@ -40,19 +41,17 @@ Flex.defaultProps = {
   flexWrap: 'wrap',
 }
 
+function styledProp<T>(...allowed: T[]) {
+  const propType = PropTypes.oneOf<T>(allowed).isRequired
+  return PropTypes.oneOfType([propType, PropTypes.arrayOf(propType)])
+}
+
 Flex.propTypes = {
   justifyContent: PropTypes.oneOf(justifyOptions),
-  alignItems: PropTypes.oneOf(['unset', 'flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
-  alignSelf: PropTypes.oneOf(['unset', 'flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
-  flexWrap: PropTypes.oneOf(['unset', 'inherit', 'wrap', 'nowrap', 'wrap-reverse']),
-  flexDirection: PropTypes.oneOf([
-    'unset',
-    'inherit',
-    'row',
-    'row-reverse',
-    'column',
-    'column-reverse',
-  ]),
+  alignItems: styledProp('unset', 'flex-start', 'flex-end', 'center', 'baseline', 'stretch'),
+  alignSelf: styledProp('unset', 'flex-start', 'flex-end', 'center', 'baseline', 'stretch'),
+  flexWrap: styledProp('unset', 'inherit', 'wrap', 'nowrap', 'wrap-reverse'),
+  flexDirection: styledProp('unset', 'inherit', 'row', 'row-reverse', 'column', 'column-reverse'),
 }
 
 export default Flex

--- a/modules/cactus-web/src/Spinner/Spinner.tsx
+++ b/modules/cactus-web/src/Spinner/Spinner.tsx
@@ -1,6 +1,4 @@
 import { StatusSpinner as SpinnerBase } from '@repay/cactus-icons'
-import PropTypes from 'prop-types'
-import * as React from 'react'
 import styled, { keyframes } from 'styled-components'
 
 const rotate = keyframes`
@@ -13,21 +11,9 @@ const rotate = keyframes`
   }
 `
 
-interface Props extends Omit<React.ComponentPropsWithRef<typeof SpinnerBase>, 'iconSize'> {
-  iconSize?: 'tiny' | 'small' | 'medium' | 'large' | string
-}
-
-export const Spinner = styled(SpinnerBase as React.FC<Props>)`
+export const Spinner = styled(SpinnerBase)`
   animation: ${rotate} 0.75s linear infinite;
 `
-
-// @ts-ignore
-Spinner.propTypes = {
-  iconSize: PropTypes.oneOfType([
-    PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
-    PropTypes.string,
-  ]),
-}
 
 Spinner.defaultProps = {
   iconSize: 'large',

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -250,7 +250,6 @@ Table.propTypes = {
   fullWidth: PropTypes.bool,
   cardBreakpoint: PropTypes.oneOf<Size>(['tiny', 'small', 'medium', 'large', 'extraLarge']),
   variant: PropTypes.oneOf<TableVariant>(['table', 'card', 'mini']),
-  as: PropTypes.elementType as PropTypes.Validator<React.ElementType>,
 }
 
 Table.defaultProps = {

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -6,6 +6,7 @@ import { compose, height, HeightProps, margin, MarginProps, width, WidthProps } 
 
 import { omitMargins } from '../helpers/omit'
 import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
+import { styledProp } from '../helpers/styled'
 
 type AreaElementProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'height' | 'width'>
 export interface TextAreaProps extends AreaElementProps, MarginProps, HeightProps, WidthProps {
@@ -82,8 +83,8 @@ export const TextArea = styled(TextAreaBase)`
 TextArea.propTypes = {
   disabled: PropTypes.bool,
   status: StatusPropType,
-  width: PropTypes.string,
-  height: PropTypes.string,
+  width: styledProp,
+  height: styledProp,
   resize: PropTypes.bool,
 }
 


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-753

`Flex`, `Spinner`, and `TextArea` were the only ones I found that currently had this issue. There were quite a few places, though, where we _could_ be using `styled-system` to implement responsive styles, but are not; I'll probably go through them one of these days and make some tickets.

`justifyContent` is a special case, unfortunately, as long as we have to support IE. I did try to make a responsive version of the fix, but unlike regular styles, the `::before` and `::after` pseudo-elements don't just disappear as they're overridden.

I added a couple of other minor Typescript fixes and removed some propTypes for the `as` prop, which I think were probably incorrect and almost certainly pointless.