### PR TITLE
CACTUS-926 React 18 Compatibility Updates

### DIFF
--- a/examples/mock-ebpp/src/components/FieldsAccordion.tsx
+++ b/examples/mock-ebpp/src/components/FieldsAccordion.tsx
@@ -3,6 +3,7 @@ import { Accordion, Flex, IconButton, Text } from '@repay/cactus-web'
 import React, { FunctionComponent } from 'react'
 
 interface FieldsAccordionProps {
+  children?: React.ReactNode
   index: number
   lastIndex: number
   header: string

--- a/examples/theme-components/src/containers/Flex.tsx
+++ b/examples/theme-components/src/containers/Flex.tsx
@@ -2,7 +2,7 @@ import { RouteComponentProps } from '@reach/router'
 import NavigationChevronLeft from '@repay/cactus-icons/i/navigation-chevron-left'
 import { Flex, SelectField, Text } from '@repay/cactus-web'
 import { Property } from 'csstype'
-import React, { useCallback, useState } from 'react'
+import React, { useState } from 'react'
 
 import Link from '../components/Link'
 
@@ -46,15 +46,14 @@ const initialState = {
 const FlexExample: React.FC<RouteComponentProps> = (): React.ReactElement => {
   const [state, setState] = useState(initialState)
 
-  const changeProps = useCallback(
-    ({ target: { name, value } }): void => {
-      if (name === 'items') {
-        value = parseInt(value.replace(/\D/g, ''), 10)
-      }
-      setState({ ...state, [name]: value })
-    },
-    [state]
-  )
+  const changeProps = ({
+    target: { name, value },
+  }: React.ChangeEvent<{ name?: any; value: any }>) => {
+    if (name === 'items') {
+      value = parseInt(value.replace(/\D/g, ''), 10)
+    }
+    setState({ ...state, [name]: value })
+  }
 
   return (
     <div style={{ height: '100%' }}>

--- a/examples/theme-components/src/containers/Grid.tsx
+++ b/examples/theme-components/src/containers/Grid.tsx
@@ -1,7 +1,7 @@
 import { RouteComponentProps } from '@reach/router'
 import NavigationChevronLeft from '@repay/cactus-icons/i/navigation-chevron-left'
 import { Box, Flex, Grid, SelectField, Text } from '@repay/cactus-web'
-import React, { useCallback, useState } from 'react'
+import React, { useState } from 'react'
 
 import Link from '../components/Link'
 
@@ -18,12 +18,11 @@ const initialState = {
 const GridExample: React.FC<RouteComponentProps> = (): React.ReactElement => {
   const [state, setState] = useState(initialState)
 
-  const changeState = useCallback(
-    ({ target: { name, value } }): void => {
-      setState({ ...state, [name]: value as ColumnNum })
-    },
-    [state]
-  )
+  const changeState = ({
+    target: { name, value },
+  }: React.ChangeEvent<{ name?: any; value: any }>) => {
+    setState({ ...state, [name]: value as ColumnNum })
+  }
   return (
     <Flex flexDirection="column" height="100%">
       <Link to="/">

--- a/examples/theme-components/src/containers/IconButton.tsx
+++ b/examples/theme-components/src/containers/IconButton.tsx
@@ -32,12 +32,11 @@ const IconbuttonExample: React.FC<RouteComponentProps> = (): React.ReactElement 
     minHeight: '100vh',
   }
 
-  const changeVariant = useCallback(
-    ({ target: { name, value } }): void => {
-      setState({ ...state, [name]: value })
-    },
-    [state]
-  )
+  const changeVariant = ({
+    target: { name, value },
+  }: React.ChangeEvent<{ name?: any; value: any }>) => {
+    setState({ ...state, [name]: value })
+  }
   const onToggleChange = useCallback(({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState((s) => ({ ...s, [target.name]: target.checked }))
   }, [])

--- a/modules/cactus-fwk/src/AppRoot.tsx
+++ b/modules/cactus-fwk/src/AppRoot.tsx
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
-import React, { WeakValidationMap } from 'react'
+import React from 'react'
 
 import { ErrorBoundary, ErrorView, OnError } from './ErrorBoundary'
 import { FeatureFlagContext } from './featureFlags'
 import { FeatureFlagsObject } from './types'
 
 interface AppRootProps {
+  children?: React.ReactNode
   /**
    * Receives an object for featureFlags
    */
@@ -24,20 +25,19 @@ const noop = (): void => {
   return
 }
 
-const AppRoot: React.FC<AppRootProps> = (props): React.ReactElement => {
-  return (
-    <ErrorBoundary onError={props.onError || noop} errorView={props.globalErrorView}>
-      <FeatureFlagContext.Provider value={props.featureFlags || null}>
-        <React.Fragment>{props.children}</React.Fragment>
-      </FeatureFlagContext.Provider>
-    </ErrorBoundary>
-  )
-}
+const AppRoot: React.FC<AppRootProps> = (props) => (
+  <ErrorBoundary onError={props.onError || noop} errorView={props.globalErrorView}>
+    <FeatureFlagContext.Provider value={props.featureFlags || null}>
+      {props.children}
+    </FeatureFlagContext.Provider>
+  </ErrorBoundary>
+)
 
 AppRoot.propTypes = {
   featureFlags: PropTypes.objectOf(PropTypes.bool.isRequired),
   onError: PropTypes.func,
-  globalErrorView: PropTypes.element,
-} as WeakValidationMap<AppRootProps>
+  // Technically shouldn't allow strings, but I don't think it's worth a custom function.
+  globalErrorView: PropTypes.elementType as any,
+}
 
 export default AppRoot

--- a/modules/cactus-fwk/src/ErrorBoundary.tsx
+++ b/modules/cactus-fwk/src/ErrorBoundary.tsx
@@ -10,6 +10,7 @@ interface ErrorViewProps {
 }
 
 interface ErrorBoundaryProps {
+  children?: React.ReactNode
   onError: OnError
   errorView?: ErrorView
 }
@@ -26,19 +27,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
 
   public static propTypes = {
     onError: PropTypes.func.isRequired,
-    errorView: (
-      props: { [k: string]: any },
-      propName: string,
-      componentName: string
-    ): Error | null => {
-      const prop = props[propName]
-      if (prop !== undefined && typeof prop !== 'string' && typeof prop !== 'function') {
-        return new Error(
-          `The prop \`${propName}\` is marked as a component type in \`${componentName}\` but its type is \`${typeof prop}\`.`
-        )
-      }
-      return null
-    },
+    errorView: PropTypes.elementType,
   }
 
   public componentDidCatch(error: Error | null, info: ErrorInfo | null): void {
@@ -76,7 +65,7 @@ const withErrorBoundary = <BaseProps extends Record<string, any>>(
     throw new Error('You must pass the `onError` prop when using `withErrorBoundary`!')
   }
 
-  const Wrapped = (props: React.PropsWithChildren<BaseProps>): ReactElement => (
+  const Wrapped = (props: BaseProps): ReactElement => (
     <ErrorBoundary onError={onError} errorView={errorView}>
       <BaseComponent {...props} />
     </ErrorBoundary>

--- a/modules/cactus-icons/tests/svgs.test.tsx
+++ b/modules/cactus-icons/tests/svgs.test.tsx
@@ -1,6 +1,7 @@
-import { StyleProvider } from '@repay/cactus-web'
+import cactusTheme from '@repay/cactus-theme'
 import { render } from '@testing-library/react'
 import React from 'react'
+import { ThemeProvider } from 'styled-components'
 
 import icons from '../ts'
 
@@ -8,9 +9,9 @@ const iconEntries = Object.entries(icons)
 
 test.each(iconEntries)('renders %s', (_, Component): void => {
   const { asFragment } = render(
-    <StyleProvider>
+    <ThemeProvider theme={cactusTheme}>
       <Component />
-    </StyleProvider>
+    </ThemeProvider>
   )
   expect(asFragment()).toMatchSnapshot()
 })

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -140,14 +140,12 @@ function AccessibleFieldBase(props: InnerProps) {
   const [forceTooltipVisible, setTooltipVisible] = React.useState<boolean>(false)
 
   const [maxWidth, setMaxWidth] = React.useState<string | undefined>(undefined)
-  React.useLayoutEffect((): void => {
+  React.useLayoutEffect(() => {
     if (ref.current instanceof HTMLElement) {
       const containerWidth = `${ref.current.getBoundingClientRect().width - 32}px`
-      if (containerWidth !== maxWidth) {
-        setMaxWidth(containerWidth)
-      }
+      setMaxWidth(containerWidth)
     }
-  }, [maxWidth, setMaxWidth])
+  }, [])
 
   const handleFieldBlur = (e: React.FocusEvent<HTMLDivElement>) => {
     onBlur?.(e)

--- a/modules/cactus-web/src/ActionBar/ActionBar.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.tsx
@@ -25,7 +25,7 @@ const stylePropNames: string[] = layout.propNames.concat(padding.propNames)
 
 type RenderFn = (t: TogglePopup, expanded: boolean) => React.ReactElement | null
 
-interface PanelProps extends StyleProps, React.HTMLAttributes<HTMLElement> {
+interface PanelProps extends StyleProps, Omit<React.HTMLAttributes<HTMLElement>, 'children'> {
   icon: React.ReactElement
   orderHint?: OrderHint
   popupType?: PopupType
@@ -66,7 +66,6 @@ const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
     })
     const buttonRef = React.useRef<HTMLButtonElement>(null)
 
-    const render = typeof children === 'function' ? (children as RenderFn) : null
     const styleProps = pick(props, stylePropNames) as StyleProps
     // Mostly expecting the label props, but I'm not going to attempt a comprehensive whitelist.
     const ariaProps: React.AriaAttributes = {}
@@ -80,6 +79,8 @@ const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
       }
     }
 
+    const childNode =
+      typeof children === 'function' ? (children as RenderFn)(toggle, expanded) : children
     return (
       <ActionBar.PanelWrapper {...wrapperProps} ref={ref}>
         <ActionBar.Button {...ariaProps} {...buttonProps} ref={buttonRef}>
@@ -91,7 +92,7 @@ const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
           position={positionPopup}
           anchorRef={buttonRef}
         >
-          {render ? render(toggle, expanded) : children}
+          {childNode}
         </ActionBar.PanelPopup>
       </ActionBar.PanelWrapper>
     )

--- a/modules/cactus-web/src/ActionBar/ActionProvider.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionProvider.tsx
@@ -81,7 +81,7 @@ export function useActionBarItems(): React.ReactElement[] {
   return actionList.map((a) => a.element)
 }
 
-const ActionProvider: React.FC = ({ children }) => {
+const ActionProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [actions, setActions] = React.useState<ActionMap>({})
   const addAction: AddAction = (key, element, orderHint) => {
     if (element.key === null) {

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -84,9 +84,8 @@ const AlertBase = (props: AlertProps): React.ReactElement => {
 
   useEffect(() => {
     if (closeTimeout && typeof onClose === 'function') {
-      setTimeout(() => {
-        onClose()
-      }, closeTimeout)
+      const timeoutId = setTimeout(onClose, closeTimeout)
+      return () => clearTimeout(timeoutId)
     }
   }, [closeTimeout, onClose])
 

--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -35,6 +35,7 @@ interface ItemProps {
 }
 
 interface UserMenuProps {
+  children?: React.ReactNode
   id?: string
   isProfilePage?: boolean
   label: React.ReactNode

--- a/modules/cactus-web/src/Calendar/Calendar.tsx
+++ b/modules/cactus-web/src/Calendar/Calendar.tsx
@@ -15,16 +15,18 @@ import DropDown from './DropDown'
 import CalendarGrid, { CalendarGridLabels, CalendarValue, FocusProps, initGridState } from './Grid'
 import Slider, { SlideDirection, SliderProps } from './Slider'
 
-export interface CalendarLabels extends CalendarGridLabels {
-  calendarKeyboardDirections: React.ReactChild
-  prevMonth: React.ReactChild
-  nextMonth: React.ReactChild
-  showMonth: React.ReactChild
-  showYear: React.ReactChild
+interface CalendarNavLabels {
+  calendarKeyboardDirections?: React.ReactChild
+  prevMonth?: React.ReactChild
+  nextMonth?: React.ReactChild
+  showMonth?: React.ReactChild
+  showYear?: React.ReactChild
   months?: string[]
 }
 
-const DEFAULT_LABELS: CalendarLabels = {
+export interface CalendarLabels extends CalendarGridLabels, CalendarNavLabels {}
+
+const DEFAULT_LABELS: CalendarNavLabels = {
   calendarKeyboardDirections: 'Press space to choose the date',
   showMonth: 'Click to change month',
   showYear: 'Click to change year',
@@ -235,7 +237,7 @@ class CalendarBase extends React.Component<InnerCalendarProps, CalendarState> {
       onChange,
       onMonthChange,
       isValidDate,
-      labels = DEFAULT_LABELS,
+      labels = {},
       locale,
       children,
       ...rest
@@ -252,7 +254,7 @@ class CalendarBase extends React.Component<InnerCalendarProps, CalendarState> {
             <NavigationChevronLeft />
           </IconButton>
           <Flex>
-            {this.renderMonthDD(locale, labels.months)}
+            {this.renderMonthDD(locale, labels.months || DEFAULT_LABELS.months)}
             {this.renderYearDD()}
           </Flex>
           <IconButton
@@ -342,8 +344,8 @@ class CalendarBase extends React.Component<InnerCalendarProps, CalendarState> {
     return this._labelIDs[label] || (this._labelIDs[label] = generateId(label))
   }
 
-  renderLabels(labels: Partial<CalendarLabels>) {
-    const keys = Object.keys(this._labelIDs) as (keyof CalendarLabels)[]
+  renderLabels(labels: CalendarNavLabels) {
+    const keys = Object.keys(this._labelIDs) as (keyof CalendarNavLabels)[]
     return (
       <div hidden>
         {keys.map((key) => (

--- a/modules/cactus-web/src/Calendar/Grid.tsx
+++ b/modules/cactus-web/src/Calendar/Grid.tsx
@@ -278,12 +278,21 @@ const CalendarGridBase = ({
   const year = yearProp ?? state.year
   const month = monthProp ?? state.month
   const isSelected = useValue(makeIsSelected, selected, compareSelected)
+
+  // REACT18-COMPAT: when restoring state it will treat the initial render
+  // like an overflow if there's ever been one before, so we need to clear it.
+  // TODO Figure out a way to test if the offscreen API sets refs to null.
+  if (!gridRef.current && state.overflow) {
+    setOverflow(['', new Date(year, month, state.day)])
+  }
+
   // First effect: if we've just had an overflow event, refocus on the grid.
   React.useEffect(() => {
     if (gridRef.current && state.overflow) {
       queryDate(gridRef.current, state.overflow)?.focus()
     }
   }, [state.overflow])
+
   // Second effect: if the grid is not currently focused,
   // make sure there's exactly one gridcell with tabIndex == 0.
   React.useEffect(() => {
@@ -374,7 +383,6 @@ const CalendarGridBase = ({
   )
 }
 
-// TODO Figure out the right style for selected `.outside-date`
 const OUTLINE = { thin: '2px' }
 export const CalendarGrid = styled(CalendarGridBase)
   .withConfig(omitProps<CalendarGridProps>(margin))

--- a/modules/cactus-web/src/Calendar/Slider.tsx
+++ b/modules/cactus-web/src/Calendar/Slider.tsx
@@ -14,7 +14,11 @@ export interface SliderProps {
 
 const TIMEOUT = isIE ? 400 : 300
 
-const Slider: React.FC<SliderProps> = ({ transition, transitionKey, children }) => (
+const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
+  transition,
+  transitionKey,
+  children,
+}) => (
   <TransitionGroup component={SlideWrapper}>
     <CSSTransition key={transitionKey} timeout={TIMEOUT} classNames={transition}>
       {children}

--- a/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
+++ b/modules/cactus-web/src/CheckBoxGroup/CheckBoxGroup.tsx
@@ -6,6 +6,7 @@ import { Fieldset, makeGroup } from '../Checkable/Group'
 import CheckBoxField, { CheckBoxFieldProps } from '../CheckBoxField/CheckBoxField'
 
 interface CheckBoxGroupProps extends Omit<ExtFieldProps, 'role'> {
+  children?: React.ReactNode
   checked?: Record<string, any> // `any` instead of `boolean` to work better with form libs.
   required?: boolean
 }

--- a/modules/cactus-web/src/ConfirmModal/ConfirmModal.tsx
+++ b/modules/cactus-web/src/ConfirmModal/ConfirmModal.tsx
@@ -49,7 +49,7 @@ const getIconWidthAndHeight = ({ iconSize }: IconProps): '56px' | '88px' | undef
 const getFlexDirection = ({ iconSize }: ConfirmModalProps): 'row' | 'column' =>
   iconSize === 'medium' ? 'row' : 'column'
 
-const ConfirmModalBase: React.FunctionComponent<ConfirmModalProps> = ({
+const ConfirmModalBase: React.FC<ConfirmModalProps> = ({
   cancelButtonText,
   children,
   confirmButtonText,
@@ -60,7 +60,7 @@ const ConfirmModalBase: React.FunctionComponent<ConfirmModalProps> = ({
   variant,
   title,
   ...props
-}): React.ReactElement => {
+}) => {
   return (
     <Modal variant={variant} onClose={onClose} flexFlow {...props}>
       <Flex alignItems="center" className="title-icon">

--- a/modules/cactus-web/src/DataGrid/types.ts
+++ b/modules/cactus-web/src/DataGrid/types.ts
@@ -41,14 +41,16 @@ export interface PaginationOptions {
   pageCount?: number
 }
 
-export interface DataColumnProps extends Omit<TableCellProps, 'as' | 'title'> {
+type BaseColumnProps = Omit<TableCellProps, 'as' | 'children' | 'title'>
+
+export interface DataColumnProps extends BaseColumnProps {
   id: string
   title: React.ReactChild
   sortable?: boolean
   as?: React.ComponentType<any>
 }
 
-export interface ColumnProps extends Omit<TableCellProps, 'as' | 'title'> {
+export interface ColumnProps extends BaseColumnProps {
   children: ColumnFn
   title?: React.ReactChild
 }

--- a/modules/cactus-web/src/Header/Header.tsx
+++ b/modules/cactus-web/src/Header/Header.tsx
@@ -17,9 +17,7 @@ export type HeaderType = FC<HeaderProps> & {
   Description: typeof HeaderDescription
 }
 
-export const HeaderItem: FC<
-  React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>
-> = (props) => <div {...props} />
+export const HeaderItem: FC<HTMLAttributes<HTMLDivElement>> = (props) => <div {...props} />
 
 export const HeaderTitle: FC<React.ComponentProps<typeof Text>> = ({ children, ...props }) => (
   <Text as="h1" textStyle="h2" {...props}>
@@ -27,7 +25,9 @@ export const HeaderTitle: FC<React.ComponentProps<typeof Text>> = ({ children, .
   </Text>
 )
 
-export const HeaderBreadcrumbRow: FC = ({ children }) => <>{children}</>
+export const HeaderBreadcrumbRow: FC<{ children?: React.ReactNode }> = ({ children }) => (
+  <>{children}</>
+)
 
 export const HeaderDescription: FC<HTMLAttributes<HTMLDivElement>> = ({ children, ...rest }) => (
   <StyledDescription {...rest}>{children}</StyledDescription>

--- a/modules/cactus-web/src/List/List.tsx
+++ b/modules/cactus-web/src/List/List.tsx
@@ -18,6 +18,7 @@ interface ListItemProps extends React.HTMLAttributes<HTMLLIElement> {
 }
 
 interface ItemHeaderProps extends Omit<TextProps, 'color'> {
+  children?: React.ReactNode
   icon?: keyof typeof icons
   as?: React.ElementType<any>
 }

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -170,7 +170,7 @@ const CloseButton = styledWithClass(IconButton, 'modal-close-btn').withConfig(
     position: absolute;
     ${buttonPosition}
   }
-` as Styled<CloseButtonProps & { onClick: ModalProps['onClose'] }>
+` as Styled<CloseButtonProps & React.HTMLAttributes<HTMLButtonElement>>
 
 CloseButton.displayName = 'Modal.CloseButton'
 CloseButton.propTypes = { label: PropTypes.string.isRequired }

--- a/modules/cactus-web/src/Notification/Notification.tsx
+++ b/modules/cactus-web/src/Notification/Notification.tsx
@@ -14,6 +14,7 @@ export interface NotificationPositionProps {
 }
 
 interface NotificationProps extends NotificationPositionProps {
+  children?: React.ReactNode
   open: boolean
 }
 

--- a/modules/cactus-web/src/Notification/Provider.tsx
+++ b/modules/cactus-web/src/Notification/Provider.tsx
@@ -131,7 +131,7 @@ const NotificationRenderer = ({ store }: { store: NotificationStore }) => {
   return notifications.length ? <>{notifications}</> : null
 }
 
-export const NotificationProvider: React.FC = ({ children }) => {
+export const NotificationProvider: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const ref = React.useRef<NotificationStore>()
   const store = ref.current || (ref.current = new NotificationStore())
   return (

--- a/modules/cactus-web/src/Pagination/Pagination.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.tsx
@@ -104,7 +104,7 @@ function dots(key: string): ReactElement {
   )
 }
 
-const PageLinkBase: React.FC<PageLinkProps> = (props: PageLinkProps): ReactElement => {
+const PageLinkBase: React.FC<PageLinkProps> = (props) => {
   const { page, disabled, children, onClick, ...rest } = props
   const linkProps: React.AnchorHTMLAttributes<HTMLAnchorElement> = rest
   if (disabled) {

--- a/modules/cactus-web/src/PrevNext/PrevNext.tsx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.tsx
@@ -21,11 +21,7 @@ interface PrevNextLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement
   disabled: boolean
 }
 
-const PrevNextLinkBase: React.FC<PrevNextLinkProps> = ({
-  disabled,
-  onClick,
-  ...rest
-}): React.ReactElement => (
+const PrevNextLinkBase: React.FC<PrevNextLinkProps> = ({ disabled, onClick, ...rest }) => (
   <a
     role="link"
     aria-disabled={disabled ? 'true' : 'false'}
@@ -72,7 +68,7 @@ const PrevNextBase: React.FC<PrevNextProps> = ({
   prevText,
   nextText,
   ...rest
-}): React.ReactElement => (
+}) => (
   <div {...rest}>
     <PrevNextLink
       as={linkAs}

--- a/modules/cactus-web/src/Preview/Preview.tsx
+++ b/modules/cactus-web/src/Preview/Preview.tsx
@@ -46,6 +46,10 @@ export const Preview = React.forwardRef<HTMLDivElement, PreviewProps>(
     const phrases = { ...DEFAULT_PHRASES, ...passedPhrases }
 
     React.useEffect(() => {
+      // REACT18-COMPAT: This could theoretically cause issues when remounting,
+      // but I don't think it's likely give how focusing the image takes over
+      // the screen: any interaction likely to "hide" the component will also
+      // likely close the selected image.
       if (imageSelected) {
         closeButtonRef.current?.focus()
       }

--- a/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
+++ b/modules/cactus-web/src/RadioGroup/RadioGroup.tsx
@@ -6,6 +6,7 @@ import { Fieldset, makeGroup } from '../Checkable/Group'
 import RadioButtonField, { RadioButtonFieldProps } from '../RadioButtonField/RadioButtonField'
 
 interface RadioGroupProps extends Omit<ExtFieldProps, 'role'> {
+  children?: React.ReactNode
   value?: string | number
   defaultValue?: string | number
   required?: boolean

--- a/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.test.tsx
+++ b/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import renderWithTheme from '../../tests/helpers/renderWithTheme'
 import { ScreenSizeContext, ScreenSizeProvider, SIZES } from './ScreenSizeProvider'
 
-const Size: React.FC = (): React.ReactElement => {
+const Size: React.FC = () => {
   return (
     <ScreenSizeContext.Consumer>
       {(value): React.ReactElement => <span>{value.toString()}</span>}

--- a/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.tsx
+++ b/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.tsx
@@ -54,9 +54,7 @@ export const ScreenSizeContext = React.createContext<ScreenSize>(SIZES[DEFAULT_S
 
 export const useScreenSize = (): ScreenSize => React.useContext(ScreenSizeContext)
 
-export const ScreenSizeProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}): React.ReactElement => {
+export const ScreenSizeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [currentSize, setSize] = React.useState<Size>(DEFAULT_SIZE)
   const theme: CactusTheme = React.useContext(ThemeContext)
 

--- a/modules/cactus-web/src/SelectField/SelectField.tsx
+++ b/modules/cactus-web/src/SelectField/SelectField.tsx
@@ -15,7 +15,7 @@ interface SelectFieldProps extends WidthProps, FieldProps, Omit<SelectProps, 'id
 
 type SelectFieldType = React.FC<SelectFieldProps> & { Option: typeof Select.Option }
 
-const SelectFieldBase: SelectFieldType = (props): React.ReactElement => {
+const SelectFieldBase: SelectFieldType = (props) => {
   const {
     id,
     name,

--- a/modules/cactus-web/src/SplitButton/SplitButton.tsx
+++ b/modules/cactus-web/src/SplitButton/SplitButton.tsx
@@ -23,7 +23,7 @@ interface DropDownProps extends React.HTMLAttributes<HTMLElement> {
 interface SplitButtonProps extends React.HTMLAttributes<HTMLDivElement>, MarginProps {
   mainActionLabel: React.ReactNode
   onSelectMainAction: (event: React.MouseEvent<HTMLButtonElement>) => void
-  mainActionIcon?: React.FunctionComponent<IconProps>
+  mainActionIcon?: React.FC<IconProps>
   disabled?: boolean
   // Aria label for the dropdown trigger. Defaults to "Action List"
   'aria-label'?: string
@@ -33,7 +33,7 @@ interface SplitButtonProps extends React.HTMLAttributes<HTMLDivElement>, MarginP
 interface SplitButtonActionProps extends Omit<MenuItemProps, 'onSelect'> {
   // !important
   onSelect: () => any
-  icon?: React.FunctionComponent<IconProps>
+  icon?: React.FC<IconProps>
 }
 interface VariantInterface {
   variant?: SplitButtonVariant

--- a/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
+++ b/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
@@ -41,7 +41,7 @@ const iconMap: IconMap = {
 
 const Noop = (): null => null
 
-const StatusMessageBase: React.FC<StatusMessageProps> = (props): React.ReactElement => {
+const StatusMessageBase: React.FC<StatusMessageProps> = (props) => {
   const { status, className, children, ...rest } = omitMargins(props)
   const StatusIcon: React.ElementType<any> = iconMap[status as Status] || Noop
   return (

--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -30,9 +30,7 @@ interface TableContextProps {
   dividers?: boolean
 }
 
-interface TableProps
-  extends MarginProps,
-    React.DetailedHTMLProps<React.TableHTMLAttributes<HTMLTableElement>, HTMLTableElement> {
+interface TableProps extends MarginProps, React.TableHTMLAttributes<HTMLTableElement> {
   fullWidth?: boolean
   cardBreakpoint?: Size
   variant?: TableVariant
@@ -40,11 +38,7 @@ interface TableProps
   dividers?: boolean
 }
 
-interface TableHeaderProps
-  extends React.DetailedHTMLProps<
-    React.TableHTMLAttributes<HTMLTableSectionElement>,
-    HTMLTableSectionElement
-  > {
+interface TableHeaderProps extends React.TableHTMLAttributes<HTMLTableSectionElement> {
   variant?: TableVariant
   dividers?: boolean
 }
@@ -52,11 +46,8 @@ interface TableHeaderProps
 export interface TableCellProps
   extends WidthProps,
     Omit<
-      React.DetailedHTMLProps<
-        React.TdHTMLAttributes<HTMLTableDataCellElement> &
-          React.ThHTMLAttributes<HTMLTableHeaderCellElement>,
-        HTMLTableDataCellElement & HTMLTableHeaderCellElement
-      >,
+      React.TdHTMLAttributes<HTMLTableDataCellElement> &
+        React.ThHTMLAttributes<HTMLTableHeaderCellElement>,
       'width'
     > {
   variant?: TableVariant
@@ -64,15 +55,9 @@ export interface TableCellProps
   as?: CellType
 }
 
-type TableRowProps = React.DetailedHTMLProps<
-  React.TableHTMLAttributes<HTMLTableRowElement>,
-  HTMLTableRowElement
->
+type TableRowProps = React.TableHTMLAttributes<HTMLTableRowElement>
 
-type TableBodyProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLTableSectionElement>,
-  HTMLTableSectionElement
->
+type TableBodyProps = React.HTMLAttributes<HTMLTableSectionElement>
 
 const DEFAULT_CONTEXT: TableContextProps = {
   inHeader: false,

--- a/modules/cactus-web/src/Tabs/Tabs.tsx
+++ b/modules/cactus-web/src/Tabs/Tabs.tsx
@@ -35,6 +35,7 @@ interface TabPanelProps extends BoxProps, Omit<React.HTMLAttributes<HTMLElement>
 }
 
 interface TabControllerProps {
+  children?: React.ReactNode
   id?: string
   initialTabId?: string
 }

--- a/modules/cactus-web/src/helpers/react.ts
+++ b/modules/cactus-web/src/helpers/react.ts
@@ -171,9 +171,9 @@ export function useStateWithCallback<S>(
   return [state, setStateWithCallback]
 }
 
-const toggle = (x: boolean) => !x
+const inc = (x: number) => x + 1
 
-export const useRenderTrigger = (): (() => void) => React.useReducer(toggle, false)[1]
+export const useRenderTrigger = (): (() => void) => React.useReducer(inc, 0)[1]
 
 type SemiControlProps<T extends React.ElementType> = {
   input: T

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint \"**/*.{ts,tsx,js,jsx}\"",
     "fmt": "yarn lint --fix",
     "test": "yarn test:local",
+    "test:types": "yarn ws:run test:types",
     "test:ci": "yarn lint && yarn ws:run test:ci",
     "test:local": "yarn lint && yarn ws:run test:local",
     "test:sonar": "yarn fwk test --coverage && yarn i18n test --coverage && yarn form test --coverage && yarn icons test --coverage && yarn theme test --coverage && yarn web test --coverage",

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "build": "yarn prebuild && gatsby build --prefix-paths && yarn postbuild",
     "postbuild": "node tools/build-storybooks",
     "test": "tsc -p tsconfig.json --noEmit --skipLibCheck",
+    "test:types": "yarn test",
     "test:ci": "yarn test",
     "test:local": "yarn test"
   },


### PR DESCRIPTION
UAT: https://repayonline.atlassian.net/browse/CACTUS-926

Mostly type changes because they removed the automatic `children` prop from `FC` & the `Component` class. Then a couple of changes due to how unmount is no longer guaranteed to destroy state in React 18, and a couple of changes that aren't directly related but fit in with the theme of making `useEffect` hooks more symmetrical.

Note that I only found the bug in `I18nProvider` by coincidence, and though I checked for similar bugs and all known issues described in the React 18 upgrade docs, I can't guarantee there aren't more such bugs that I missed.

I strongly recommend you review commits individually, since most of them have additional information in the commit messages.