### PR TITLE
CACTUS-931 Fix prop forwarding

### DIFF
--- a/modules/cactus-icons/package.json
+++ b/modules/cactus-icons/package.json
@@ -61,7 +61,6 @@
     "testEnvironment": "jsdom"
   },
   "peerDependencies": {
-    "prop-types": ">=15.0.0",
     "react": "^16.8.3 || ^17.0.0",
     "styled-components": "^5.1.0"
   },
@@ -87,7 +86,6 @@
     "jest": "^27.5.1",
     "jest-sonar": "^0.2.12",
     "jest-styled-components": "^7.0.8",
-    "prop-types": "^15.8.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "styled-components": "^5.3.3",

--- a/modules/cactus-icons/scripts/post-build-ts.js
+++ b/modules/cactus-icons/scripts/post-build-ts.js
@@ -20,6 +20,7 @@ async function main() {
     "import * as icons from './icons'",
     "export * from './icons'",
     "export * from './types'",
+    "export { default as CactusIcon } from './CactusIcon'",
     "export { default as iconSizes } from './iconSizes'",
     'export default icons',
   ]

--- a/modules/cactus-icons/scripts/post-build-ts.js
+++ b/modules/cactus-icons/scripts/post-build-ts.js
@@ -20,7 +20,7 @@ async function main() {
     "import * as icons from './icons'",
     "export * from './icons'",
     "export * from './types'",
-    "export { default as CactusIcon } from './CactusIcon'",
+    "export { default as AbstractIcon } from './AbstractIcon'",
     "export { default as iconSizes } from './iconSizes'",
     'export default icons',
   ]

--- a/modules/cactus-icons/scripts/svgr.js
+++ b/modules/cactus-icons/scripts/svgr.js
@@ -4,6 +4,7 @@ const path = require('path')
 const fs = require('fs').promises
 const { prettierConfig, ...configFile } = require('../svgr.config')
 const prettier = require('prettier')
