### PR TITLE
fix(cactus-web): fix event handling on touch screens

### DIFF
--- a/modules/cactus-web/src/Calendar/Slider.tsx
+++ b/modules/cactus-web/src/Calendar/Slider.tsx
@@ -456,6 +456,7 @@ const Slider = ({
 const StyledSlider = styled.div<{ $offset: number }>`
   overflow: hidden;
   background-color: ${color('lightContrast')};
+  touch-action: none;
 
   .slider {
     display: flex;


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-454

Apparently touch screens cancel pointer events after a short delay for some reason beyond the ken of mere mortals like me. Fortunately the spec writers weren't complete morons and provided a simple way to restore logical functionality.

### UAT
Chrome-based browser devtools have a touch-screen simulator that I used to reproduce & fix the issue (not sure how to get dev code running on an actual mobile device). Firefox supposedly has something similar, but it didn't reproduce the bug so it can't be used to validate the fix.