### PR TITLE
CACTUS-963: add variety of text-related styling props

### DIFF
--- a/modules/cactus-web/src/Box/Box.story.tsx
+++ b/modules/cactus-web/src/Box/Box.story.tsx
@@ -41,6 +41,10 @@ export default {
     borderBottomLeftRadius: HIDE_CONTROL,
     borderBottomRightRadius: HIDE_CONTROL,
     textStyle: { options: textStyles },
+    textDecoration: STRING,
+    fontVariant: STRING,
+    textIndent: SPACE,
+    textTransform: STRING,
   },
   args: {
     padding: '4',

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -3,8 +3,6 @@ import styled, { DefaultTheme, ThemedStyledProps } from 'styled-components'
 import {
   border,
   BorderProps,
-  color,
-  ColorProps,
   colorStyle,
   ColorStyleProps,
   compose,
@@ -12,18 +10,14 @@ import {
   DisplayProps,
   layout,
   LayoutProps,
-  overflow,
-  OverflowProps,
   position,
   PositionProps,
   space,
   SpaceProps,
-  typography,
-  TypographyProps,
 } from 'styled-system'
 
-import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { getOmittableProps } from '../helpers/omit'
+import { allText, AllTextProps, flexItem, FlexItemProps } from '../helpers/styled'
 import { radius, textStyle } from '../helpers/theme'
 
 interface CustomBR {
@@ -52,12 +46,10 @@ export interface BoxProps
   extends PositionProps,
     LayoutProps,
     SpaceProps,
-    ColorProps,
     ColorStyleProps,
     DisplayProps,
-    TypographyProps,
+    AllTextProps,
     CustomBorderProps,
-    OverflowProps,
     FlexItemProps {
   textStyle?: keyof TextStyleCollection
 }
@@ -100,18 +92,7 @@ const decideBorderRadius = (props: ThemedStyledProps<BoxProps, DefaultTheme>) =>
   return borderRadiusStyles
 }
 
-const styleFn = compose(
-  position,
-  display,
-  layout,
-  space,
-  colorStyle,
-  color,
-  typography,
-  border,
-  overflow,
-  flexItem
-)
+const styleFn = compose(position, display, layout, space, colorStyle, allText, border, flexItem)
 const styleProps = getOmittableProps(styleFn, 'textStyle')
 export const Box = styled('div').withConfig({
   shouldForwardProp: (p) => !styleProps.has(p),

--- a/modules/cactus-web/src/Text/Text.story.tsx
+++ b/modules/cactus-web/src/Text/Text.story.tsx
@@ -2,7 +2,7 @@ import cactusTheme from '@repay/cactus-theme'
 import React from 'react'
 
 import { Text } from '../'
-import { HIDE_STYLED, SPACE, Story } from '../helpers/storybook'
+import { HIDE_STYLED, SPACE, Story, STRING } from '../helpers/storybook'
 
 const COLOR_STYLES = Object.keys(cactusTheme.colorStyles)
 
@@ -20,6 +20,10 @@ export default {
     colors: { options: COLOR_STYLES },
     margin: SPACE,
     padding: SPACE,
+    textDecoration: STRING,
+    fontVariant: STRING,
+    textIndent: SPACE,
+    textTransform: STRING,
     ...HIDE_STYLED,
   },
   args: {

--- a/modules/cactus-web/src/Text/Text.tsx
+++ b/modules/cactus-web/src/Text/Text.tsx
@@ -1,29 +1,19 @@
 import { textStyle, TextStyleCollection } from '@repay/cactus-theme'
 import styled from 'styled-components'
-import {
-  color,
-  ColorProps,
-  colorStyle,
-  ColorStyleProps,
-  compose,
-  space,
-  SpaceProps,
-  typography,
-  TypographyProps,
-} from 'styled-system'
+import { colorStyle, ColorStyleProps, compose, space, SpaceProps } from 'styled-system'
 
 import { getOmittableProps } from '../helpers/omit'
-import { omitStyles } from '../helpers/styled'
+import { allText, AllTextProps, flexItem, FlexItemProps, omitStyles } from '../helpers/styled'
 
 // These are covered by `textStyle` instead.
-type FontProps = Omit<TypographyProps, 'fontSize' | 'lineHeight'>
-const font = omitStyles(typography, 'fontSize', 'lineHeight')
+type FontProps = Omit<AllTextProps, 'fontSize' | 'lineHeight'>
+const font = omitStyles(allText, 'fontSize', 'lineHeight')
 
-export interface TextProps extends SpaceProps, ColorProps, ColorStyleProps, FontProps {
+export interface TextProps extends SpaceProps, ColorStyleProps, FontProps, FlexItemProps {
   textStyle?: keyof TextStyleCollection
 }
 
-const styleProps = getOmittableProps(space, color, colorStyle, font, 'textStyle')
+const styleProps = getOmittableProps(space, colorStyle, font, flexItem, 'textStyle')
 export const Text = styled('span').withConfig({
   shouldForwardProp: (p) => !styleProps.has(p),
 })<TextProps>`
@@ -31,7 +21,7 @@ export const Text = styled('span').withConfig({
     margin: 0;
   }
   &&& {
-    ${compose(space, color, colorStyle, font)}
+    ${compose(space, colorStyle, font, flexItem)}
     ${(p) => p.textStyle && textStyle(p, p.textStyle)}
   }
 `

--- a/modules/cactus-web/src/helpers/storybook.ts
+++ b/modules/cactus-web/src/helpers/storybook.ts
@@ -50,7 +50,7 @@ const mapSpace = (str: string | undefined): Length | Length[] | undefined => {
   if (!parts.length) return undefined
   else if (parts.length > 1) return parts.map(mapSpace) as Length[]
   str = parts[0]
-  return /^[0-7]$/.test(str) ? parseInt(str) : str
+  return /^-?[0-7]$/.test(str) ? parseInt(str) : str
 }
 export const SPACE: ArgType = { ...STRING, map: mapSpace }
 

--- a/modules/cactus-web/src/helpers/styled.ts
+++ b/modules/cactus-web/src/helpers/styled.ts
@@ -1,27 +1,9 @@
 import { CactusTheme } from '@repay/cactus-theme'
+import { Property } from 'csstype'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { StyledComponent, ThemedStyledFunction } from 'styled-components'
-import {
-  compose,
-  flexbox,
-  FlexboxProps,
-  height,
-  HeightProps,
-  maxHeight,
-  MaxHeightProps,
-  maxWidth,
-  MaxWidthProps,
-  minHeight,
-  MinHeightProps,
-  minWidth,
-  MinWidthProps,
-  ResponsiveValue,
-  styleFn,
-  system,
-  width,
-  WidthProps,
-} from 'styled-system'
+import * as SS from 'styled-system'
 
 // This file exists, in part, because styled-components types are a PAIN.
 export type Styled<P> = StyledComponent<React.FC<P>, CactusTheme>
@@ -55,24 +37,24 @@ export const styledProp = PropTypes.oneOfType([cssVal, PropTypes.arrayOf(cssVal)
 
 export const classes = (...args: (string | undefined)[]): string => args.filter(Boolean).join(' ')
 
-export const pickStyles = (styles: styleFn, ...keys: string[]): styleFn => {
-  const picked: styleFn[] = []
+export const pickStyles = (styles: SS.styleFn, ...keys: string[]): SS.styleFn => {
+  const picked: SS.styleFn[] = []
   for (const key of keys) {
     const maybeFn = (styles as any)[key]
     if (maybeFn) picked.push(maybeFn)
   }
-  return compose(...picked)
+  return SS.compose(...picked)
 }
 
-export const omitStyles = (styles: styleFn, ...keys: string[]): styleFn => {
-  const picked: styleFn[] = []
+export const omitStyles = (styles: SS.styleFn, ...keys: string[]): SS.styleFn => {
+  const picked: SS.styleFn[] = []
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   for (const key of Object.keys(styles.config!)) {
     if (!keys.includes(key)) {
       picked.push((styles as any)[key])
     }
   }
-  return compose(...picked)
+  return SS.compose(...picked)
 }
 
 // Not exhaustive, but all possible values include at least one of these words.
@@ -82,7 +64,7 @@ const isFlexKey = RegExp.prototype.test.bind(/row|column|reverse|wrap/)
 // is equivalent to `<C display="flex" flexDirection="row" flexWrap="wrap">`.
 // Depending on where it's used, the `display` part could be redundant;
 // keep that in mind if you need a different `display` value (e.g. 'inline-flex').
-export const flexFlow = system({
+export const flexFlow = SS.system({
   flexFlow: (value: any) => {
     if (typeof value === 'boolean') {
       return value ? { display: 'flex' } : undefined
@@ -110,19 +92,150 @@ const itemKeys = [
   'order',
 ] as const
 
-export interface FlexProps extends Pick<FlexboxProps, typeof flexKeys[number]> {
-  flexFlow?: ResponsiveValue<boolean | string>
+export interface FlexProps extends Pick<SS.FlexboxProps, typeof flexKeys[number]> {
+  flexFlow?: SS.ResponsiveValue<boolean | Property.FlexFlow>
 }
-export type FlexItemProps = Pick<FlexboxProps, typeof itemKeys[number]>
-;(flexbox as any).flexFlow = flexFlow
-export const flexContainer = pickStyles(flexbox, 'flexFlow', ...flexKeys)
-export const flexItem = pickStyles(flexbox, ...itemKeys)
+export type FlexItemProps = Pick<SS.FlexboxProps, typeof itemKeys[number]>
+;(SS.flexbox as any).flexFlow = flexFlow
+export const flexContainer = pickStyles(SS.flexbox, 'flexFlow', ...flexKeys)
+export const flexItem = pickStyles(SS.flexbox, ...itemKeys)
 
-export type AllWidthProps = WidthProps & MinWidthProps & MaxWidthProps
-export const allWidth = compose(width, minWidth, maxWidth)
+export type AllWidthProps = SS.WidthProps & SS.MinWidthProps & SS.MaxWidthProps
+export const allWidth = SS.compose(SS.width, SS.minWidth, SS.maxWidth)
 
-export type AllHeightProps = HeightProps & MinHeightProps & MaxHeightProps
-export const allHeight = compose(height, minHeight, maxHeight)
+export type AllHeightProps = SS.HeightProps & SS.MinHeightProps & SS.MaxHeightProps
+export const allHeight = SS.compose(SS.height, SS.minHeight, SS.maxHeight)
 
 export type SizingProps = AllWidthProps & AllHeightProps
-export const sizing = compose(width, minWidth, maxWidth, height, minHeight, maxHeight)
+export const sizing = SS.compose(
+  SS.width,
+  SS.minWidth,
+  SS.maxWidth,
+  SS.height,
+  SS.minHeight,
+  SS.maxHeight
+)
+
+/******* Text Styling *******/
+
+interface TextDecorationProps {
+  textDecoration?: SS.ResponsiveValue<Property.TextDecoration>
+  textDecorationColor?: SS.ResponsiveValue<Property.TextDecorationColor>
+  textDecorationLine?: SS.ResponsiveValue<Property.TextDecorationLine>
+  textDecorationSkipInk?: SS.ResponsiveValue<Property.TextDecorationSkipInk>
+  textDecorationStyle?: SS.ResponsiveValue<Property.TextDecorationStyle>
+  textDecorationThickness?: SS.ResponsiveValue<Property.TextDecorationThickness<string | number>>
+  textUnderlineOffset?: SS.ResponsiveValue<Property.TextUnderlineOffset<string | number>>
+  textUnderlinePosition?: SS.ResponsiveValue<Property.TextUnderlinePosition>
+}
+
+const textDecoration = SS.system({
+  textDecoration: true,
+  textDecorationColor: { property: 'textDecorationColor', scale: 'colors' },
+  textDecorationLine: true,
+  textDecorationSkipInk: true,
+  textDecorationStyle: true,
+  textDecorationThickness: { property: 'textDecorationThickness', scale: 'space' },
+  textUnderlineOffset: { property: 'textUnderlineOffset', scale: 'space' },
+  textUnderlinePosition: true,
+})
+
+interface TextDirectionProps {
+  textOrientation?: SS.ResponsiveValue<Property.TextOrientation>
+  writingMode?: SS.ResponsiveValue<Property.WritingMode>
+}
+
+const textDirection = SS.system({
+  textOrientation: true,
+  writingMode: true,
+})
+
+interface TextDisplayProps {
+  fontStretch?: SS.ResponsiveValue<Property.FontStretch>
+  fontVariant?: SS.ResponsiveValue<Property.FontVariant>
+  fontVariantCaps?: SS.ResponsiveValue<Property.FontVariantCaps>
+  fontVariantLigatures?: SS.ResponsiveValue<Property.FontVariantLigatures>
+  fontVariantNumeric?: SS.ResponsiveValue<Property.FontVariantNumeric>
+  textIndent?: SS.ResponsiveValue<Property.TextIndent<string | number>>
+  textTransform?: SS.ResponsiveValue<Property.TextTransform>
+}
+
+const textDisplay = SS.system({
+  fontStretch: true,
+  fontVariant: true,
+  fontVariantCaps: true,
+  fontVariantLigatures: true,
+  fontVariantNumeric: true,
+  textIndent: {
+    property: 'textIndent',
+    scale: 'space',
+    // Unlike most other space props, it makes sense to allow negative numbers.
+    transform: (value, scale) => {
+      if (scale) {
+        if (typeof value === 'number' && value < 0) {
+          const scaleVal = scale[-value]
+          if (typeof scaleVal === 'number') {
+            return -scaleVal
+          } else if (scaleVal) {
+            return `-${scaleVal}`
+          }
+        }
+        return scale[value] ?? value
+      }
+      return value
+    },
+  },
+  textTransform: true,
+})
+
+interface TextOverflowProps extends SS.OverflowProps {
+  hyphens?: SS.ResponsiveValue<Property.Hyphens>
+  overflowWrap?: SS.ResponsiveValue<Property.OverflowWrap>
+  textOverflow?: SS.ResponsiveValue<Property.TextOverflow>
+  whiteSpace?: SS.ResponsiveValue<Property.WhiteSpace>
+  wordBreak?: SS.ResponsiveValue<Property.WordBreak>
+}
+
+const textOverflow = SS.compose(
+  SS.overflow,
+  SS.overflowX,
+  SS.overflowY,
+  SS.system({
+    hyphens: true,
+    overflowWrap: { properties: ['overflowWrap', 'wordWrap'] },
+    textOverflow: true,
+    whiteSpace: true,
+    wordBreak: true,
+  })
+)
+
+interface UserSelectProps {
+  userSelect?: SS.ResponsiveValue<Property.UserSelect>
+}
+// This one doesn't really fit anywhere else...
+const userSelect = SS.system({ userSelect: true })
+
+// Other text-related props I'm not including:
+// `textJustify`: lack of browser support
+// `fontVariantAlternates`: lack of browser support
+// `fontVariantPosition`: lack of browser support
+// `fontVariantAlternates`: lack of browser support
+// `fontVariationSettings`: common use cases covered by other properties
+// `textShadow`: requires custom transform to utilize themed shadows, wait for use case to add
+
+export const allText = SS.compose(
+  SS.color,
+  SS.typography,
+  textDecoration,
+  textDirection,
+  textDisplay,
+  textOverflow,
+  userSelect
+)
+export type AllTextProps = SS.ColorProps &
+  SS.TypographyProps &
+  TextDecorationProps &
+  TextDirectionProps &
+  TextDisplayProps &
+  TextOverflowProps &
+  UserSelectProps


### PR DESCRIPTION
UAT: https://repayonline.atlassian.net/browse/CACTUS-963

There turned out to be quite a few properties here:
- `textDecoration`: brings underline & strikethrough, which are both useful
- `textOrientation`/`writingMode`: I thought these might be useful someday in vertical table labels or something, to save space
- `textTransform`: we've already used this in a couple of header-ish components
- `fontVariant`: seems like a more useful & flexible version of `textTransform`
- `textOverflow`: we've mostly handled this internally in components, but I wouldn't be surprised if it came up somewhere outside of those
- some of those are shortcut properties, so I included the full versions as well

`color` is foreground (usually text) color, so I included it in AllTextProps. Overflow doesn't quite fit, but you have to set it for `textOverflow` to work.