+const convertKebabToPascal = require('./helpers/kebabToPascal')
 
 async function main() {
   // Find all svgs under the svgs folder
@@ -35,7 +36,8 @@ async function main() {
       .toLowerCase()
 
     // Generate React components for each svg
-    const tsxCode = await svgr(svgCode, configFile)
+    const state = { componentName: convertKebabToPascal(tsxFileName) }
+    const tsxCode = await svgr(svgCode, configFile, state)
     const code = prettier.format(tsxCode, prettierConfig)
     // Write the components to files in the ts directory
     await fs.writeFile(path.join(__dirname, '..', `ts/${tsxFileName}.tsx`), code, 'utf-8')

--- a/modules/cactus-icons/src/AbstractIcon.ts
+++ b/modules/cactus-icons/src/AbstractIcon.ts
@@ -5,17 +5,19 @@ import { color, compose, space, verticalAlign } from 'styled-system'
 import iconSizes from './iconSizes'
 import { IconStyleProps } from './types'
 
-const AbstractIcon: React.FC = () => null
+const NullIcon: React.FC = () => null
 
 const styleFn = compose(space, color, verticalAlign, iconSizes)
 const stylePropNames = new Set<string>()
 styleFn.propNames?.forEach((propName) => stylePropNames.add(propName))
 
-const CactusIcon = styled(AbstractIcon).withConfig({
+// Naming it this way so the generated CSS class will start with "CactusIcon-".
+const CactusIcon = styled(NullIcon).withConfig({
   shouldForwardProp: (p) => !stylePropNames.has(p),
 })<IconStyleProps>`
   vertical-align: middle;
   ${styleFn}
 `
+CactusIcon.displayName = 'AbstractIcon'
 
 export default CactusIcon

--- a/modules/cactus-icons/src/CactusIcon.ts
+++ b/modules/cactus-icons/src/CactusIcon.ts
@@ -1,0 +1,21 @@
+import React from 'react'
+import styled from 'styled-components'
+import { color, compose, space, verticalAlign } from 'styled-system'
+
+import iconSizes from './iconSizes'
+import { IconStyleProps } from './types'
+
+const AbstractIcon: React.FC = () => null
+
+const styleFn = compose(space, color, verticalAlign, iconSizes)
+const stylePropNames = new Set<string>()
+styleFn.propNames?.forEach((propName) => stylePropNames.add(propName))
+
+const CactusIcon = styled(AbstractIcon).withConfig({
+  shouldForwardProp: (p) => !stylePropNames.has(p),
+})<IconStyleProps>`
+  vertical-align: middle;
+  ${styleFn}
+`
+
+export default CactusIcon

--- a/modules/cactus-icons/src/types.ts
+++ b/modules/cactus-icons/src/types.ts
@@ -1,12 +1,10 @@
 import { Property } from 'csstype'
-import { SVGProps } from 'react'
+import React from 'react'
 import { ColorProps, ResponsiveValue, SpaceProps, VerticalAlignProps } from 'styled-system'
 
 export type IconSizes = 'tiny' | 'small' | 'medium' | 'large' | Property.FontSize<number>
-export interface IconProps
-  extends Omit<SVGProps<SVGSVGElement>, 'ref' | 'color' | 'opacity'>,
-    SpaceProps,
-    ColorProps,
-    VerticalAlignProps {
+export interface IconStyleProps extends SpaceProps, ColorProps, VerticalAlignProps {
   iconSize?: ResponsiveValue<IconSizes>
 }
+export type SVGProps = Omit<React.SVGProps<SVGSVGElement>, 'color' | 'opacity'>
+export interface IconProps extends SVGProps, IconStyleProps {}

--- a/modules/cactus-icons/stories/Icons.story.tsx
+++ b/modules/cactus-icons/stories/Icons.story.tsx
@@ -2,8 +2,8 @@ import React, { ReactElement } from 'react'
 
 import icons, { IconProps } from '../i'
 
-type IconName = Exclude<keyof typeof icons, 'iconSizes'>
-const iconNames = Object.keys(icons).filter((x) => x !== 'iconSizes') as IconName[]
+type IconName = keyof typeof icons
+const iconNames = Object.keys(icons) as IconName[]
 
 type SizeArg = { iconSize: string }
 type Icon = (props: IconProps) => ReactElement

--- a/modules/cactus-icons/svgr.config.js
+++ b/modules/cactus-icons/svgr.config.js
@@ -7,13 +7,13 @@ const exportedTemplate = ({ template }, opts, { jsx, componentName }) => {
   const { name } = componentName
   const code = `
 import React from 'react'
-import CactusIcon from './CactusIcon'
+import AbstractIcon from './AbstractIcon'
 import { SVGProps } from './types'
 
 const Icon = React.forwardRef<SVGSVGElement, SVGProps>((props, svgRef) => (
   JSX
 ))
-const ${name} = CactusIcon.withComponent(Icon)
+const ${name} = AbstractIcon.withComponent(Icon)
 ${name}.displayName = '${name}'
 
 export default ${name}

--- a/modules/cactus-icons/svgr.config.js
+++ b/modules/cactus-icons/svgr.config.js
@@ -3,52 +3,33 @@ const prettierConfig = JSON.parse(
 )
 prettierConfig.parser = 'typescript'
 
-const exportedTemplate = ({ template }, opts, { componentName, jsx }) => {
+const exportedTemplate = ({ template }, opts, { jsx, componentName }) => {
+  const { name } = componentName
   const code = `
-import PropTypes from 'prop-types'
-import * as React from 'react'
-import styled from 'styled-components'
-import { color, compose, space, verticalAlign } from 'styled-system'
-import iconSizes from './iconSizes'
-import { IconProps } from './types'
+import React from 'react'
+import CactusIcon from './CactusIcon'
+import { SVGProps } from './types'
 
-const Base = ({ iconSize, verticalAlign, opacity, color, ...props }: IconProps) => {
-  return (
-    JSX
-  )
-}
+const Icon = React.forwardRef<SVGSVGElement, SVGProps>((props, svgRef) => (
+  JSX
+))
+const ${name} = CactusIcon.withComponent(Icon)
+${name}.displayName = '${name}'
 
-const COMPONENT_NAME = styled(Base)(
-  compose(
-    space,
-    color,
-    verticalAlign,
-    iconSizes
-  )
-)
-
-COMPONENT_NAME.propTypes = {
-  // @ts-ignore
-  iconSize: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
-}
-
-COMPONENT_NAME.defaultProps = {
-  verticalAlign: 'middle',
-}
-
-export default COMPONENT_NAME
-  `
+export default ${name}
+`
   const typeScriptTpl = template.smart(code, {
     plugins: ['typescript'],
     preserveComments: true,
     placeholderPattern: /^[_A-Z]{2,}$/,
   })
 
-  return typeScriptTpl({ JSX: jsx, COMPONENT_NAME: componentName })
+  return typeScriptTpl({ JSX: jsx })
 }
 
 module.exports = {
   icon: true,
+  ref: true,
   ext: 'tsx',
   template: exportedTemplate,
   svgProps: {

--- a/modules/cactus-icons/tests/__snapshots__/exports.test.tsx.snap
+++ b/modules/cactus-icons/tests/__snapshots__/exports.test.tsx.snap
@@ -145,6 +145,7 @@ Array [
 
 exports[`Exports should match snapshot of named exports 1`] = `
 Array [
+  "AbstractIcon",
   "ActionsAdd",
   "ActionsCoachmarks",
   "ActionsCopy",
@@ -165,7 +166,6 @@ Array [
   "BatchstatusOpen",
   "BatchstatusReconciled",
   "BatchstatusSettle",
-  "CactusIcon",
   "DescriptiveApps",
   "DescriptiveAssistant",
   "DescriptiveAt",

--- a/modules/cactus-icons/tests/__snapshots__/exports.test.tsx.snap
+++ b/modules/cactus-icons/tests/__snapshots__/exports.test.tsx.snap
@@ -165,6 +165,7 @@ Array [
   "BatchstatusOpen",
   "BatchstatusReconciled",
   "BatchstatusSettle",
+  "CactusIcon",
   "DescriptiveApps",
   "DescriptiveAssistant",
   "DescriptiveAt",

--- a/modules/cactus-icons/tests/__snapshots__/names.test.tsx.snap
+++ b/modules/cactus-icons/tests/__snapshots__/names.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`Icon names should match the snapshot of icon names 1`] = `
 Array [
-  "CactusIcon.d.ts",
-  "CactusIcon.js",
-  "CactusIcon.js.map",
+  "AbstractIcon.d.ts",
+  "AbstractIcon.js",
+  "AbstractIcon.js.map",
   "actions-add.d.ts",
   "actions-add.js",
   "actions-add.js.map",

--- a/modules/cactus-icons/tests/__snapshots__/names.test.tsx.snap
+++ b/modules/cactus-icons/tests/__snapshots__/names.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`Icon names should match the snapshot of icon names 1`] = `
 Array [
+  "CactusIcon.d.ts",
+  "CactusIcon.js",
+  "CactusIcon.js.map",
   "actions-add.d.ts",
   "actions-add.js",
   "actions-add.js.map",

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -23,6 +23,7 @@ import {
 } from 'styled-system'
 
 import { flexItem, FlexItemProps } from '../helpers/flexItem'
+import { getOmittableProps } from '../helpers/omit'
 import { radius, textStyle } from '../helpers/theme'
 
 interface CustomBR {
@@ -99,20 +100,24 @@ const decideBorderRadius = (props: ThemedStyledProps<BoxProps, DefaultTheme>) =>
   return borderRadiusStyles
 }
 
-export const Box = styled('div')<BoxProps>`
+const styleFn = compose(
+  position,
+  display,
+  layout,
+  space,
+  colorStyle,
+  color,
+  typography,
+  border,
+  overflow,
+  flexItem
+)
+const styleProps = getOmittableProps(styleFn, 'textStyle')
+export const Box = styled('div').withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<BoxProps>`
   box-sizing: border-box;
-  ${compose(
-    position,
-    display,
-    layout,
-    space,
-    colorStyle,
-    color,
-    typography,
-    border,
-    overflow,
-    flexItem
-  )}
+  ${styleFn}
   ${(p) => p.textStyle && textStyle(p.theme, p.textStyle)}
   ${decideBorderRadius}
 `

--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -5,6 +5,7 @@ import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { AsProps, GenericComponent } from '../helpers/asProps'
+import { getOmittableProps } from '../helpers/omit'
 import { radius, textStyle } from '../helpers/theme'
 import Spinner from '../Spinner/Spinner'
 
@@ -187,8 +188,9 @@ function ButtonFunc<E, C extends GenericComponent = 'button'>(
   )
 }
 
+const styleProps = getOmittableProps(margin)
 const StyledButton = styled.button.withConfig({
-  shouldForwardProp: (p) => !margin.propNames?.includes(p),
+  shouldForwardProp: (p) => !styleProps.has(p),
 })<{ $inverse?: boolean; $variant?: ButtonVariants }>`
   position: relative;
   padding: 2px 30px;
@@ -255,8 +257,6 @@ ButtonFR.propTypes = {
 
 ButtonFR.defaultProps = {
   variant: 'standard',
-  disabled: false,
-  inverse: false,
   type: 'button',
   loadingText: 'loading',
 }

--- a/modules/cactus-web/src/Card/Card.tsx
+++ b/modules/cactus-web/src/Card/Card.tsx
@@ -11,6 +11,7 @@ import {
   WidthProps,
 } from 'styled-system'
 
+import { getOmittableProps } from '../helpers/omit'
 import { flexItem, FlexItemProps } from '../helpers/styled'
 
 interface CardProps extends SpaceProps, WidthProps, MaxWidthProps, FlexItemProps {
@@ -28,7 +29,10 @@ const getBoxShadow = (props: CardProps & { theme: CactusTheme }) => {
     : `border: ${border(props, 'lightContrast')};`
 }
 
-export const Card = styled.div<CardProps>`
+const styleProps = getOmittableProps(flexItem, maxWidth, marginPadding, width, 'useBoxShadow')
+export const Card = styled.div.withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<CardProps>`
   box-sizing: border-box;
   ${colorStyle('standard')};
   border-radius: ${radius(8)};

--- a/modules/cactus-web/src/CheckBox/CheckBox.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.tsx
@@ -83,8 +83,4 @@ CheckBox.propTypes = {
   disabled: PropTypes.bool,
 }
 
-CheckBox.defaultProps = {
-  disabled: false,
-}
-
 export default CheckBox

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
@@ -48,9 +48,4 @@ CheckBoxField.propTypes = {
   disabled: PropTypes.bool,
 }
 
-CheckBoxField.defaultProps = {
-  labelProps: {},
-  disabled: false,
-}
-
 export default CheckBoxField

--- a/modules/cactus-web/src/ConfirmModal/ConfirmModal.tsx
+++ b/modules/cactus-web/src/ConfirmModal/ConfirmModal.tsx
@@ -147,7 +147,6 @@ ConfirmModal.propTypes = {
 ConfirmModal.defaultProps = {
   cancelButtonText: 'Cancel',
   confirmButtonText: 'Confirm',
-  iconName: undefined,
   iconSize: 'medium',
   title: 'Modal Title',
 }

--- a/modules/cactus-web/src/Dimmer/Dimmer.tsx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.tsx
@@ -11,9 +11,6 @@ class DimmerBase extends React.Component<DimmerProps> {
   public static propTypes = {
     active: PropTypes.bool.isRequired,
   }
-  public static defaultProps = {
-    active: false,
-  }
   componentDidUpdate(prevProps: DimmerProps): void {
     if (prevProps.active === false && this.props.active === true && document.activeElement) {
       try {

--- a/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
+++ b/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
@@ -2,9 +2,13 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { flexItem, FlexItemProps } from '../helpers/flexItem'
+import { getOmittableProps } from '../helpers/omit'
 
 type StyleProps = MarginProps & FlexItemProps & { $gap?: number }
-export const FieldWrapper = styled.div<StyleProps>`
+const styleProps = getOmittableProps(margin, flexItem)
+export const FieldWrapper = styled.div.withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<StyleProps>`
   min-width: 1px; /* IE Fix for some situations. */
   :not(:first-child) {
     margin-top: ${(p) => p.theme.space[p.$gap ?? 4]}px;

--- a/modules/cactus-web/src/Flex/Flex.tsx
+++ b/modules/cactus-web/src/Flex/Flex.tsx
@@ -4,6 +4,7 @@ import { flexbox, FlexboxProps } from 'styled-system'
 
 import { Box, BoxProps } from '../Box/Box'
 import { isIE } from '../helpers/constants'
+import { getOmittableProps } from '../helpers/omit'
 
 interface FlexBoxProps extends BoxProps, Omit<FlexboxProps, 'justifySelf'> {}
 
@@ -19,7 +20,10 @@ export const justifyOptions = [
 ] as const
 export type JustifyContent = typeof justifyOptions[number]
 
-export const Flex = styled(Box)<FlexBoxProps>`
+const styleProps = getOmittableProps(flexbox)
+export const Flex = styled(Box).withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<FlexBoxProps>`
   display: flex;
   ${flexbox}
 

--- a/modules/cactus-web/src/Grid/Grid.tsx
+++ b/modules/cactus-web/src/Grid/Grid.tsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import styled, { StyledComponentBase } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
+import { getOmittableProps } from '../helpers/omit'
+
 const GUTTER_WIDTH = 16
 
 type ColumnNum = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
@@ -88,7 +90,10 @@ interface GridComponent extends StyledComponentBase<'div', CactusTheme, GridProp
   Item: typeof Item
 }
 
-export const Grid = styled.div<GridProps>`
+const styleProps = getOmittableProps(margin, 'justify')
+export const Grid = styled.div.withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<GridProps>`
   box-sizing: border-box;
   width: 100%;
 

--- a/modules/cactus-web/src/Link/Link.tsx
+++ b/modules/cactus-web/src/Link/Link.tsx
@@ -3,24 +3,28 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { omitMargins } from '../helpers/omit'
+import { getOmittableProps } from '../helpers/omit'
 
-export interface LinkProps
-  extends MarginProps,
-    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+interface AnchorProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
   to: string
+}
+
+interface LinkStyleProps extends MarginProps {
   variant?: 'standard' | 'dark'
 }
 
-const LinkBase = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const { to, ...rest } = omitMargins(props)
+export interface LinkProps extends AnchorProps, LinkStyleProps {}
+
+const LinkBase = React.forwardRef<HTMLAnchorElement, AnchorProps>((props, ref) => {
+  const { to, ...rest } = props
 
   return <a ref={ref} href={to} {...rest} />
 })
 
+const styleProps = getOmittableProps(margin, 'variant')
 export const Link = styled(LinkBase).withConfig({
-  shouldForwardProp: (prop) => prop !== 'variant',
-})`
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<LinkStyleProps>`
   font-style: italic;
   outline: none;
 
@@ -49,10 +53,6 @@ export const Link = styled(LinkBase).withConfig({
 Link.propTypes = {
   to: PropTypes.string.isRequired,
   variant: PropTypes.oneOf(['standard', 'dark']),
-}
-
-Link.defaultProps = {
-  variant: 'standard',
 }
 
 export default Link

--- a/modules/cactus-web/src/PrevNext/PrevNext.tsx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { keyDownAsClick } from '../helpers/a11y'
+import { getOmittableProps } from '../helpers/omit'
 import { border, fontSize } from '../helpers/theme'
 
 type NavDirection = 'prev' | 'next'
@@ -87,9 +88,10 @@ const PrevNextBase: React.FC<PrevNextProps> = ({
   </div>
 )
 
-export const PrevNext = styled(PrevNextBase)`
-  ${margin}
-`
+const styleProps = getOmittableProps(margin)
+export const PrevNext = styled(PrevNextBase).withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<MarginProps>(margin)
 
 PrevNext.displayName = 'PrevNext'
 

--- a/modules/cactus-web/src/RadioButton/RadioButton.tsx
+++ b/modules/cactus-web/src/RadioButton/RadioButton.tsx
@@ -94,8 +94,4 @@ RadioButton.propTypes = {
   disabled: PropTypes.bool,
 }
 
-RadioButton.defaultProps = {
-  disabled: false,
-}
-
 export default RadioButton

--- a/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
+++ b/modules/cactus-web/src/RadioButtonField/RadioButtonField.tsx
@@ -48,9 +48,4 @@ RadioButtonField.propTypes = {
   id: PropTypes.string,
 }
 
-RadioButtonField.defaultProps = {
-  labelProps: {},
-  disabled: false,
-}
-
 export default RadioButtonField

--- a/modules/cactus-web/src/StepAvatar/StepAvatar.tsx
+++ b/modules/cactus-web/src/StepAvatar/StepAvatar.tsx
@@ -2,6 +2,7 @@ import { ColorStyle } from '@repay/cactus-theme'
 import styled, { css, DefaultTheme, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
+import { getOmittableProps } from '../helpers/omit'
 import { boxShadow, fontSize } from '../helpers/theme'
 
 export type AvatarStep = 'notDone' | 'inProcess' | 'done'
@@ -33,7 +34,10 @@ const variant = (
   return stepColorMap[stepType]
 }
 
-export const StepAvatar = styled.div<StepAvatarProps>`
+const styleProps = getOmittableProps(margin, 'status')
+export const StepAvatar = styled.div.withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<StepAvatarProps>`
   box-sizing: border-box;
   border-radius: 50%;
   width: 48px;

--- a/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
+++ b/modules/cactus-web/src/StyleProvider/StyleProvider.tsx
@@ -218,8 +218,4 @@ StyleProvider.propTypes = {
   }),
 }
 
-StyleProvider.defaultProps = {
-  global: false,
-}
-
 export default StyleProvider

--- a/modules/cactus-web/src/Tag/Tag.tsx
+++ b/modules/cactus-web/src/Tag/Tag.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
+import { getOmittableProps } from '../helpers/omit'
 import { IconButton } from '../IconButton/IconButton'
 
 const closeTypes = ['no-button', 'button'] as const
@@ -36,7 +37,10 @@ const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
   }
 )
 
-export const Tag = styled(TagBase)`
+const styleProps = getOmittableProps(margin)
+export const Tag = styled(TagBase).withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<MarginProps>`
   ${colorStyle('standard')};
   box-sizing: border-box;
   ${textStyle('small')};

--- a/modules/cactus-web/src/Text/Text.tsx
+++ b/modules/cactus-web/src/Text/Text.tsx
@@ -12,6 +12,7 @@ import {
   TypographyProps,
 } from 'styled-system'
 
+import { getOmittableProps } from '../helpers/omit'
 import { omitStyles } from '../helpers/styled'
 
 // These are covered by `textStyle` instead.
@@ -22,7 +23,10 @@ export interface TextProps extends SpaceProps, ColorProps, ColorStyleProps, Font
   textStyle?: keyof TextStyleCollection
 }
 
-export const Text = styled('span')<TextProps>`
+const styleProps = getOmittableProps(space, color, colorStyle, font, 'textStyle')
+export const Text = styled('span').withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<TextProps>`
   &:not(p) {
     margin: 0;
   }

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -88,10 +88,4 @@ TextArea.propTypes = {
   resize: PropTypes.bool,
 }
 
-TextArea.defaultProps = {
-  disabled: false,
-  status: null,
-  resize: false,
-}
-
 export default TextArea

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
+import { getOmittableProps } from '../helpers/omit'
 import { border, radius, textStyle } from '../helpers/theme'
 
 export type TextButtonVariants = 'standard' | 'action' | 'danger' | 'dark'
@@ -79,7 +80,10 @@ export const focusStyle = css`
   }
 `
 
-export const TextButton = styled.button<TextButtonProps>`
+const styleProps = getOmittableProps(margin, 'variant', 'inverse')
+export const TextButton = styled.button.withConfig({
+  shouldForwardProp: (p) => !styleProps.has(p),
+})<TextButtonProps>`
   ${(p) => textStyle(p.theme, 'body')};
   position: relative;
   border: none;
@@ -120,8 +124,6 @@ TextButton.propTypes = {
 
 TextButton.defaultProps = {
   variant: 'standard',
-  disabled: false,
-  inverse: false,
   type: 'button',
 }
 

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -89,9 +89,4 @@ TextInput.propTypes = {
   textStyle: PropTypes.oneOf(textStyles),
 }
 
-TextInput.defaultProps = {
-  disabled: false,
-  status: null,
-}
-
 export default TextInput

--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -127,10 +127,6 @@ Toggle.propTypes = {
   disabled: PropTypes.bool,
 }
 
-Toggle.defaultProps = {
-  disabled: false,
-}
-
 // Enable use of `Toggle` as a styled-components CSS class.
 Toggle.toString = Wrapper.toString
 Toggle.displayName = 'Toggle'

--- a/modules/cactus-web/src/helpers/omit.ts
+++ b/modules/cactus-web/src/helpers/omit.ts
@@ -66,11 +66,19 @@ export const split: Split = (
 
 type Omittable = string | string[] | { propNames?: string[] }
 
-// 3rd party type constraint, have to just ignore it.
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const omitProps = <P extends object>(...args: Omittable[]): StyledConfig<P> => {
-  const excludedProps = new Set<any>()
-  const add = (x: string) => excludedProps.add(x)
+/*
+ * Intended for use in the `shouldForwardProp` function:
+ *
+ * const styleProps = getOmittableProps(margin)
+ * const X = styled.div.withConfig({ shouldForwardProp: (p) => !styleProps.has(p) })``
+ *
+ * I'd rather cut a little boilerplate and return the entire function or config
+ * object, but for some reason Typescript refuses to infer the type correctly,
+ * even if I explicitly set the type to what Typescript infers in the above code.
+ */
+export const getOmittableProps = (...args: Omittable[]): Set<string> => {
+  const omittableProps = new Set<string>()
+  const add = (x: string) => omittableProps.add(x)
   for (const arg of args) {
     if (typeof arg === 'string') {
       add(arg)
@@ -80,6 +88,13 @@ export const omitProps = <P extends object>(...args: Omittable[]): StyledConfig<
       arg.propNames.forEach(add)
     }
   }
+  return omittableProps
+}
+
+// 3rd party type constraint, have to just ignore it.
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const omitProps = <P extends object>(...args: Omittable[]): StyledConfig<P> => {
+  const excludedProps = getOmittableProps(...args) as Set<any>
   return { shouldForwardProp: (p) => !excludedProps.has(p) }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5230,14 +5230,12 @@ __metadata:
     jest: ^27.5.1
     jest-sonar: ^0.2.12
     jest-styled-components: ^7.0.8
-    prop-types: ^15.8.1
     react: ^17.0.1
     react-dom: ^17.0.1
     styled-components: ^5.3.3
     styled-system: ^5.1.5
     typescript: ~4.6.2
   peerDependencies:
-    prop-types: ">=15.0.0"
     react: ^16.8.3 || ^17.0.0
     styled-components: ^5.1.0
   languageName: unknown


### PR DESCRIPTION
UAT: https://repayonline.atlassian.net/browse/CACTUS-931

One question I wanted to ask regarding the first commit: should we name `CactusIcon` differently? `AbstractIcon` might be a better name since it's not actually an icon, or maybe `StyledIcon`. (Or something else if you guys can come up with a better name.)

Most of the changes were changing the prop forwarding but I did remove some default props, mostly booleans that defaulted to false but don't differentiate from `undefined` which is also falsy.

Check individual commit messages for more info, but this is the most important part:

This is the culmination of my understanding of `styled-components` types, which has been improving over the years: and I've been trying to make better use of _our_ types so they work as expected, especially when the polymorphic `as` prop is in play. Here's what I've learned:

- When you do `X = styled(C)<StyleProps>()`, the props of X combine _two_ types: `React.ComponentProps<typeof C> & StyleProps`.
- When you use the `as` prop, it swaps out _only_ the first type: `<X as={Y} />` will validate props against the type `React.ComponentProps<typeof Y> & StyleProps`.
- Therefore, the resulting type will be most flexible & correct if the type of the base component **does not include** the style props.
- It's also best to utilize `shouldForwardProp` to remove the style props, so they won't be forwarded to the base _or_ polymorphic components.

Unfortunately the solution I've been using for that, `omitProps`, is breaking the types (more info in the comment in `helpers/omit.ts`); I'd like to fix the existing calls, but it would require more effort than I can put into this unrelated ticket.