### PR TITLE
CACTUS-969: add more ways of pagination to DataGrid

### DIFF
--- a/modules/cactus-web/src/DataGrid/DataGrid.mdx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.mdx
@@ -53,11 +53,11 @@ interface CellInfo {
 
 ## Best practices
 
-- It is the responsibility of the developer to save changes to `sortOptions` & `paginationOptions` and pass the updated values back
-  through the props; the `DataGrid` component does not manage those values internally.
+- The `sortOptions` & `paginationOptions` props can be used either controlled or uncontrolled. If using them uncontrolled, the `onPagisort` handler can be used to update the data source whenever a change is made to either pagination _or_ sorting.
+- `paginationOptions` can be passed as a single object to the `<DataGrid>` element, or as individual props to the relevant sub-components: `pageSize` to `PageSizeSelect`, `currentPage` & `pageCount` to `Pagination`, etc.; if not using `PageSizeSelect`, `pageSize` can also be passed to `Pagination` or `PrevNext`.
 - Use the `sortLabels` prop on `TopSection` to pass internationalized labels for the sorting dropdowns used in the card view.
 - Just like the `Table`, the `DataGrid` should be rendered as a descendant of `ScreenSizeProvider` to take advantage of the card carousel feature.
-- If you would like to use the `DataGrid.Pagination` component, you must include `pageCount` in `paginationOptions`. If no `pageCount` is provided, you should use `DataGrid.PrevNext` instead.
+- If you would like to use the `DataGrid.Pagination` component, you must include `pageCount` OR `itemCount` & `pageSize` in `paginationOptions`. If no page count is known, you should use `DataGrid.PrevNext` instead.
 - Similar to the `Table` component, the `DataGrid` exposes the `cardBreakpoint` prop, where you can define at what breakpoint you would like to switch to card
   view. It defaults to `tiny` but you can select from any of our breakpoints: `tiny`, `small`, `medium`, `large` and `extraLarge`.
 - Alternatively, you can pass `variant` to directly control whether it renders as cards or a table.
@@ -69,21 +69,13 @@ interface CellInfo {
 ```
 const YesNo = ({ value }) => <div>{value ? 'YES' : 'NO'}</div>
 
+const initialPageSize = 4
 const DataGridContainer = ({ data: INITIAL_DATA }) => {
-  const [state, setState] = React.useState({
-    data: INITIAL_DATA,
-    sortOptions: [{ id: 'created', sortAscending: false }],
-    paginationOptions: { currentPage: 1, pageCount: 3, pageSize: 4 },
-  })
-  const paginateData = () => {
-    const index1 = (state.paginationOptions.currentPage - 1) * state.paginationOptions.pageSize
-    const index2 = index1 + state.paginationOptions.pageSize
-    return state.data.slice(index1, index2)
-  }
-  const onSort = (newSortOptions) => {
+  const [data, setData] = React.useState(() => INITIAL_DATA.slice(0, initialPageSize))
+  const onPagisort = ({ itemOffset, pageSize: newPageSize, sort: newSortOptions }) => {
     const sortId = newSortOptions[0].id
     const sortAscending = newSortOptions[0].sortAscending
-    const dataCopy = state.data.slice()
+    const dataCopy = [...INITIAL_DATA]
     if (sortId === 'created') {
       if (sortAscending) {
         dataCopy.sort((a, b) => {
@@ -105,38 +97,20 @@ const DataGridContainer = ({ data: INITIAL_DATA }) => {
         })
       }
     }
-    setState((state) => ({
-      ...state,
-      data: dataCopy,
-      sortOptions: newSortOptions,
-    }))
-  }
-  const onPageChange = (newPaginationOptions) => {
-    if (newPaginationOptions.pageSize !== state.paginationOptions.pageSize) {
-      newPaginationOptions.pageCount = Math.ceil(state.data.length / newPaginationOptions.pageSize)
-    }
-    setState((state) => ({
-      ...state,
-      paginationOptions: newPaginationOptions,
-    }))
+    setData(dataCopy.slice(itemOffset, itemOffset + newPageSize))
   }
   return (
-    <DataGrid
-      paginationOptions={state.paginationOptions}
-      sortOptions={state.sortOptions}
-      onSort={onSort}
-      onPageChange={onPageChange}
-      cardBreakpoint="tiny"
-    >
+    <DataGrid onPagisort={onPagisort} cardBreakpoint="tiny">
       <DataGrid.TopSection justifyContent="flex-end" spacing={4}>
         <DataGrid.PageSizeSelect
-          pageSizeOptions={[4, 6, 12]}
+           initialPageSize={initialPageSize}
+           pageSizeOptions={[4, 6, 12]}
         />
       </DataGrid.TopSection>
-      <DataGrid.Table data={paginateData()}>
-        <DataGrid.DataColumn id="name" title="Name" />
-        <DataGrid.DataColumn id="created" title="Created" sortable />
-        <DataGrid.DataColumn id="active" title="Active" sortable as={YesNo} />
+      <DataGrid.Table data={data}>
+        <DataGrid.Column id="name" title="Name" />
+        <DataGrid.Column id="created" title="Created" sortable />
+        <DataGrid.Column id="active" title="Active" sortable as={YesNo} />
         <DataGrid.Column>
           {(rowData) => (
             <SplitButton onSelectMainAction={() => {}} mainActionLabel="Edit">
@@ -147,7 +121,7 @@ const DataGridContainer = ({ data: INITIAL_DATA }) => {
         </DataGrid.Column>
       </DataGrid.Table>
       <DataGrid.BottomSection justifyContent="flex-end">
-        <DataGrid.Pagination />
+        <DataGrid.Pagination itemCount={INITIAL_DATA.length} />
       </DataGrid.BottomSection>
     </DataGrid>
   )

--- a/modules/cactus-web/src/DataGrid/DataGrid.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.tsx
@@ -1,24 +1,26 @@
-import { noop } from 'lodash'
+import { identity } from 'lodash'
 import PropTypes from 'prop-types'
 import React, { ReactElement, useContext, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import Pagination, { PaginationProps } from '../Pagination/Pagination'
-import PrevNext, { PrevNextProps } from '../PrevNext/PrevNext'
+import { useControllableValue } from '../hooks'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
 import { TableVariant } from '../Table/Table'
 import BottomSection from './BottomSection'
 import DataGridColumn, { useColumns } from './DataGridColumn'
 import DataGridTable from './DataGridTable'
-import { DataGridContext, getMediaQuery } from './helpers'
+import { DataGridContext, getMediaQuery, initialPageState } from './helpers'
 import PageSizeSelect from './PageSizeSelect'
+import { calcPageState, DataGridPagination, DataGridPrevNext, pageStateReducer } from './Pagination'
 import TopSection from './TopSection'
-import { PaginationOptions, SortOption, TransientProps } from './types'
+import { PageStateAction, PaginationOptions, Pagisort, SortOption, TransientProps } from './types'
 
 interface DataGridProps extends MarginProps {
   paginationOptions?: PaginationOptions
   sortOptions?: SortOption[]
+  initialSort?: SortOption[]
+  onPagisort?: (newPagisort: Pagisort) => void
   onPageChange?: (newPageOptions: PaginationOptions) => void
   onSort?: (newSortOptions: SortOption[]) => void
   children: React.ReactNode
@@ -30,15 +32,45 @@ interface DataGridProps extends MarginProps {
 export const DataGrid = (props: DataGridProps): ReactElement => {
   const {
     children,
+    onPagisort,
+    initialSort = [],
+    onSort: onSortProp,
+    onPageChange,
     fullWidth = false,
-    sortOptions,
-    onSort = noop,
-    paginationOptions,
-    onPageChange = noop,
     cardBreakpoint = 'tiny',
     variant,
     ...rest
   } = props
+
+  const [sortOptions, setSort] = useControllableValue(rest, 'sortOptions', initialSort)
+  const [pageState, setPageState] = useControllableValue(
+    rest,
+    'paginationOptions',
+    pageStateReducer,
+    initialPageState
+  )
+
+  const onSort = (newSortOptions: SortOption[]) => {
+    newSortOptions = setSort(newSortOptions)
+    onSortProp?.(newSortOptions)
+    if (onPagisort) {
+      const pagisort: Pagisort = { ...setPageState(identity), sort: newSortOptions }
+      calcPageState(pagisort)
+      onPagisort(pagisort)
+    }
+  }
+
+  const updatePageState = (action: PageStateAction, raiseEvent = false) => {
+    const newPageOptions = setPageState(action)
+    if (raiseEvent && newPageOptions !== pageState) {
+      onPageChange?.(newPageOptions)
+      if (onPagisort) {
+        const pagisort: Pagisort = { ...newPageOptions, sort: setSort(identity) }
+        onPagisort(pagisort)
+      }
+    }
+  }
+
   const [columnState, columnDispatch] = useColumns()
   const [topSectionRendered, setTopSectionRendered] = useState<boolean>(false)
 
@@ -68,10 +100,10 @@ export const DataGrid = (props: DataGridProps): ReactElement => {
         value={{
           ...columnState,
           columnDispatch,
-          sortOptions: sortOptions || [],
+          sortOptions: sortOptions,
           onSort,
-          paginationOptions,
-          onPageChange,
+          pageState,
+          updatePageState,
           fullWidth,
           cardBreakpoint,
           isCardView,
@@ -97,46 +129,13 @@ const StyledDataGrid = styled.div<DataGridProps & TransientProps>`
   }
 `
 
-export const DataGridPagination: React.FC<
-  Omit<PaginationProps, 'currentPage' | 'onPageChange' | 'pageCount'>
-> = (props) => {
-  const { paginationOptions, onPageChange } = useContext(DataGridContext)
-  return paginationOptions && paginationOptions.pageCount ? (
-    <Pagination
-      currentPage={paginationOptions.currentPage}
-      pageCount={paginationOptions.pageCount}
-      onPageChange={(page: number): void => {
-        onPageChange({ ...paginationOptions, currentPage: page })
-      }}
-      {...props}
-    />
-  ) : null
-}
-
-export const DataGridPrevNext: React.FC<PrevNextProps> = (props) => {
-  const { paginationOptions, onPageChange } = useContext(DataGridContext)
-  return paginationOptions ? (
-    <PrevNext
-      disablePrev={paginationOptions.currentPage === 1}
-      onNavigate={(direction: 'prev' | 'next'): void => {
-        onPageChange({
-          ...paginationOptions,
-          currentPage:
-            direction === 'prev'
-              ? paginationOptions.currentPage - 1
-              : paginationOptions.currentPage + 1,
-        })
-      }}
-      {...props}
-    />
-  ) : null
-}
-
 DataGrid.propTypes = {
   paginationOptions: PropTypes.shape({
-    currentPage: PropTypes.number.isRequired,
-    pageSize: PropTypes.number.isRequired,
+    currentPage: PropTypes.number,
+    pageSize: PropTypes.number,
     pageCount: PropTypes.number,
+    itemCount: PropTypes.number,
+    itemOffset: PropTypes.number,
   }),
   sortOptions: PropTypes.arrayOf(
     PropTypes.shape({ id: PropTypes.string.isRequired, sortAscending: PropTypes.bool.isRequired })
@@ -147,9 +146,6 @@ DataGrid.propTypes = {
   fullWidth: PropTypes.bool,
   cardBreakpoint: PropTypes.oneOf<Size>(['tiny', 'small', 'medium', 'large', 'extraLarge']),
 }
-
-DataGridPrevNext.displayName = 'PrevNext'
-DataGridPagination.displayName = 'Pagination'
 
 type DataGridType = React.ComponentType<DataGridProps> & {
   Table: typeof DataGridTable

--- a/modules/cactus-web/src/DataGrid/DataGrid.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.tsx
@@ -54,9 +54,8 @@ export const DataGrid = (props: DataGridProps): ReactElement => {
     newSortOptions = setSort(newSortOptions)
     onSortProp?.(newSortOptions)
     if (onPagisort) {
-      const pagisort: Pagisort = { ...setPageState(identity), sort: newSortOptions }
-      calcPageState(pagisort)
-      onPagisort(pagisort)
+      const pagisort = { ...setPageState(identity), sort: newSortOptions }
+      onPagisort(calcPageState(pagisort))
     }
   }
 

--- a/modules/cactus-web/src/DataGrid/DataGridTable.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGridTable.tsx
@@ -20,7 +20,7 @@ const renderHeader = ({ columns, sortOptions, onSort, isCardView }: DataGridCont
     {columns.map((column) => {
       const { key, id, title = '' } = column
       const props = { ...column.cellProps, ...column.headerProps, key, children: title }
-      if (column.sortable && id && sortOptions) {
+      if (column.sortable && id) {
         const sortOpt = sortOptions.find((opt) => opt.id === id)
         let sortDesc = false
         let Icon: React.ComponentType<IconProps> | undefined = undefined

--- a/modules/cactus-web/src/DataGrid/PageSizeSelect.tsx
+++ b/modules/cactus-web/src/DataGrid/PageSizeSelect.tsx
@@ -9,6 +9,8 @@ import { border, fontSize } from '../helpers/theme'
 import { DataGridContext } from './helpers'
 
 export interface PageSizeSelectProps extends MarginProps {
+  pageSize?: number
+  initialPageSize?: number
   makePageSizeLabel?: (pageSize: number) => string
   pageSizeSelectLabel?: React.ReactChild
   pageSizeOptions: number[]
@@ -17,38 +19,39 @@ export interface PageSizeSelectProps extends MarginProps {
 const defaultPageSizeLabel = (pageSize: number): string => `View ${pageSize} rows per page`
 
 const PageSizeSelect = (props: PageSizeSelectProps): ReactElement => {
+  const { pageState, updatePageState } = useContext(DataGridContext)
   const {
     pageSizeSelectLabel,
     pageSizeOptions,
     makePageSizeLabel = defaultPageSizeLabel,
+    initialPageSize = 1,
+    pageSize: currentPageSize = pageState.pageSize || initialPageSize,
     ...rest
   } = props
-  const { paginationOptions, onPageChange } = useContext(DataGridContext)
+  React.useEffect(() => {
+    updatePageState({ pageSize: currentPageSize })
+  }, [currentPageSize]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <StyledPageSizeSelect {...rest}>
       <span>{pageSizeSelectLabel || 'View'}</span>
       <ol className="page-options-list">
-        {pageSizeOptions &&
-          paginationOptions &&
-          pageSizeOptions.map((pageSize): ReactElement => {
-            const isCurrentPageSize = paginationOptions.pageSize === pageSize
-            return (
-              <li className="page-option" key={`page-size-option-${pageSize}`}>
-                <a
-                  role="link"
-                  aria-selected={isCurrentPageSize ? 'true' : 'false'}
-                  onClick={(): void => {
-                    onPageChange({ ...paginationOptions, pageSize: pageSize })
-                  }}
-                  onKeyDown={keyDownAsClick}
-                  tabIndex={isCurrentPageSize ? undefined : 0}
-                  aria-label={makePageSizeLabel(pageSize)}
-                >
-                  {pageSize}
-                </a>
-              </li>
-            )
-          })}
+        {pageSizeOptions?.map((pageSize): ReactElement => {
+          const isCurrentPageSize = currentPageSize === pageSize
+          return (
+            <li className="page-option" key={`page-size-option-${pageSize}`}>
+              <a
+                role="link"
+                aria-selected={isCurrentPageSize ? 'true' : 'false'}
+                onClick={() => updatePageState({ pageSize }, true)}
+                onKeyDown={keyDownAsClick}
+                tabIndex={isCurrentPageSize ? undefined : 0}
+                aria-label={makePageSizeLabel(pageSize)}
+              >
+                {pageSize}
+              </a>
+            </li>
+          )
+        })}
       </ol>
     </StyledPageSizeSelect>
   )

--- a/modules/cactus-web/src/DataGrid/Pagination.tsx
+++ b/modules/cactus-web/src/DataGrid/Pagination.tsx
@@ -1,0 +1,128 @@
+import { assignWith, isEqual } from 'lodash'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import Pagination, { PaginationProps } from '../Pagination/Pagination'
+import PrevNext, { PrevNextProps } from '../PrevNext/PrevNext'
+import { DataGridContext } from './helpers'
+import { PageState, PageStateAction, pageStateKeys, PaginationOptions } from './types'
+
+interface PageStateProps extends PageState {
+  initialPage?: number
+}
+
+export interface ExtendedPaginationProps
+  extends Omit<PaginationProps, 'currentPage' | 'pageCount'>,
+    PageStateProps {}
+
+export interface ExtendedPrevNextProps extends PrevNextProps, PageStateProps {}
+
+export const calcPageState = (p: PageState): PaginationOptions => {
+  // TS appeasement: comparison operators work perfectly fine with undefined.
+  const r = p as Required<PageState>
+  if (r.pageSize > 0) {
+    if (r.itemCount >= 0) {
+      r.pageCount = Math.ceil(r.itemCount / r.pageSize)
+    }
+    if (r.currentPage > 0) {
+      if (r.currentPage > r.pageCount) {
+        r.currentPage = r.pageCount
+      }
+      r.itemOffset = (r.currentPage - 1) * r.pageSize
+    } else if (r.itemOffset >= 0) {
+      r.currentPage = Math.floor(r.itemOffset / r.pageSize) + 1
+      if (r.currentPage > r.pageCount) {
+        r.currentPage = r.pageCount
+        r.itemOffset = (r.currentPage - 1) * r.pageSize
+      }
+    }
+  }
+  return r
+}
+
+const assignIfUndefined = (dest: unknown, src: unknown) => dest ?? src
+
+const interleave = (state: PageState, updates: PageState) => {
+  // To get the correct derived/implied values from the updates, we do the
+  // calculations twice: first with updates + pageSize, then combined with state.
+  const combinedState = calcPageState({ pageSize: state.pageSize, ...updates })
+  return calcPageState(assignWith(combinedState, state, assignIfUndefined))
+}
+
+export const pageStateReducer = (state: PaginationOptions, action: PageStateAction) => {
+  const updates = typeof action === 'function' ? action(state) : action
+  if (updates !== state) {
+    const nextState = interleave(state, updates)
+    return isEqual(state, nextState) ? state : nextState
+  }
+  return state
+}
+
+const usePageState = (props: PageStateProps) => {
+  const { pageState, updatePageState } = React.useContext(DataGridContext)
+  const controlledProps: PageState = {}
+  for (const key of pageStateKeys) {
+    if (props[key] !== undefined) controlledProps[key] = props[key]
+    delete props[key] // Remove from props so the rest can be safely forwarded.
+  }
+  const combinedState = interleave(pageState, controlledProps)
+  if (!combinedState.currentPage) {
+    controlledProps.currentPage = combinedState.currentPage = props.initialPage || 1
+  }
+  delete props.initialPage
+
+  React.useEffect(() => {
+    updatePageState(controlledProps)
+  })
+  return [combinedState, updatePageState] as const
+}
+
+export const DataGridPagination: React.FC<ExtendedPaginationProps> = ({
+  onPageChange,
+  ...props
+}) => {
+  const [pageState, updatePageState] = usePageState(props)
+  if (!pageState.pageCount) return null
+  return (
+    <Pagination
+      {...props}
+      currentPage={pageState.currentPage}
+      pageCount={pageState.pageCount}
+      onPageChange={(currentPage) => {
+        updatePageState({ currentPage }, true)
+        onPageChange?.(currentPage)
+      }}
+    />
+  )
+}
+DataGridPagination.displayName = 'DataGrid.Pagination'
+
+DataGridPagination.propTypes = {}
+pageStateKeys.forEach((key) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  DataGridPagination.propTypes![key] = PropTypes.number
+})
+
+const incrementPage: PageStateAction = ({ currentPage = 0 }) => ({ currentPage: currentPage + 1 })
+const decrementPage: PageStateAction = ({ currentPage = 2 }) => ({ currentPage: currentPage - 1 })
+
+export const DataGridPrevNext: React.FC<ExtendedPrevNextProps> = ({ onNavigate, ...props }) => {
+  const [pageState, updatePageState] = usePageState(props)
+  return (
+    <PrevNext
+      disablePrev={pageState.currentPage === 1}
+      onNavigate={(direction: 'prev' | 'next'): void => {
+        updatePageState(direction === 'prev' ? decrementPage : incrementPage, true)
+        onNavigate?.(direction)
+      }}
+      {...props}
+    />
+  )
+}
+DataGridPrevNext.displayName = 'DataGrid.PrevNext'
+
+DataGridPrevNext.propTypes = {
+  currentPage: PropTypes.number,
+  pageSize: PropTypes.number,
+  itemOffset: PropTypes.number,
+}

--- a/modules/cactus-web/src/DataGrid/TopSection.tsx
+++ b/modules/cactus-web/src/DataGrid/TopSection.tsx
@@ -33,17 +33,14 @@ const TopSection = (props: TopSectionProps): ReactElement | null => {
   const theme = useTheme()
 
   const handleSortColChange = (id: string) => {
-    if (sortOptions) {
-      const { sortAscending: currentSortAscending } = sortOptions[0] || {}
-      const newOptions = [
-        { id, sortAscending: currentSortAscending !== undefined ? currentSortAscending : false },
-      ]
-      onSort(newOptions)
-    }
+    // TODO We should have a way (per column) to specify default sort direction.
+    const { sortAscending: currentSortAscending = false } = sortOptions[0] || {}
+    const newOptions = [{ id, sortAscending: currentSortAscending }]
+    onSort(newOptions)
   }
 
   const handleSortDirChange = (sortAscending: boolean) => {
-    if (sortOptions) {
+    if (sortOptions.length) {
       onSort([{ ...sortOptions[0], sortAscending }])
     }
   }

--- a/modules/cactus-web/src/DataGrid/helpers.ts
+++ b/modules/cactus-web/src/DataGrid/helpers.ts
@@ -2,7 +2,7 @@ import { noop } from 'lodash'
 import { createContext } from 'react'
 import { DefaultTheme, ThemedStyledProps } from 'styled-components'
 
-import { DataGridContextType, TransientProps } from './types'
+import { DataGridContextType, PaginationOptions, TransientProps } from './types'
 
 export const getMediaQuery = (
   props: ThemedStyledProps<TransientProps, DefaultTheme>
@@ -34,14 +34,16 @@ export const getMediaQuery = (
   }
 }
 
+export const initialPageState: PaginationOptions = { currentPage: 0, pageSize: 0 }
+
 export const DataGridContext = createContext<DataGridContextType>({
   columns: [],
   sortableColumns: [],
   columnDispatch: noop,
   sortOptions: [],
   onSort: noop,
-  paginationOptions: undefined,
-  onPageChange: noop,
+  pageState: initialPageState,
+  updatePageState: noop,
   fullWidth: false,
   cardBreakpoint: 'tiny',
   isCardView: false,

--- a/modules/cactus-web/src/DataGrid/types.ts
+++ b/modules/cactus-web/src/DataGrid/types.ts
@@ -61,10 +61,25 @@ export interface SortOption {
   sortAscending: boolean
 }
 
-export interface PaginationOptions {
+export const pageStateKeys = [
+  'currentPage',
+  'pageCount',
+  'pageSize',
+  'itemCount',
+  'itemOffset',
+] as const
+
+export type PageState = { [K in typeof pageStateKeys[number]]?: number }
+
+// Backwards compat; if we ever make a breaking change, use `PageState` everywhere.
+export interface PaginationOptions extends PageState {
   currentPage: number
   pageSize: number
-  pageCount?: number
+}
+export type PageStateAction = React.SetStateAction<PageState>
+
+export interface Pagisort extends PaginationOptions {
+  sort?: SortOption[]
 }
 
 export interface ColumnProps extends Omit<TableCellProps, 'as' | 'children' | 'title'> {
@@ -82,8 +97,8 @@ export interface DataGridContextType extends ColumnState {
   columnDispatch: ColumnDispatch
   sortOptions: SortOption[]
   onSort: (newSortOptions: SortOption[]) => void
-  paginationOptions: PaginationOptions | undefined
-  onPageChange: (newPageOptions: PaginationOptions) => void
+  pageState: PaginationOptions
+  updatePageState: (action: PageStateAction, raiseEvent?: boolean) => void
   fullWidth: boolean
   cardBreakpoint: Size
   isCardView: boolean

--- a/modules/cactus-web/src/hooks.ts
+++ b/modules/cactus-web/src/hooks.ts
@@ -1,0 +1,3 @@
+// repay-scripts can't handle `index` files for some reason...
+export { default as useControllableValue } from './hooks/useControllableValue'
+export { default as useRefState } from './hooks/useRefState'

--- a/modules/cactus-web/src/hooks/tests/useControllableValue.test.tsx
+++ b/modules/cactus-web/src/hooks/tests/useControllableValue.test.tsx
@@ -1,0 +1,154 @@
+import { act, render } from '@testing-library/react'
+import React from 'react'
+
+import useControllableValue from '../useControllableValue'
+import { SyncDispatch } from '../useRefState'
+
+interface Props {
+  value?: string
+  num?: number
+}
+
+// In reality you should never change the "controlled-ness" of a prop,
+// but doing so in these tests is a convenient way to illustrate behavior.
+describe('`useControllableValue` hook', () => {
+  test('uncontrolled to controlled', () => {
+    let value = 'initial'
+    let setValue: SyncDispatch<string> = () => ''
+
+    const Component = (props: Props) => {
+      ;[value, setValue] = useControllableValue(props, 'value', 'first')
+      return null
+    }
+    const { rerender } = render(<Component />)
+    expect(value).toBe('first')
+
+    act(() => {
+      expect(setValue((s) => `+${s}`)).toBe('+first')
+    })
+    expect(value).toBe('+first')
+
+    rerender(<Component value="testing" />)
+    expect(value).toBe('testing')
+    act(() => {
+      expect(setValue('bad')).toBe('bad')
+    })
+    expect(value).toBe('testing')
+  })
+
+  test('uncontrolled to controlled with normalizer', () => {
+    let value = NaN
+    let setValue: SyncDispatch<number> = () => NaN
+
+    const norm = (p: Props, s: number) => p.num ?? (p.value?.length || 1) * s
+    const Component = (props: Props) => {
+      ;[value, setValue] = useControllableValue(props, norm, 21)
+      return null
+    }
+    const { rerender } = render(<Component />)
+    expect(value).toBe(21)
+
+    act(() => {
+      expect(setValue(14)).toBe(14)
+    })
+    expect(value).toBe(14)
+
+    rerender(<Component value="hey" />)
+    expect(value).toBe(42)
+    act(() => {
+      expect(setValue(2)).toBe(2)
+    })
+    expect(value).toBe(6)
+    // Normally you'd never want a normalizer that modifies the existing state
+    // just by rendering, but it works well to illustrate when & how it's called.
+    rerender(<Component value="hey" />)
+    expect(value).toBe(18)
+
+    rerender(<Component value="hey" num={42} />)
+    expect(value).toBe(42)
+  })
+
+  test('controlled to uncontrolled', () => {
+    let value = ''
+    let setValue: SyncDispatch<string, void> = () => ''
+
+    const reducer = (x: string) => `-${x}`
+    const Component = (props: Props) => {
+      ;[value, setValue] = useControllableValue(props, 'value', reducer, 'hello')
+      return null
+    }
+    const { rerender } = render(<Component value="goodbye" />)
+    expect(value).toBe('goodbye')
+
+    act(() => {
+      expect(setValue()).toBe('-goodbye')
+    })
+    expect(value).toBe('goodbye')
+
+    rerender(<Component />)
+    expect(value).toBe('goodbye')
+    act(() => {
+      expect(setValue()).toBe('-goodbye')
+    })
+    expect(value).toBe('-goodbye')
+  })
+})
+
+// The underlying logic is tested in the `useRefState` tests, so we don't need to
+// write actual test cases for these; but we still want to cover the type checks.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// useState is covered sufficiently in tests above.
+// useReducer with key & initial arg is covered in the test above
+
+const useReducerWithInitializerFunc = () => {
+  const props: { flag?: boolean } = {}
+  const reducer = (x: boolean, a: string) => !x && a.length > 7
+  const init = (x: string) => x.length < 2
+  const [value, setValue] = useControllableValue(props, 'flag', reducer, 'seven', init)
+  const bool: boolean = value
+  setValue('hey')
+  // @ts-expect-error
+  const s: string = value
+  // @ts-expect-error
+  setValue(undefined)
+  // @ts-expect-error
+  setValue(false)
+  // @ts-expect-error
+  setValue(() => true)
+}
+
+const useReducerWithNormalizerAndInitialArg = () => {
+  const props: { flag?: boolean } = {}
+  const norm = (p: typeof props, s: boolean) => s
+  const reducer = (x: boolean, a: string) => !x && a.length > 7
+  const [value, setValue] = useControllableValue(props, norm, reducer, false)
+  const bool: boolean = value
+  setValue('hey')
+  // @ts-expect-error
+  const s: string = value
+  // @ts-expect-error
+  setValue(undefined)
+  // @ts-expect-error
+  setValue(false)
+  // @ts-expect-error
+  setValue(() => true)
+}
+
+const useReducerWithNormalizerAndInitializerFunc = () => {
+  const props: { flag?: boolean } = {}
+  const norm = (p: typeof props, s: boolean) => s
+  const reducer = (x: boolean, a: string) => !x && a.length > 7
+  const init = (x: string) => x.length < 2
+  const [value, setValue] = useControllableValue(props, norm, reducer, 'seven', init)
+  const bool: boolean = value
+  setValue('hey')
+  // @ts-expect-error
+  const s: string = value
+  // @ts-expect-error
+  setValue(undefined)
+  // @ts-expect-error
+  setValue(false)
+  // @ts-expect-error
+  setValue(() => true)
+}

--- a/modules/cactus-web/src/hooks/tests/useRefState.test.tsx
+++ b/modules/cactus-web/src/hooks/tests/useRefState.test.tsx
@@ -1,0 +1,210 @@
+import { act, render } from '@testing-library/react'
+import React from 'react'
+
+import useRefState from '../useRefState'
+
+interface TestCase {
+  expected: unknown
+  update: () => any
+}
+
+interface TestData {
+  initialValue: unknown
+  ref: React.RefObject<any>
+}
+
+type HookResult = [TestData, ...TestCase[]]
+
+const runTestCases = (useTest: () => HookResult) => {
+  let $testCases: HookResult = null as any
+  const Component = () => {
+    $testCases = useTest()
+    return <div>{$testCases[0].ref.current}</div>
+  }
+  const { container } = render(<Component />)
+  const [{ ref, initialValue }, ...testCases] = $testCases
+  expect(ref.current).toBe(initialValue)
+  for (const { expected, update } of testCases) {
+    act(() => {
+      // Show that the update happens synchronously.
+      expect(update()).toBe(expected)
+      expect(ref.current).toBe(expected)
+    })
+    expect(container).toHaveTextContent(String(expected ?? ''))
+  }
+}
+
+describe('`useRefState` hook', () => {
+  // I'm going to put some Typescript errors after the return values so they won't affect the test.
+  /* eslint-disable no-unreachable */
+
+  describe('when used like `useState`', () => {
+    test('with no initializer', () => {
+      runTestCases(function useTest() {
+        const ref = useRefState<string>()
+        const funcAction = (x: string | undefined) => `${x}-suffix`
+        return [
+          { ref, initialValue: undefined },
+          { expected: undefined, update: () => ref.setState(undefined) },
+          { expected: 'undefined-suffix', update: () => ref.setState(funcAction) },
+          { expected: 'something', update: () => ref.setState('something') },
+          { expected: 'something-suffix', update: () => ref.setState(funcAction) },
+        ]
+        // @ts-expect-error
+        ref.setState(42)
+        // @ts-expect-error
+        ref.setState((x: number) => x.toString())
+        // @ts-expect-error
+        ref.setState((x: string | undefined) => parseInt(x))
+        // @ts-expect-error
+        ref.setState((x: string) => x)
+      })
+    })
+
+    test('with initial value', () => {
+      runTestCases(function useTest() {
+        const ref = useRefState('nope')
+        const funcAction = (x: string) => `${x}-suffix`
+        return [
+          { ref, initialValue: 'nope' },
+          { expected: 'nope-suffix', update: () => ref.setState(funcAction) },
+          { expected: 'something', update: () => ref.setState('something') },
+        ]
+        // @ts-expect-error
+        ref.setState(undefined)
+        // @ts-expect-error
+        ref.setState(42)
+      })
+    })
+
+    test('with initializer function', () => {
+      const initial = Math.random()
+
+      runTestCases(function useTest() {
+        const ref = useRefState(() => initial)
+        const funcAction = (x: number) => x + 2
+        return [
+          { ref, initialValue: initial },
+          { expected: initial + 2, update: () => ref.setState(funcAction) },
+          { expected: 4242564, update: () => ref.setState(4242564) },
+        ]
+        // @ts-expect-error
+        ref.setState(undefined)
+        // @ts-expect-error
+        ref.setState('testing')
+      })
+    })
+  })
+
+  describe('when used like `useReducer`', () => {
+    describe('with void action', () => {
+      test('with no initializer', () => {
+        runTestCases(function useTest() {
+          const ref = useRefState<number>((x: number | undefined) => (x === undefined ? -1 : -x))
+          return [
+            { ref, initialValue: undefined },
+            { expected: -1, update: () => ref.setState() },
+            { expected: 1, update: () => ref.setState() },
+          ]
+          // @ts-expect-error
+          ref.setState(10)
+          // @ts-expect-error
+          ref.setState((x: any) => x)
+        })
+      })
+
+      test('with initial value', () => {
+        runTestCases(function useTest() {
+          const ref = useRefState((x: number) => x / 2 + 1, 42)
+          return [
+            { ref, initialValue: 42 },
+            { expected: 22, update: () => ref.setState() },
+            { expected: 12, update: () => ref.setState() },
+          ]
+          // @ts-expect-error
+          ref.setState(10)
+          // @ts-expect-error
+          ref.setState((x: any) => x)
+        })
+      })
+
+      test('with initializer function', () => {
+        runTestCases(function useTest() {
+          const ref = useRefState((x: number) => -x + 3, '17.5', parseInt)
+          return [
+            { ref, initialValue: 17 },
+            { expected: -14, update: () => ref.setState() },
+            { expected: 17, update: () => ref.setState() },
+          ]
+          // @ts-expect-error
+          ref.setState(10)
+          // @ts-expect-error
+          ref.setState((x: any) => x)
+        })
+      })
+    })
+
+    describe('with concrete action', () => {
+      test('with no initializer', () => {
+        runTestCases(function useTest() {
+          const ref = useRefState<number, boolean>((x, y) => {
+            if (x === undefined) return Number(y)
+            return y ? x + 1 : x - 1
+          })
+          return [
+            { ref, initialValue: undefined },
+            { expected: 1, update: () => ref.setState(true) },
+            { expected: 2, update: () => ref.setState(true) },
+            { expected: 1, update: () => ref.setState(false) },
+          ]
+          // @ts-expect-error
+          ref.setState(10)
+          // @ts-expect-error
+          ref.setState((x: any) => x)
+        })
+      })
+
+      test('with initial value', () => {
+        runTestCases(function useTest() {
+          const ref = useRefState(
+            (x: string, y: number) =>
+              Array(y)
+                .fill(x[y] || 'x')
+                .join('q'),
+            'hello'
+          )
+          return [
+            { ref, initialValue: 'hello' },
+            { expected: 'lql', update: () => ref.setState(2) },
+            { expected: 'xqxqxqx', update: () => ref.setState(4) },
+            { expected: 'q', update: () => ref.setState(1) },
+          ]
+          // @ts-expect-error
+          ref.setState('10')
+          // @ts-expect-error
+          ref.setState((x: any) => x)
+        })
+      })
+
+      test('with initializer function', () => {
+        runTestCases(function useTest() {
+          const ref = useRefState(
+            (x: number, y: boolean) => (y ? x + 10 : x / 2),
+            { value: 7 },
+            (o) => o.value
+          )
+          return [
+            { ref, initialValue: 7 },
+            { expected: 17, update: () => ref.setState(true) },
+            { expected: 27, update: () => ref.setState(true) },
+            { expected: 13.5, update: () => ref.setState(false) },
+          ]
+          // @ts-expect-error
+          ref.setState(10)
+          // @ts-expect-error
+          ref.setState((x: any) => x)
+        })
+      })
+    })
+  })
+})

--- a/modules/cactus-web/src/hooks/useControllableValue.ts
+++ b/modules/cactus-web/src/hooks/useControllableValue.ts
@@ -1,0 +1,92 @@
+/* State that represents a value that may or may not be controlled by a prop.
+ *
+ * Uses `useRefState` for synchronous updates, so `onChange` events can be
+ * raised with their original event objects (e.g. using `CactusChangeEvent`).
+ *
+ * When controlled, the prop value is always used for rendering but the state
+ * isn't updated till rendering finishes to avoid concurrency issues (React 18).
+ * State updates might operate on "old" state in the interim, but since such
+ * updates generally arise from user input, and the users haven't even seen the
+ * "new" state yet, this is probably the correct behavior.
+ *
+ * If the state DOES change during render, the controlled value is dropped
+ * under the assumption that another render is already pending as a result
+ * of the concurrent state change.
+ */
+import { Reducer, useEffect } from 'react'
+
+import useRefState, { Initializer, SyncDispatch } from './useRefState'
+
+export type Normalizer<P, S> = (props: P, lastState: S) => S
+
+// Advanced mapping: drops any keys that don't map to values of the state type.
+type Keyof<P, S> = keyof { [K in keyof P as S extends P[K] ? K : never]: unknown }
+
+// Unlike `useRefState`, this requires an initializer because (presumably)
+// the fact that it falls back to internal state if the prop is undefined
+// means the value shouldn't be undefined (unless explicitly part of the type).
+interface UseControllableValue {
+  /* Simple version: pass the prop name to extract the value from props. */
+  <S, P>(props: P, key: Keyof<P, S>, initArg: Initializer<S>): [S, SyncDispatch<S>]
+  <S, P, A = void>(props: P, key: Keyof<P, S>, reducer: Reducer<S, A>, initial: S): [
+    S,
+    SyncDispatch<S, A>
+  ]
+  <S, P, I = S, A = void>(
+    props: P,
+    key: Keyof<P, S>,
+    reducer: Reducer<S, A>,
+    initArg: I,
+    initializer: (i: I) => S
+  ): [S, SyncDispatch<S, A>]
+
+  /* Normalized version: pass a function that extracts the value from props. */
+  <S, P>(props: P, normalize: Normalizer<P, S>, initArg: Initializer<S>): [S, SyncDispatch<S>]
+  <S, P, A = void>(props: P, normalize: Normalizer<P, S>, reducer: Reducer<S, A>, initial: S): [
+    S,
+    SyncDispatch<S, A>
+  ]
+  <S, P, I = S, A = void>(
+    props: P,
+    normalize: Normalizer<P, S>,
+    reducer: Reducer<S, A>,
+    initArg: I,
+    initializer: (i: I) => S
+  ): [S, SyncDispatch<S, A>]
+}
+
+// Uses generic types externally, but concrete types internally to validate logic.
+type Props = { value?: number }
+
+// If the `props` object passed is mutable, the given key will be deleted after extraction.
+const extractByKey = (props: Props, key: 'value', lastState: number) => {
+  const value = props[key] ?? lastState
+  try {
+    delete props[key]
+  } catch {}
+  return value
+}
+
+const useControllableValue = (
+  props: Props,
+  key: 'value' | Normalizer<Props, number>,
+  ...args: [Reducer<number, void>, string, (s: string) => number]
+): [number, SyncDispatch<number, void>] => {
+  const ref = useRefState(...args)
+  const preRenderState = ref.current
+  const value: number =
+    typeof key === 'function'
+      ? key(props, preRenderState)
+      : extractByKey(props, key, preRenderState)
+
+  useEffect(() => {
+    // We just used this value, so don't need to trigger a re-render;
+    // however, only update if nothing has changed since render started.
+    if (ref.current === preRenderState) {
+      ref.current = value
+    }
+  })
+
+  return [value, ref.setState]
+}
+export default useControllableValue as UseControllableValue

--- a/modules/cactus-web/src/hooks/useControllableValue.ts
+++ b/modules/cactus-web/src/hooks/useControllableValue.ts
@@ -56,10 +56,14 @@ interface UseControllableValue {
 }
 
 // Uses generic types externally, but concrete types internally to validate logic.
-type Props = { value?: number }
+type StateType = string
+type ActionType = void
+type Props = { value?: StateType }
+type KeyType = Keyof<Props, StateType>
+type StateHookArgs = [Reducer<StateType, ActionType>, StateType]
 
 // If the `props` object passed is mutable, the given key will be deleted after extraction.
-const extractByKey = (props: Props, key: 'value', lastState: number) => {
+const extractByKey = (props: Props, key: KeyType, lastState: StateType) => {
   const value = props[key] ?? lastState
   try {
     delete props[key]
@@ -69,12 +73,12 @@ const extractByKey = (props: Props, key: 'value', lastState: number) => {
 
 const useControllableValue = (
   props: Props,
-  key: 'value' | Normalizer<Props, number>,
-  ...args: [Reducer<number, void>, string, (s: string) => number]
-): [number, SyncDispatch<number, void>] => {
+  key: KeyType | Normalizer<Props, StateType>,
+  ...args: StateHookArgs
+): [StateType, SyncDispatch<StateType, ActionType>] => {
   const ref = useRefState(...args)
   const preRenderState = ref.current
-  const value: number =
+  const value: StateType =
     typeof key === 'function'
       ? key(props, preRenderState)
       : extractByKey(props, key, preRenderState)

--- a/modules/cactus-web/src/hooks/useRefState.ts
+++ b/modules/cactus-web/src/hooks/useRefState.ts
@@ -1,0 +1,87 @@
+/* A `useState`/`useReducer` replacement featuring a constant,
+ * mutable state object and synchronous state updates.
+ *
+ * Note the return value isn't an array; I figured since we already have
+ * a stable object with both the value & dispatcher attached, might as
+ * well just return it instead of initializing an array.
+ *
+ * Just like regular refs or state, you should treat it as immutable in the
+ * body of render functions, and only change the value in events/effect hooks.
+ * You generally shouldn't pass the ref itself to child components, only the value.
+ *
+ * I got the idea for this kind of semi-mutable state from the `useSyncExternalStore` shim.
+ */
+import { Reducer, SetStateAction, useReducer } from 'react'
+
+export type Initializer<T> = T | (() => T)
+
+// Unlike normal dispatch, this returns the next state; because of the
+// synchronous guarantee, the dev may want to do something with it.
+export type SyncDispatch<S, A = SetStateAction<S>> = (action: A) => S
+
+export interface RefState<State, Action = SetStateAction<State>> {
+  current: State
+  setState: SyncDispatch<State, Action>
+}
+
+interface UseRefState {
+  <S>(initial: Initializer<S>): RefState<S>
+  <S = undefined>(): RefState<S | undefined>
+  <S, A = void>(reducer: Reducer<S, A>, initial: S): RefState<S, A>
+  <S, I = S, A = void>(reducer: Reducer<S, A>, initArg: I, initializer: (i: I) => S): RefState<S, A>
+  <S = undefined, A = void>(reducer: Reducer<S | undefined, A>): RefState<S | undefined, A>
+}
+
+// Uses generic types externally, but concrete types internally to validate logic.
+type Func<A> = (arg: A) => string
+
+type StateHookArgs = [Initializer<string>]
+type ReducerHookArgs = [Reducer<string, number>, 'key', Func<'key'>?]
+
+type HookArgs = StateHookArgs | ReducerHookArgs
+type InnerState = { ref: RefState<string, unknown> }
+
+const reduceRef = (state: InnerState): InnerState => ({ ...state })
+
+const initializeRef = (args: HookArgs): InnerState => {
+  let current: string
+  if (isReducer(args)) {
+    current = args[1]
+    if (typeof args[2] === 'function') {
+      current = args[2](args[1])
+    }
+  } else if (typeof args[0] === 'function') {
+    current = args[0]()
+  } else {
+    current = args[0]
+  }
+  // TS appeasement; define the real thing in the hook body.
+  const setState: Func<unknown> = false as any
+  return { ref: { current, setState } }
+}
+
+// `useState` only takes one arg, and if it's a function it shouldn't have any params.
+const isReducer = (args: HookArgs): args is ReducerHookArgs =>
+  args.length > 1 || (typeof args[0] === 'function' && args[0].length > 0)
+
+// This is basically what the real `useState` does behind the scenes.
+const genericReducer = (state: string, action: string | Func<string>) =>
+  typeof action === 'function' ? action(state) : action
+
+const useRefState = (...args: HookArgs): InnerState['ref'] => {
+  const [{ ref }, triggerRender] = useReducer(reduceRef, args, initializeRef)
+  if (!ref.setState) {
+    const reducer: Reducer<string, any> = isReducer(args) ? args[0] : genericReducer
+    ref.setState = (action) => {
+      const nextState = reducer(ref.current, action)
+      if (nextState !== ref.current) {
+        ref.current = nextState
+        triggerRender()
+      }
+      return nextState
+    }
+  }
+  return ref
+}
+
+export default useRefState as UseRefState

--- a/modules/cactus-web/src/index.ts
+++ b/modules/cactus-web/src/index.ts
@@ -1,4 +1,5 @@
 import './helpers/polyfills'
+export * from './hooks'
 
 export { AccessibleField, useAccessibleField } from './AccessibleField/AccessibleField'
 export { default as Accordion } from './Accordion/Accordion'

--- a/modules/cactus-web/tests/__snapshots__/exports.test.ts.snap
+++ b/modules/cactus-web/tests/__snapshots__/exports.test.ts.snap
@@ -86,5 +86,7 @@ Array [
   "usePopup",
   "useScreenSize",
   "useScrollTrap",
+  "useControllableValue",
+  "useRefState",
 ]
 `;


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-969

This consists of three changes:
- Added `itemCount` and `itemOffset` as alternatives to `pageCount` and `currentPage` respectively (`pageSize` required to use).
- Added ability to control pagination via props passed directly to `PageSizeSelect`, `Pagination`, and `PrevNext`.
  - Along with this, I moved most of the pagination-related logic to its own file.
- Added `onPagisort` handler, combining `onSort` & `onPageChange` and allowing pagination & sorting to be done uncontrolled.

Originally this would have involved making `currentPage` and `pageCount` optional properties, but it turns out that would have been a breaking change to the `onPageChange` handler.

Also made some story changes:
- Sort is now entirely uncontrolled.
- Pagination is now controlled through sub-components.
- I'd have made that uncontrolled as well, but it wouldn't work with clone/delete.

And finally, the hooks:

`useControllableValue` is a hook I've been mulling around in my head since at least the last time I worked on the `Select` component, although I've been trying to come up with the "ideal" way of handling that use case basically since I started on the team. Not that complicated, though it took a while to get Typescript playing nicely with it. Eventually, I'd like to refactor a lot of our other components to use this.

`useRefState` is mostly to make `useControllableValue` viable in React 18, but I've had at least one other use case for it in Channels. It could also possibly be used as a replacement for `useStateWithCallback`, although I can't say for sure there would _never_ be a use case for running a callback after the new state value has been _rendered_, instead of just after it's been _changed_.

The new hooks directory/file is for two reasons:
1. `helpers/react.ts` is getting pretty crowded.
2. Often the hooks I write in cactus-web are useful enough that I want to use them in Channels (or elsewhere), so I wanted somewhere we could put all the "exportable" hooks. We can keep hooks for internal-use only in `helpers`, and slowly move the others to the `hooks` directory and export them via `hooks.ts`. (Speaking of which, should we fix `repay-scripts` to be able to handle index files?)