### PR TITLE
CACTUS-1043: add italic placeholder styles to TextArea

### DIFF
--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -1,17 +1,21 @@
-import { border, color, colorStyle, mediaGTE, radius, textStyle } from '@repay/cactus-theme'
+import { mediaGTE, radius, textStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import { compose, height, HeightProps, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
+import { StatusProps, StatusPropType } from '../helpers/status'
 import { styledProp } from '../helpers/styled'
+import { commonInputStyles } from '../TextInput/TextInput'
 
 type AreaElementProps = Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'height' | 'width'>
-export interface TextAreaProps extends AreaElementProps, MarginProps, HeightProps, WidthProps {
-  disabled?: boolean
-  status?: Status | null
+export interface TextAreaProps
+  extends AreaElementProps,
+    StatusProps,
+    MarginProps,
+    HeightProps,
+    WidthProps {
   resize?: boolean
 }
 
@@ -21,41 +25,19 @@ interface AreaProps extends TextAreaProps {
 }
 
 const Area = styled.textarea<AreaProps>`
-  border: ${border('darkContrast')};
   border-radius: ${radius(8)};
   min-height: 100px;
   ${mediaGTE('small')} {
     min-width: 336px;
   }
-  box-sizing: border-box;
   ${textStyle('body')}
   padding: 8px 16px;
-  outline: none;
-  ${colorStyle('standard')};
   height: ${(p) => p.$height};
   width: ${(p) => p.$width};
   display: block;
   resize: ${(p) => (p.resize ? 'vertical' : 'none')};
 
-  &:first-line {
-    padding-right: 15px;
-  }
-
-  &:focus {
-    border-color: ${color('callToAction')};
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    border-color: ${color('lightGray')};
-    ${colorStyle('disable')};
-  }
-
-  &:disabled::placeholder {
-    color: ${color('mediumGray')};
-    font-style: oblique;
-  }
-  ${getStatusStyles}
+  ${commonInputStyles}
 `
 
 const TextAreaBase = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -8,27 +8,22 @@ import defaultTheme, {
 } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { compose, margin, MarginProps, width, WidthProps } from 'styled-system'
 
 import { omitMargins } from '../helpers/omit'
-import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
+import { getStatusStyles, StatusProps, StatusPropType } from '../helpers/status'
 
 type TextStyleKey = keyof TextStyleCollection
 export const textStyles = Object.keys(defaultTheme.textStyles) as TextStyleKey[]
 
 type InputElementProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'width'>
-export interface TextInputProps extends InputElementProps, MarginProps, WidthProps {
-  /** !important */
-  disabled?: boolean
-  status?: Status | null
+export interface TextInputProps extends InputElementProps, StatusProps, MarginProps, WidthProps {
   textStyle?: TextStyleKey
 }
 
-interface InputProps {
+interface InputProps extends StatusProps {
   $width: string
-  disabled?: boolean
-  status?: Status | null
   textStyle?: TextStyleKey
 }
 
@@ -44,15 +39,11 @@ const TextInputBase = React.forwardRef<HTMLInputElement, TextInputProps>(
   }
 )
 
-const Input = styled.input<InputProps>`
+export const commonInputStyles = css<StatusProps>`
   box-sizing: border-box;
   border: ${border('darkContrast')};
-  border-radius: ${radius(20)};
   outline: none;
-  padding: 3px 28px 3px 15px;
-  ${(p) => textStyle(p, p.textStyle || 'body')};
   ${colorStyle('standard')}
-  width: ${(p) => p.$width};
 
   &:disabled {
     cursor: not-allowed;
@@ -70,10 +61,19 @@ const Input = styled.input<InputProps>`
 
   &::placeholder {
     color: ${color('mediumContrast')};
-    font-style: oblique;
+    font-style: italic;
   }
 
   ${getStatusStyles}
+`
+
+const Input = styled.input<InputProps>`
+  border-radius: ${radius(20)};
+  padding: 3px 28px 3px 15px;
+  ${(p) => textStyle(p, p.textStyle || 'body')};
+  width: ${(p) => p.$width};
+
+  ${commonInputStyles}
 `
 
 export const TextInput = styled(TextInputBase)`

--- a/modules/cactus-web/src/helpers/status.ts
+++ b/modules/cactus-web/src/helpers/status.ts
@@ -7,13 +7,13 @@ export type Status = typeof statuses[number]
 type StatusBackground = 'successLight' | 'warningLight' | 'errorLight'
 export const StatusPropType = PropTypes.oneOf<Status>(statuses)
 
-interface StatusProps {
-  theme: CactusTheme
+export interface StatusProps {
   status?: Status | null
+  /** !important */
   disabled?: boolean
 }
 
-export const getStatusStyles = (p: StatusProps): CSSObject | undefined => {
+export const getStatusStyles = (p: StatusProps & { theme: CactusTheme }): CSSObject | undefined => {
   if (!p.disabled && statuses.includes(p.status as any)) {
     return {
       borderColor: color(p, p.status as Status),


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-1043

I just refactored so all the common styles, including the italic, are in one place. I was going to add the min-width override that I talked about, but with the extra div there I don't think it's possible. With `width` you can just change from "auto" to "100%", but if you set `min-width: 100%`, that's going to change the actual width, not the min-width; and if you set it to the same value as the outer div, `min-width: 50%` would effectively be 25% instead. We'll just have to defer that change to https://repayonline.atlassian.net/browse/CACTUS-1055.

