### PR TITLE
CACTUS-899: use snyk cli to monitor repo

### DIFF
--- a/.github/workflows/snyk-scan.yml
+++ b/.github/workflows/snyk-scan.yml
@@ -1,0 +1,17 @@
+name: Snyk Scan
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+jobs:
+  scan-if-merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Snyk
+        uses: ./actions/snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/actions/snyk/action.yml
+++ b/actions/snyk/action.yml
@@ -1,0 +1,18 @@
+name: "Snyk"
+description: "Copied from github.com/snyk/actions because we can't use 3rd party actions in our repos"
+author: "Gareth Rushgrove"
+branding:
+  icon: "alert-triangle"
+  color: "yellow"
+runs:
+  using: "docker"
+  image: "docker://snyk/snyk:node"
+  env:
+    FORCE_COLOR: 2
+    SNYK_INTEGRATION_NAME: GITHUB_ACTIONS
+    SNYK_INTEGRATION_VERSION: node
+  args:
+  - snyk
+  - monitor
+  - '--all-projects'
+  - '--org=ui-wy8'


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-899

I tested the action and it works, but we won't know if the "on merge" condition works till we merge this PR. For now I just set the `SNYK_TOKEN` to my personal token, we can switch that out at any time.

Here's the successful run: https://github.com/repaygithub/cactus/actions/runs/2430326793