### PR TITLE
CACTUS-998: support Flex gap property; add `Flex.Item`

### DIFF
--- a/examples/mock-ebpp/src/containers/ui-config.tsx
+++ b/examples/mock-ebpp/src/containers/ui-config.tsx
@@ -284,11 +284,11 @@ const UIConfig: React.FunctionComponent<RouteComponentProps> = () => {
                     error={touched.establishedDate && errors.establishedDate}
                   />
 
-                  <Flex width="100%" justifyContent="center">
-                    <Button type="reset" variant="standard" my={3} mr={3}>
+                  <Flex width="100%" justifyContent="space-evenly" marginTop={4} gap={4}>
+                    <Button type="reset" variant="standard">
                       Reset
                     </Button>
-                    <Button type="submit" variant="action" my={3} ml={3}>
+                    <Button type="submit" variant="action">
                       Submit
                     </Button>
                   </Flex>

--- a/modules/cactus-web/src/Flex/Flex.mdx
+++ b/modules/cactus-web/src/Flex/Flex.mdx
@@ -14,8 +14,8 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 ### Try it out
 
 export const code = `<Flex ph={1} justifyContent="space-between">
-  <Button variant="standard">Cancel</Button>
-  <Button variant="action">Action</Button>
+  <Flex.Item as={Button} variant="standard">Cancel</Flex.Item>
+  <Flex.Item as={Button} variant="action">Action</Flex.Item>
 </Flex>`
 
 <LiveProvider code={code} scope={{ Flex, Button }}>
@@ -26,34 +26,43 @@ export const code = `<Flex ph={1} justifyContent="space-between">
 
 ## Best practices
 
-Use the theme based parameters when possible to avoid discrepencies between the design-system and the layout.
+Use the theme-based parameters when possible to avoid discrepencies between the design-system and the layout.
 
 The `flexDirection=reverse` property should only be used for user experience purposes to affect the tab order. An example would be that the submit button is on the right and we want the user to tab there first instead of the Cancel button which is on the left.
 
 ## Basic usage
 
-The `Flex` component is a generic component which is an extension of the <a href="../box/">Box</a> component which adds flex based styling.
+The `Flex` component is an extension of the <a href="../box/">Box</a> component which adds flex-based styling.
+It has all the props from `Box`, plus all flex container _and_ flex item props.
+It also has a subcomponent, `Flex.Item`, with just the flex item props.
 
-```jsx
-import React from 'react'
-import { Flex, Button } from '@repay/cactus-web'
+### IE Compatibility
 
-/**
- *  center a button in it's container using margin = 0 auto
- *  and setting padding top and bottom to the 3rd
- *  space with the `ph` prop
- */
-export default () => (
-  <Flex ph={3} justifyContent="space-between">
-    <Button variant="standard">Cancel</Button>
-    <Button variant="action">Action</Button>
-  </Flex>
-)
-```
+IE doesn't have the greatest flex support. We have a couple built-in workarounds,
+but even then if you need IE support be careful and test thoroughly.
+- `justifyContent="space-evenly"` is not supported, but is faked by adding empty `::before` & `::after` pseudo-elements and using `space-between`. Don't try to combine this with an element that already has such pseudo-elements.
+- `gap` (or `rowGap` & `colGap`) is not supported at all, but that's worked around by setting the margins on all direct children to `calc([gap] / 2)`.
+  - This will override any margins set directly on the children, so be careful of that.
+  - It also leaves some extra space around the edges of the container. The extra space can be "removed" by setting a negative margin on the Flex container, but this is not done automatically because it throws off width calculations and interferes with explicitly set margins, which are more common on containers than flex items.
+  - **To help with some custom fixes, there's a boolean Flex.supportsGap property that can be checked.**
 
 ## Properties
 
-Has the same styled props as <a href="../box/">Box</a>, plus the [styled-system flexbox](https://styled-system.com/api/#flexbox) props.
+All Box props, plus:
+- alignItems
+- alignContent
+- justifyContent
+- flexWrap
+- flexDirection
+- gap (or rowGap & colGap)
+- all flex item props (see below)
 
-Note that, although `justifyContent="stretch"` is supported by this component, `stretch` is not supported in Internet Explorer, so make
-sure you know whether or not you need to support IE before using that value.
+### Flex.Item
+
+- flex
+- flexShrink
+- flexGrow
+- flexBasis
+- alignSelf
+- order
+- polymorphic `as` prop from styled-components

--- a/modules/cactus-web/src/Flex/Flex.story.tsx
+++ b/modules/cactus-web/src/Flex/Flex.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { Flex } from '../'
-import { Story } from '../helpers/storybook'
+import { HIDE_CONTROL, SPACE, Story } from '../helpers/storybook'
 
 const justifyOptions = [
   'unset',
@@ -29,6 +29,11 @@ export default {
     flexDirection: { options: directionOptions },
     height: { control: 'text' },
     alignSelf: { options: alignOptions },
+    gap: SPACE,
+    as: HIDE_CONTROL,
+    ref: HIDE_CONTROL,
+    theme: HIDE_CONTROL,
+    forwardedAs: HIDE_CONTROL,
   },
   args: {
     justifyContent: 'flex-end',

--- a/modules/cactus-web/src/Flex/Flex.test.tsx
+++ b/modules/cactus-web/src/Flex/Flex.test.tsx
@@ -11,6 +11,7 @@ describe('component: Flex', () => {
         alignItems="center"
         flexWrap="nowrap"
         flexDirection="column"
+        gap={4}
         data-testid="flexContainer"
       >
         <Flex alignSelf="flex-end" />
@@ -24,6 +25,7 @@ describe('component: Flex', () => {
     expect(styles.alignItems).toBe('center')
     expect(styles.flexWrap).toBe('nowrap')
     expect(styles.flexDirection).toBe('column')
+    expect(styles.gap).toBe('16px')
   })
 
   test('should accept basic built-in props', () => {

--- a/modules/cactus-web/src/Footer/Footer.tsx
+++ b/modules/cactus-web/src/Footer/Footer.tsx
@@ -28,6 +28,7 @@ import {
   flexItem,
   FlexItemProps,
   FlexProps,
+  gapWorkaround,
   sizing,
   SizingProps,
   styledUnpoly,
@@ -169,6 +170,7 @@ export const Footer = styledUnpoly(FooterBase as FooterComponent)`
     ${colorStyle('darkContrast', 'lightCallToAction')};
   }
 
+  ${gapWorkaround}
   &&& {
     ${compose(flexContainer, padding)}
   }

--- a/modules/cactus-web/src/Modal/Modal.tsx
+++ b/modules/cactus-web/src/Modal/Modal.tsx
@@ -29,6 +29,7 @@ import {
   flexItem,
   FlexItemProps,
   FlexProps,
+  gapWorkaround,
   pickStyles,
   Styled,
   styledProp,
@@ -144,6 +145,7 @@ const ModalPopUp = styledWithClass(DialogContent, 'cactus-modal').withConfig(
     padding: ${space(7)} 88px;
   }
 
+  ${gapWorkaround}
   // Because of how styled-components groups styles, we have to increase
   // the specificity in order to override the styles in the media queries.
   && {


### PR DESCRIPTION
UAT: https://repayonline.atlassian.net/browse/CACTUS-998

I also moved the `space-evenly` fix into the styled-system code, and removed some properties that have no effect on flex layouts (`justifyItems` & `justifySelf`).

The `Flex.Item` component is just because I've come across quite a few situations where I wanted to set a flex property, but the component I was using didn't support them.

Because `Modal` and `Footer` also utilize the `flexContainer` styles, I added the gap workaround to them as well.

