### PR TITLE
CACTUS-1016: fix popup overlap with sticky positioning

### DIFF
--- a/modules/cactus-web/src/Table/Table.tsx
+++ b/modules/cactus-web/src/Table/Table.tsx
@@ -10,7 +10,6 @@ import styled, {
 } from 'styled-components'
 import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
-import { isIE } from '../helpers/constants'
 import { extractMargins } from '../helpers/omit'
 import { useMergedRefs } from '../helpers/react'
 import { border, boxShadow, media, radius, textStyle } from '../helpers/theme'
@@ -125,25 +124,6 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
         }
       }
     })
-
-    // Can be removed if we switch popups back to portals.
-    React.useEffect(() => {
-      if (sticky === 'right' && !isIE && tableRef.current) {
-        const observer = new MutationObserver((mutations) => {
-          for (const mut of mutations) {
-            if (mut.type === 'attributes' && mut.attributeName === 'aria-expanded') {
-              const target = mut.target as HTMLElement
-              const cell = target.closest('td, th') as HTMLElement
-              if (cell) {
-                cell.style.zIndex = target.getAttribute('aria-expanded') === 'true' ? '1' : ''
-              }
-            }
-          }
-        })
-        observer.observe(tableRef.current, { attributeFilter: ['aria-expanded'], subtree: true })
-        return () => observer.disconnect()
-      }
-    }, [sticky])
 
     if (props.variant) {
       context.variant = props.variant
@@ -394,6 +374,9 @@ const table = css<TableProps>`
     }
     :last-child {
       border-right: ${(p): string => border(p.theme, 'lightContrast')};
+      :focus-within {
+        z-index: 1;
+      }
       ${(p) =>
         p.sticky === 'right' ? `position: sticky; right: 0; ${boxShadow(p.theme, 0)}` : ''};
     }


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-1016

You can UAT this on the `DataGrid` story.

This is kind of a hacky solution; if we switch to using portals, this whole commit can just be reverted.
- The MutationObserver fixes the issue of popups appearing underneath the next row(s).
- The scroll parent change fixes the issue of popups being hidden by the table's scroll container. (Not mentioned in the ticket, but can easily be seen by opening the drop-down on the last row; somehow doesn't appear to happen on Chrome, though? It does on Firefox.)