### PR TITLE
Remove Docs Versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-is": "^17.0.0",
-    "deep-object-diff": "1.1.0"
+    "deep-object-diff": "1.1.0",
+    "devcert": "1.2.0"
   }
 }

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -2,8 +2,6 @@ const path = require('path')
 const modulesHelper = require('./tools/modules-helper')
 const { default: cactusTheme } = require('@repay/cactus-theme')
 
-const pastWebVersions = ['1.1.2', '2.1.0', '3.3.2', '4.4.1', '5.2.0', '6.5.0', '7.1.0', '8.1.0']
-
 module.exports = {
   siteMetadata: {
     title: 'Cactus Design System',
@@ -39,15 +37,6 @@ module.exports = {
         ignore: ['**/*.ts', '**/*.tsx', '**/*.json', '**/*.snap'],
       },
     },
-    ...pastWebVersions.map((version) => ({
-      resolve: 'gatsby-source-git',
-      options: {
-        name: `cactus-web/v${version.split('.')[0]}`,
-        remote: 'https://github.com/repaygithub/cactus.git',
-        branch: `@repay/cactus-web@${version}`,
-        patterns: ['modules/cactus-web/src/**/*.mdx'],
-      },
-    })),
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
     {

--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -99,29 +99,7 @@ function getTitle({ node, getNode }) {
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
-  const parentNode = getNode(node.parent)
-  const sourceInstanceName = parentNode?.sourceInstanceName
-
-  if (sourceInstanceName && sourceInstanceName.match(/cactus-web\/v[0-9]+/g)) {
-    // Remove the live examples for these older versions
-    node.rawBody = node.rawBody.replace(/[#]+ Try it out[\s\S]*<\/LiveProvider>/i, '')
-
-    createNodeField({
-      name: 'slug',
-      node,
-      value: `${sourceInstanceName}/components/${parentNode.name.toLowerCase()}`,
-    })
-    createNodeField({
-      name: 'isComponent',
-      node,
-      value: true,
-    })
-    createNodeField({
-      name: 'title',
-      node,
-      value: getTitle({ node, getNode }),
-    })
-  } else if (node.internal.type === 'Mdx') {
+  if (node.internal.type === 'Mdx') {
     const isComponent = getNode(node.parent).sourceInstanceName === 'components'
     createNodeField({
       name: 'slug',

--- a/website/package.json
+++ b/website/package.json
@@ -58,7 +58,6 @@
     "@repay/cactus-theme": "^3.0.0",
     "@repay/cactus-web": "^9.0.0",
     "color": "^4.2.1",
-    "gatsby-source-git": "^1.1.0",
     "normalize.css": "^8.0.1",
     "prop-types": "^15.8.1",
     "react": "^17.0.1",

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -65,8 +65,7 @@ function addNode(group: MenuGroup, node: MenuItem): void {
     const parent = group.items.find((g): boolean => g.url.endsWith(route))
     if (parent !== undefined) {
       addNode(parent, node)
-    } else if (!node.url.match(/cactus-web\/v[0-9]+/g)) {
-      // TODO: Remove this ^ condition when the older docs actually should have a group
+    } else {
       console.error(`Could not find group for: `, node)
       console.log(`${route} not found among:`)
       group.items.forEach((g): void => console.log('\t' + g.url))

--- a/website/src/components/PropsTable.tsx
+++ b/website/src/components/PropsTable.tsx
@@ -162,7 +162,7 @@ const PropsTable: React.FC<PropsTableProps> = ({
   const data = useDocgen()
   // Not sure why some pull from `dist` instead of `src`.
   if (!fileName) {
-    fileName = component?.__filemeta?.filename.replace(/dist(.*)js/, 'src$1tsx')
+    fileName = component.__filemeta?.filename.replace(/dist(.*)js/, 'src$1tsx')
   } else if (!fileName.includes('src')) {
     fileName = '../modules/cactus-web/src/' + fileName
   }
@@ -209,7 +209,7 @@ const PropsTable: React.FC<PropsTableProps> = ({
       styledSystemProps,
       styledComponentProps: probablyStyledComponentProps,
     }
-  }, [component?.displayName, docItem, staticProp])
+  }, [component.displayName, docItem, staticProp])
 
   if (ownProps === undefined) {
     return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -13268,9 +13268,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"devcert@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "devcert@npm:1.2.1"
+"devcert@npm:1.2.0":
+  version: 1.2.0
+  resolution: "devcert@npm:1.2.0"
   dependencies:
     "@types/configstore": ^2.1.1
     "@types/debug": ^0.0.30
@@ -13287,7 +13287,6 @@ __metadata:
     eol: ^0.9.1
     get-port: ^3.2.0
     glob: ^7.1.2
-    is-valid-domain: ^0.1.6
     lodash: ^4.17.4
     mkdirp: ^0.5.1
     password-prompt: ^1.0.4
@@ -13295,7 +13294,7 @@ __metadata:
     sudo-prompt: ^8.2.0
     tmp: ^0.0.33
     tslib: ^1.10.0
-  checksum: 30c08044f7ded8e2b8dc94bde9a811b217c7556d7b8ec00bfca2e3e49e947c6f4421f8eca23a9e7472b4abe9c4bfbfb69fc261a12e8ae9f32aaf71b15e972f0f
+  checksum: 3671d172b69d28de86e78851701cc63a17ffa3748ee92337b4ebeea0f53d85cde55d45cc529899a047b8ffe605300203af6ba2549a69e91ce9dd4cf310387611
   languageName: node
   linkType: hard
 
@@ -19300,15 +19299,6 @@ __metadata:
   version: 0.2.1
   resolution: "is-utf8@npm:0.2.1"
   checksum: 167ccd2be869fc228cc62c1a28df4b78c6b5485d15a29027d3b5dceb09b383e86a3522008b56dcac14b592b22f0a224388718c2505027a994fd8471465de54b3
-  languageName: node
-  linkType: hard
-
-"is-valid-domain@npm:^0.1.6":
-  version: 0.1.6
-  resolution: "is-valid-domain@npm:0.1.6"
-  dependencies:
-    punycode: ^2.1.1
-  checksum: 4e497673431c57b83026dfded173ff65fb432fad6db6715d14435acdd125e4acc2fc2fe865290c6329d0895362416b57f43483e0b73258b97242004f151b10ca
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5483,13 +5483,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@sindresorhus/is@npm:0.7.0"
-  checksum: decc50f6fe80b75c981bcff0a585c05259f5e04424a46a653ac9a7e065194145c463ca81001e3a229bd203f59474afadb5b1fa0af5507723f87f2dd45bd3897c
-  languageName: node
-  linkType: hard
-
 "@sindresorhus/is@npm:^4.0.0":
   version: 4.6.0
   resolution: "@sindresorhus/is@npm:4.6.0"
@@ -10088,24 +10081,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-queue-memory@npm:^1.0.1":
-  version: 1.0.4
-  resolution: "better-queue-memory@npm:1.0.4"
-  checksum: c4d54f73ccbf3bc4b494007b6012ff0698a4690ebdccda29a9d0dcae2ece72e6495efcad90137e2e90c3765479580c02e86859b4a588bebf6f7e317c848676eb
-  languageName: node
-  linkType: hard
-
-"better-queue@npm:^3.8.10":
-  version: 3.8.10
-  resolution: "better-queue@npm:3.8.10"
-  dependencies:
-    better-queue-memory: ^1.0.1
-    node-eta: ^0.9.0
-    uuid: ^3.0.0
-  checksum: 14d03cbf2c71c0a38c6ae40f067781a5908a05b46ff33092f2540eaee1a8e2796fa169eadc1aa12d8117839a3c278423a3852e58af0b3bb66888f2ce49c10073
-  languageName: node
-  linkType: hard
-
 "big.js@npm:^5.2.2":
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
@@ -10757,21 +10732,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacheable-request@npm:^2.1.1":
-  version: 2.1.4
-  resolution: "cacheable-request@npm:2.1.4"
-  dependencies:
-    clone-response: 1.0.2
-    get-stream: 3.0.0
-    http-cache-semantics: 3.8.1
-    keyv: 3.0.0
-    lowercase-keys: 1.0.0
-    normalize-url: 2.0.1
-    responselike: 1.0.2
-  checksum: 69c684cb3645f75af094e3ef6e7959ca5edff33d70737498de1a068d2f719a12786efdd82fe1e2254a1f332bb88cce088273bd78fad3e57cdef5034f3ded9432
-  languageName: node
-  linkType: hard
-
 "cacheable-request@npm:^6.0.0":
   version: 6.1.0
   resolution: "cacheable-request@npm:6.1.0"
@@ -11250,7 +11210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.0, chokidar@npm:^3.4.1, chokidar@npm:^3.4.2, chokidar@npm:^3.4.3, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
+"chokidar@npm:^3.4.0, chokidar@npm:^3.4.1, chokidar@npm:^3.4.2, chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -11465,7 +11425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clone-response@npm:1.0.2, clone-response@npm:^1.0.2":
+"clone-response@npm:^1.0.2":
   version: 1.0.2
   resolution: "clone-response@npm:1.0.2"
   dependencies:
@@ -13476,7 +13436,6 @@ __metadata:
     gatsby-remark-images: ^6.10.1
     gatsby-remark-smartypants: ^5.10.0
     gatsby-source-filesystem: ^4.10.0
-    gatsby-source-git: ^1.1.0
     gatsby-transformer-sharp: ^4.10.0
     normalize.css: ^8.0.1
     prop-types: ^15.8.1
@@ -15264,7 +15223,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^2.2.3, fast-glob@npm:^2.2.6":
+"fast-glob@npm:^2.2.6":
   version: 2.2.7
   resolution: "fast-glob@npm:2.2.7"
   dependencies:
@@ -15440,7 +15399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-type@npm:^16.0.0, file-type@npm:^16.5.3":
+"file-type@npm:^16.5.3":
   version: 16.5.3
   resolution: "file-type@npm:16.5.3"
   dependencies:
@@ -15875,7 +15834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"from2@npm:^2.1.0, from2@npm:^2.1.1":
+"from2@npm:^2.1.0":
   version: 2.3.0
   resolution: "from2@npm:2.3.0"
   dependencies:
@@ -15914,17 +15873,6 @@ __metadata:
     jsonfile: ^6.0.1
     universalify: ^2.0.0
   checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "fs-extra@npm:5.0.0"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^4.0.0
-    universalify: ^0.1.0
-  checksum: b3dcaf1d545097013c4fa649951c85cad1b845316ab473cc3440254a45e9b0b17d8ca9355af477e982c7d126f1a30417bcf78b1f744593ce77a0f43165f2d5e5
   languageName: node
   linkType: hard
 
@@ -16155,21 +16103,6 @@ __metadata:
   bin:
     gatsby: cli.js
   checksum: 51bfa3b028cd55dae9479da4615adb7f8823bb9dfcc26c734e111cd590d9c92632dfee8316ef000dfa58fb45563b831b24edf0b88e7aab1f4092bb20524e73ea
-  languageName: node
-  linkType: hard
-
-"gatsby-core-utils@npm:^1.10.1":
-  version: 1.10.1
-  resolution: "gatsby-core-utils@npm:1.10.1"
-  dependencies:
-    ci-info: 2.0.0
-    configstore: ^5.0.1
-    fs-extra: ^8.1.0
-    node-object-hash: ^2.0.0
-    proper-lockfile: ^4.1.1
-    tmp: ^0.2.1
-    xdg-basedir: ^4.0.0
-  checksum: 140728965e8e3486ce7822a80056440cf907d8832cdc29599652a70896d7ac18a02d3468b0c71be5b766a3fbe23561e83b5807b5d134921df42142799fa46379
   languageName: node
   linkType: hard
 
@@ -16553,29 +16486,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-source-filesystem@npm:^2.1.19":
-  version: 2.11.1
-  resolution: "gatsby-source-filesystem@npm:2.11.1"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-    better-queue: ^3.8.10
-    chokidar: ^3.4.3
-    file-type: ^16.0.0
-    fs-extra: ^8.1.0
-    gatsby-core-utils: ^1.10.1
-    got: ^9.6.0
-    md5-file: ^5.0.0
-    mime: ^2.4.6
-    pretty-bytes: ^5.4.1
-    progress: ^2.0.3
-    valid-url: ^1.0.9
-    xstate: ^4.14.0
-  peerDependencies:
-    gatsby: ^2.2.0
-  checksum: d056b61cfef6a37e6c2f29aea81e079bd1f591b5cfaffeb9e239db011e68ccb97e86586671d45f4d075c7836b022be61d67e10a22dc815bee519dc964c8a317c
-  languageName: node
-  linkType: hard
-
 "gatsby-source-filesystem@npm:^4.10.0":
   version: 4.16.0
   resolution: "gatsby-source-filesystem@npm:4.16.0"
@@ -16595,22 +16505,6 @@ __metadata:
   peerDependencies:
     gatsby: ^4.0.0-next
   checksum: 77a0d7a282f3f3a8e4d788b2307c44efc7b07ba2936c0df69eeab8ec68f7afe266e6561e6efd139d57e2608a0d8ce8dcf210a47bfc41526206a23612358309b6
-  languageName: node
-  linkType: hard
-
-"gatsby-source-git@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "gatsby-source-git@npm:1.1.0"
-  dependencies:
-    fast-glob: ^2.2.3
-    fs-extra: ^5.0.0
-    gatsby-source-filesystem: ^2.1.19
-    git-url-parse: ^11.1.1
-    rimraf: ^2.6.2
-    simple-git: ^1.105.0
-  peerDependencies:
-    gatsby: ">2.0.0-alpha"
-  checksum: 12ff405c201721bd4bf563ccc31314efb98c7dde97fddcc4adf5bb9c4dda543a3ed5845748729e90dbaeb34c69e947d05492d3380038e95378ab197032ad8925
   languageName: node
   linkType: hard
 
@@ -16981,13 +16875,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:3.0.0, get-stream@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "get-stream@npm:3.0.0"
-  checksum: 36142f46005ed74ce3a45c55545ec4e7da8e243554179e345a786baf144e5c4a35fb7bdc49fadfa9f18bd08000589b6fe364abdadfc4e1eb0e1b9914a6bb9c56
-  languageName: node
-  linkType: hard
-
 "get-stream@npm:^4.0.0, get-stream@npm:^4.1.0":
   version: 4.1.0
   resolution: "get-stream@npm:4.1.0"
@@ -17114,7 +17001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-url-parse@npm:^11.1.1, git-url-parse@npm:^11.4.4":
+"git-url-parse@npm:^11.4.4":
   version: 11.6.0
   resolution: "git-url-parse@npm:11.6.0"
   dependencies:
@@ -17403,31 +17290,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:8.3.2":
-  version: 8.3.2
-  resolution: "got@npm:8.3.2"
-  dependencies:
-    "@sindresorhus/is": ^0.7.0
-    cacheable-request: ^2.1.1
-    decompress-response: ^3.3.0
-    duplexer3: ^0.1.4
-    get-stream: ^3.0.0
-    into-stream: ^3.1.0
-    is-retry-allowed: ^1.1.0
-    isurl: ^1.0.0-alpha5
-    lowercase-keys: ^1.0.0
-    mimic-response: ^1.0.0
-    p-cancelable: ^0.4.0
-    p-timeout: ^2.0.1
-    pify: ^3.0.0
-    safe-buffer: ^5.1.1
-    timed-out: ^4.0.1
-    url-parse-lax: ^3.0.0
-    url-to-options: ^1.0.1
-  checksum: ab05bfcb6de86dc0c3fba8d25cc51cb2b09851ff3f6f899c86cde8c63b30269f8823d69dbbc6d03f7c58bb069f55a3c5f60aba74aad6721938652d8f35fd3165
-  languageName: node
-  linkType: hard
-
 "got@npm:^11.8.2, got@npm:^11.8.3":
   version: 11.8.5
   resolution: "got@npm:11.8.5"
@@ -17712,26 +17574,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-symbol-support-x@npm:^1.4.1":
-  version: 1.4.2
-  resolution: "has-symbol-support-x@npm:1.4.2"
-  checksum: ff06631d556d897424c00e8e79c10093ad34c93e88bb0563932d7837f148a4c90a4377abc5d8da000cb6637c0ecdb4acc9ae836c7cfd0ffc919986db32097609
-  languageName: node
-  linkType: hard
-
 "has-symbols@npm:^1.0.1, has-symbols@npm:^1.0.2, has-symbols@npm:^1.0.3":
   version: 1.0.3
   resolution: "has-symbols@npm:1.0.3"
   checksum: a054c40c631c0d5741a8285010a0777ea0c068f99ed43e5d6eb12972da223f8af553a455132fdb0801bdcfa0e0f443c0c03a68d8555aa529b3144b446c3f2410
-  languageName: node
-  linkType: hard
-
-"has-to-string-tag-x@npm:^1.2.0":
-  version: 1.4.1
-  resolution: "has-to-string-tag-x@npm:1.4.1"
-  dependencies:
-    has-symbol-support-x: ^1.4.1
-  checksum: 804c4505727be7770f8b2f5e727ce31c9affc5b83df4ce12344f44b68d557fefb31f77751dbd739de900653126bcd71f8842fac06f97a3fae5422685ab0ce6f0
   languageName: node
   linkType: hard
 
@@ -18168,13 +18014,6 @@ __metadata:
     domutils: ^3.0.1
     entities: ^4.3.0
   checksum: 06d5c71e8313597722bc429ae2a7a8333d77bd3ab07ccb916628384b37332027b047f8619448d8f4a3312b6609c6ea3302a4e77435d859e9e686999e6699ca39
-  languageName: node
-  linkType: hard
-
-"http-cache-semantics@npm:3.8.1":
-  version: 3.8.1
-  resolution: "http-cache-semantics@npm:3.8.1"
-  checksum: b1108d37be478fa9b03890d4185217aac2256e9d2247ce6c6bd90bc5432687d68dc7710ba908cea6166fb983a849d902195241626cf175a3c62817a494c0f7f6
   languageName: node
   linkType: hard
 
@@ -18681,16 +18520,6 @@ __metadata:
   version: 1.2.5
   resolution: "intl@npm:1.2.5"
   checksum: 54c2444ec334b4e7f501c1b988ccfdae96d62a6275a915b9c75a38fc42d611bfc7dd33447e94079b7a8fdb3fbf36b95afd13132af4bfd70e2ec4bf9c9e0935f9
-  languageName: node
-  linkType: hard
-
-"into-stream@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "into-stream@npm:3.1.0"
-  dependencies:
-    from2: ^2.1.1
-    p-is-promise: ^1.1.0
-  checksum: e6e1a202227b20c446c251ef95348b3e8503cdc75aa2a09076f8821fc42c1b7fd43fabaeb8ed3cf9eb875942cfa4510b66949c5317997aa640921cc9bbadcd17
   languageName: node
   linkType: hard
 
@@ -19219,13 +19048,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-object@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "is-object@npm:1.0.2"
-  checksum: 971219c4b1985b9751f65e4c8296d3104f0457b0e8a70849e848a4a2208bc47317d73b3b85d4a369619cb2df8284dc22584cb2695a7d99aca5e8d0aa64fc075a
-  languageName: node
-  linkType: hard
-
 "is-path-cwd@npm:^1.0.0":
   version: 1.0.0
   resolution: "is-path-cwd@npm:1.0.0"
@@ -19357,13 +19179,6 @@ __metadata:
   dependencies:
     is-unc-path: ^1.0.0
   checksum: 3271a0df109302ef5e14a29dcd5d23d9788e15ade91a40b942b035827ffbb59f7ce9ff82d036ea798541a52913cbf9d2d0b66456340887b51f3542d57b5a4c05
-  languageName: node
-  linkType: hard
-
-"is-retry-allowed@npm:^1.1.0":
-  version: 1.2.0
-  resolution: "is-retry-allowed@npm:1.2.0"
-  checksum: 50d700a89ae31926b1c91b3eb0104dbceeac8790d8b80d02f5c76d9a75c2056f1bb24b5268a8a018dead606bddf116b2262e5ac07401eb8b8783b266ed22558d
   languageName: node
   linkType: hard
 
@@ -19685,16 +19500,6 @@ __metadata:
     html-escaper: ^2.0.0
     istanbul-lib-report: ^3.0.0
   checksum: 2132983355710c522f6b26808015cab9a0ee8b9f5ae0db0d3edeff40b886dd83cb670fb123cb7b32dbe59473d7c00cdde2ba6136bc0acdb20a865fccea64dfe1
-  languageName: node
-  linkType: hard
-
-"isurl@npm:^1.0.0-alpha5":
-  version: 1.0.0
-  resolution: "isurl@npm:1.0.0"
-  dependencies:
-    has-to-string-tag-x: ^1.2.0
-    is-object: ^1.0.1
-  checksum: 28a96e019269d57015fa5869f19dda5a3ed1f7b21e3e0c4ff695419bd0541547db352aa32ee4a3659e811a177b0e37a5bc1a036731e71939dd16b59808ab92bd
   languageName: node
   linkType: hard
 
@@ -20776,15 +20581,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keyv@npm:3.0.0":
-  version: 3.0.0
-  resolution: "keyv@npm:3.0.0"
-  dependencies:
-    json-buffer: 3.0.0
-  checksum: 5182775e546cdbb88dc583825bc0e990164709f31904a219e3321b3bf564a301ac4e5255ba95f7fba466548eba793b356a04a0242110173b199a37192b3b565f
-  languageName: node
-  linkType: hard
-
 "keyv@npm:^3.0.0":
   version: 3.1.0
   resolution: "keyv@npm:3.1.0"
@@ -21549,13 +21345,6 @@ __metadata:
   dependencies:
     tslib: ^2.0.3
   checksum: 83a0a5f159ad7614bee8bf976b96275f3954335a84fad2696927f609ddae902802c4f3312d86668722e668bef41400254807e1d3a7f2e8c3eede79691aa1f010
-  languageName: node
-  linkType: hard
-
-"lowercase-keys@npm:1.0.0":
-  version: 1.0.0
-  resolution: "lowercase-keys@npm:1.0.0"
-  checksum: 2370110c149967038fd5eb278f9b2d889eb427487c0e7fb417ab2ef4d93bacba1c8f226cf2ef1c2848b3191f37d84167d4342fbee72a1a122086680adecf362b
   languageName: node
   linkType: hard
 
@@ -22942,13 +22731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-eta@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "node-eta@npm:0.9.0"
-  checksum: aea7831697c056286dca46908d74cca1c8c55471d4bd73b9a917401a624d4aa61adf63c47f37fc2eaad3579b0ed7b91c18e8f85990c565b62014ece7b93c3ed9
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:2.6.1":
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
@@ -23109,7 +22891,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-object-hash@npm:^2.0.0, node-object-hash@npm:^2.3.10":
+"node-object-hash@npm:^2.3.10":
   version: 2.3.10
   resolution: "node-object-hash@npm:2.3.10"
   checksum: 5d2a80f67810294d352205bfc4823aa6097b06cd5dee6e0fec7e2bc40b55bfe5251e90313046230abe2fd230b8b7c5dcda967243e4136b94971e2630e6c7d0cd
@@ -23197,17 +22979,6 @@ __metadata:
   version: 0.1.2
   resolution: "normalize-range@npm:0.1.2"
   checksum: 9b2f14f093593f367a7a0834267c24f3cb3e887a2d9809c77d8a7e5fd08738bcd15af46f0ab01cc3a3d660386f015816b5c922cea8bf2ee79777f40874063184
-  languageName: node
-  linkType: hard
-
-"normalize-url@npm:2.0.1":
-  version: 2.0.1
-  resolution: "normalize-url@npm:2.0.1"
-  dependencies:
-    prepend-http: ^2.0.0
-    query-string: ^5.0.1
-    sort-keys: ^2.0.0
-  checksum: 30e337ee03fc7f360c7d2b966438657fabd2628925cc58bffc893982fe4d2c59b397ae664fa2c319cd83565af73eee88906e80bc5eec91bc32b601920e770d75
   languageName: node
   linkType: hard
 
@@ -23764,13 +23535,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-cancelable@npm:^0.4.0":
-  version: 0.4.1
-  resolution: "p-cancelable@npm:0.4.1"
-  checksum: d11144d72ee3a99f62fe595cb0e13b8585ea73c3807b4a9671744f1bf5d3ccddb049247a4ec3ceff05ca4adba9d0bb0f1862829daf20795bf528c86fa088509c
-  languageName: node
-  linkType: hard
-
 "p-cancelable@npm:^1.0.0":
   version: 1.1.0
   resolution: "p-cancelable@npm:1.1.0"
@@ -23828,13 +23592,6 @@ __metadata:
   version: 2.0.1
   resolution: "p-finally@npm:2.0.1"
   checksum: 6306a2851c3b28f8b603624f395ae84dce76970498fed8aa6aae2d930595053746edf1e4ee0c4b78a97410d84aa4504d63179f5310d555511ecd226f53ed1e8e
-  languageName: node
-  linkType: hard
-
-"p-is-promise@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "p-is-promise@npm:1.1.0"
-  checksum: 64d7c6cda18af2c91c04209e5856c54d1a9818662d2320b34153d446645f431307e04406969a1be00cad680288e86dcf97b9eb39edd5dc4d0b1bd714ee85e13b
   languageName: node
   linkType: hard
 
@@ -23971,15 +23728,6 @@ __metadata:
     "@types/retry": 0.12.0
     retry: ^0.13.1
   checksum: 45c270bfddaffb4a895cea16cb760dcc72bdecb6cb45fef1971fa6ea2e91ddeafddefe01e444ac73e33b1b3d5d29fb0dd18a7effb294262437221ddc03ce0f2e
-  languageName: node
-  linkType: hard
-
-"p-timeout@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "p-timeout@npm:2.0.1"
-  dependencies:
-    p-finally: ^1.0.0
-  checksum: 9205a661173f03adbeabda8e02826de876376b09c99768bdc33e5b25ae73230e3ac00e520acedbe3cf05fbd3352fb02efbd3811a9a021b148fb15eb07e7accac
   languageName: node
   linkType: hard
 
@@ -25549,7 +25297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proper-lockfile@npm:^4.1.1, proper-lockfile@npm:^4.1.2":
+"proper-lockfile@npm:^4.1.2":
   version: 4.1.2
   resolution: "proper-lockfile@npm:4.1.2"
   dependencies:
@@ -25765,17 +25513,6 @@ __metadata:
   version: 6.5.3
   resolution: "qs@npm:6.5.3"
   checksum: 6f20bf08cabd90c458e50855559539a28d00b2f2e7dddcb66082b16a43188418cb3cb77cbd09268bcef6022935650f0534357b8af9eeb29bf0f27ccb17655692
-  languageName: node
-  linkType: hard
-
-"query-string@npm:^5.0.1":
-  version: 5.1.1
-  resolution: "query-string@npm:5.1.1"
-  dependencies:
-    decode-uri-component: ^0.2.0
-    object-assign: ^4.1.0
-    strict-uri-encode: ^1.0.0
-  checksum: 4ac760d9778d413ef5f94f030ed14b1a07a1708dd13fd3bc54f8b9ef7b425942c7577f30de0bf5a7d227ee65a9a0350dfa3a43d1d266880882fb7ce4c434a4dd
   languageName: node
   linkType: hard
 
@@ -27277,7 +27014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"responselike@npm:1.0.2, responselike@npm:^1.0.2":
+"responselike@npm:^1.0.2":
   version: 1.0.2
   resolution: "responselike@npm:1.0.2"
   dependencies:
@@ -28062,15 +27799,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^1.105.0":
-  version: 1.132.0
-  resolution: "simple-git@npm:1.132.0"
-  dependencies:
-    debug: ^4.0.1
-  checksum: 717d7cf7919ebe771b2562ed70c79c3971ac650d9577a15c47052472f8e549a088aea593b6a7245d73af0425a202106e6c236d35a73dc4c48dce99bf7b4f939a
-  languageName: node
-  linkType: hard
-
 "simple-swizzle@npm:^0.2.2":
   version: 0.2.2
   resolution: "simple-swizzle@npm:0.2.2"
@@ -28826,13 +28554,6 @@ __metadata:
   version: 0.1.2
   resolution: "streamsearch@npm:0.1.2"
   checksum: d2db57cbfbf7947ab9c75a7b4c80a8ef8d24850cf0a1a24258bb6956c97317ce1eab7dbcbf9c5aba3e6198611af1053b02411057bbedb99bf9c64b8275248997
-  languageName: node
-  linkType: hard
-
-"strict-uri-encode@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "strict-uri-encode@npm:1.1.0"
-  checksum: 9466d371f7b36768d43f7803f26137657559e4c8b0161fb9e320efb8edba3ae22f8e99d4b0d91da023b05a13f62ec5412c3f4f764b5788fac11d1fea93720bb3
   languageName: node
   linkType: hard
 
@@ -30052,13 +29773,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timed-out@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "timed-out@npm:4.0.1"
-  checksum: 98efc5d6fc0d2a329277bd4d34f65c1bf44d9ca2b14fd267495df92898f522e6f563c5e9e467c418e0836f5ca1f47a84ca3ee1de79b1cc6fe433834b7f02ec54
-  languageName: node
-  linkType: hard
-
 "timers-browserify@npm:^2.0.4":
   version: 2.0.12
   resolution: "timers-browserify@npm:2.0.12"
@@ -31200,13 +30914,6 @@ __metadata:
   dependencies:
     prepend-http: ^2.0.0
   checksum: 1040e357750451173132228036aff1fd04abbd43eac1fb3e4fca7495a078bcb8d33cb765fe71ad7e473d9c94d98fd67adca63bd2716c815a2da066198dd37217
-  languageName: node
-  linkType: hard
-
-"url-to-options@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "url-to-options@npm:1.0.1"
-  checksum: 20e59f4578525fb0d30ffc22b13b5aa60bc9e57cefd4f5842720f5b57211b6dec54abeae2d675381ac4486fd1a2e987f1318725dea996e503ff89f8c8ce2c17e
   languageName: node
   linkType: hard
 
@@ -32382,7 +32089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xstate@npm:^4.14.0, xstate@npm:^4.26.0, xstate@npm:^4.26.1":
+"xstate@npm:^4.26.0, xstate@npm:^4.26.1":
   version: 4.32.1
   resolution: "xstate@npm:4.32.1"
   checksum: c16298b2b3dab7689da99d5b1e5128d2ca3bf381f37c8cb95e4af83bb1044b9251629fc00758f7f31785a72c2ddddd26f602b2801e6068cd78373b7f6dd6c28b


### PR DESCRIPTION
I left the stuff I'm removing here in another branch called `broken-docs-versioning`, and I pinned `devcert` since that was causing issues with running the docs site locally.

#732 was the original if you want to compare these changes with the PR where they were added.