### PR TITLE
CACTUS-966 :: Have merges to master automatically run docs:publish on merge on Cactus

### DIFF
--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    
+
+    - name: Install Packages
+      run: yarn install --immutable
+
     - name: Publish the docs
       run: yarn docs:publish


### PR DESCRIPTION
[CACTUS-966](https://repayonline.atlassian.net/browse/CACTUS-966) 

Added the `yarn install` step to this workflow:


not sure if a `yarn build` step should be necessary for this. If this fails, I'll open this again and then add that step.