### PR TITLE
CACTUS-981/982 :: Fix Snyk Issues

### DIFF
--- a/actions/integration-tests/Dockerfile
+++ b/actions/integration-tests/Dockerfile
@@ -1,9 +1,12 @@
 
-FROM node:lts
+FROM node:16-bullseye-slim
 
 COPY entrypoint.sh /entrypoint.sh
 
-
+RUN apt-get update && apt-get install -y \
+  wget \
+  unzip \
+  procps
 RUN wget https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip && \
   unzip BrowserStackLocal-linux-x64.zip && \
   rm BrowserStackLocal-linux-x64.zip && \

--- a/actions/storyshots/Dockerfile
+++ b/actions/storyshots/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:16-bullseye-slim
 RUN apt-get update && apt-get install -y \
   wget \
   unzip \
@@ -38,10 +38,9 @@ RUN apt-get update && apt-get install -y \
   libxtst6 \
   ca-certificates \
   fonts-liberation \
-  libappindicator1 \
   libnss3 \
   lsb-release \
   xdg-utils \
-  wget
+  procps
 ENTRYPOINT ["yarn", "w", "@repay/cactus-web"]
 CMD ["test:visual-update"]


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-981

This image was missing a few things that we needed (`wget`, `unzip`, `procps`), but seems to be working now that I added them.

https://repayonline.atlassian.net/browse/CACTUS-982

I wasn't able to install `libappindicator1` with this image, but apparently we don't need it. Also had to add `procps` to this one too.

Nothing to test for either of these. If we get some green checkmarks we should be good to go.