### PR TITLE
cactus-898:: set prop type nooptionstext select

### DIFF
--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -111,7 +111,7 @@ function willTruncateBlockShow(
 
 const ValueSwitch = (props: {
   selected: ExtendedOptionType[]
-  placeholder: React.ReactNode | undefined
+  placeholder?: React.ReactNode
   extraLabel: string
   multiple?: boolean
   onTagClick: React.MouseEventHandler<HTMLElement>

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -62,19 +62,22 @@ type Target = CactusEventTarget<SelectValueType>
 export interface SelectProps
   extends MarginProps,
     WidthProps,
-    Omit<React.HTMLAttributes<HTMLButtonElement>, 'onChange' | 'onBlur' | 'onFocus'> {
+    Omit<
+      React.HTMLAttributes<HTMLButtonElement>,
+      'onChange' | 'onBlur' | 'onFocus' | 'placeholder'
+    > {
   options?: (OptionType | OptionValue)[]
   id: string
   name: string
   value?: SelectValueType
-  placeholder?: string
+  placeholder?: React.ReactNode
   className?: string
   /** !important */
   disabled?: boolean
   multiple?: boolean
   comboBox?: boolean
   canCreateOption?: boolean
-  matchNotFoundText?: string
+  matchNotFoundText?: React.ReactNode
   comboBoxSearchLabel?: string
   onDropdownToggle?: (prop: boolean) => void
   noOptionsText?: React.ReactNode
@@ -503,7 +506,7 @@ interface ListProps {
   isOpen: boolean
   comboBox?: boolean
   canCreateOption: boolean
-  matchNotFoundText: string
+  matchNotFoundText: React.ReactNode
   comboBoxSearchLabel: string
   options: ExtendedOptionType[]
   getSelected: GetSelectedCallback
@@ -1625,19 +1628,19 @@ Select.propTypes = {
     PropTypes.number,
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
   ]),
-  placeholder: PropTypes.string,
+  placeholder: PropTypes.node,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   multiple: PropTypes.bool,
   comboBox: PropTypes.bool,
   canCreateOption: PropTypes.bool,
-  matchNotFoundText: PropTypes.string,
+  matchNotFoundText: PropTypes.node,
   extraLabel: PropTypes.string,
   status: StatusPropType,
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
-  noOptionsText: PropTypes.node,
+  noOptionsText: PropTypes.string,
   children: function (props: Record<string, any>): Error | null {
     if (props.children && props.options) {
       return new Error('Should use `options` prop OR pass children, not both')

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -77,7 +77,7 @@ export interface SelectProps
   matchNotFoundText?: string
   comboBoxSearchLabel?: string
   onDropdownToggle?: (prop: boolean) => void
-  noOptionsText?: string
+  noOptionsText?: React.ReactNode
   /**
    * Used when there are multiple selected, but too many to show. place '{}' to insert unshown number in label
    */
@@ -108,7 +108,7 @@ function willTruncateBlockShow(
 
 const ValueSwitch = (props: {
   selected: ExtendedOptionType[]
-  placeholder: string | undefined
+  placeholder: React.ReactNode
   extraLabel: string
   multiple?: boolean
   onTagClick: React.MouseEventHandler<HTMLElement>
@@ -1637,7 +1637,7 @@ Select.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
-  noOptionsText: PropTypes.string,
+  noOptionsText: PropTypes.node,
   children: function (props: Record<string, any>): Error | null {
     if (props.children && props.options) {
       return new Error('Should use `options` prop OR pass children, not both')

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -1640,7 +1640,7 @@ Select.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
-  noOptionsText: PropTypes.string,
+  noOptionsText: PropTypes.node,
   children: function (props: Record<string, any>): Error | null {
     if (props.children && props.options) {
       return new Error('Should use `options` prop OR pass children, not both')

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -108,7 +108,7 @@ function willTruncateBlockShow(
 
 const ValueSwitch = (props: {
   selected: ExtendedOptionType[]
-  placeholder: React.ReactNode
+  placeholder: React.ReactNode | undefined
   extraLabel: string
   multiple?: boolean
   onTagClick: React.MouseEventHandler<HTMLElement>


### PR DESCRIPTION
Ticket: https://repayonline.atlassian.net/browse/CACTUS-898

I updated the prop type for noOptionsText as well as `placeholder` (They get used in the same place so they should be the same type), and as per a conversation with glen, `matchNotFoundText` because it should be a node too for the same reason as `noOptionsText`.