### PR TITLE
CACTUS-929 :: Fix BrandBar when no `logo`

### DIFF
--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -124,7 +124,11 @@ export const BrandBar: BrandBarType = ({ logo, children, className, ...props }) 
   return (
     <StyledBrandBar {...props} className={classes(className, layoutClass)} $isTiny={isTiny}>
       <Flex justifyContent={justify} flexWrap="nowrap">
-        <LogoWrapper>{typeof logo === 'string' ? <img alt="Logo" src={logo} /> : logo}</LogoWrapper>
+        {logo && (
+          <LogoWrapper>
+            {typeof logo === 'string' ? <img alt="Logo" src={logo} /> : logo}
+          </LogoWrapper>
+        )}
         {!isTiny && leftChildren}
       </Flex>
       {isTiny ? (


### PR DESCRIPTION

[CACTUS-929](https://repayonline.atlassian.net/browse/CACTUS-929)

Renders LogoWrapper if `logo` is not undefined. The change is applied not only for tiny screens, I consider the `isTiny` check unnecessary so the blank space is removed from both tiny and larger screens. 