### PR TITLE
ci(cactus-web) :: Have merges to master automatically run docs:publish on merge on Cactus

### DIFF
--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -1,0 +1,17 @@
+name: Master Pipeline
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Publish the docs
+      run: yarn docs:publish

--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -1,14 +1,10 @@
 name: Master Pipeline
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - master
-
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
+  publish_docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
[CACTUS-966](https://repayonline.atlassian.net/browse/CACTUS-966)


Hey, want to add a new workflow to cactus but it seems I don’t have permission for doing that:
<img width="1245" alt="Screen Shot 2022-07-26 at 1 21 31 PM" src="https://user-images.githubusercontent.com/77983162/181082435-28a20333-03e7-4caa-a65b-f38b571a0fd3.png">

I created the branch and the file directly here on Github... but maybe there are some permissions we need to be assigned to my profile for future workflow-related tickets.  