### PR TITLE
CACTUS-1063 :: Fix Layout Height Bug

### DIFF
--- a/modules/cactus-web/src/Layout/grid.ts
+++ b/modules/cactus-web/src/Layout/grid.ts
@@ -269,10 +269,16 @@ const toComponentLayout = (role: string, position: Position, order: number): Com
 }
 
 const ZERO_POSITION: CSSPosition = { top: 0, left: 0, bottom: 0, right: 0 }
+// Special case fix for a bug that is caused by the address bar disappearing on Chrome for Android.
+const IS_ANDROID_CHROME =
+  navigator.userAgent.match(/chrome|chromium/i) &&
+  navigator.userAgent.match(/android/i) &&
+  'ontouchstart' in document.documentElement
+const POSITION = IS_ANDROID_CHROME ? 'fixed' : 'absolute'
 const BASIC_GRID = `
   display: -ms-grid;
   display: grid;
-  position: absolute;
+  position: ${POSITION};
   overflow: auto;
 `
 
@@ -284,7 +290,7 @@ const generateGridStyles = (components: ComponentLayout[]): StyleList => {
   const gridItems: GridItem[] = []
   const gridRows: GridMap = {}
   const gridCols: GridMap = {}
-  const fixed: CSSPosition & Sizes & { position?: 'fixed' | 'absolute' } = { ...ZERO_POSITION }
+  const fixed: CSSPosition & Sizes = { ...ZERO_POSITION }
   for (const layout of components) {
     if (layout.type === 'fixed') {
       styles.push(css`
@@ -315,13 +321,6 @@ const generateGridStyles = (components: ComponentLayout[]): StyleList => {
   // Some CSS engines are too dumb to figure out height/width from the fixed position offsets.
   fixed.width = `calc(100% - ${fixed.left + fixed.right}px)`
   fixed.height = `calc(100% - ${fixed.top + fixed.bottom}px)`
-  if (
-    navigator.userAgent.match(/chrome|chromium/i) &&
-    navigator.userAgent.match(/android/i) &&
-    'ontouchstart' in document.documentElement
-  ) {
-    fixed.position = 'fixed'
-  }
   styles.push(fixedKeyOrder.reduce(reduceToPx, fixed))
   // The last line is at +1, and another +1 to offset negative line numbers starting at -1.
   const lastRow = rows.length + 2

--- a/modules/cactus-web/src/Layout/grid.ts
+++ b/modules/cactus-web/src/Layout/grid.ts
@@ -284,7 +284,7 @@ const generateGridStyles = (components: ComponentLayout[]): StyleList => {
   const gridItems: GridItem[] = []
   const gridRows: GridMap = {}
   const gridCols: GridMap = {}
-  const fixed: CSSPosition & Sizes = { ...ZERO_POSITION }
+  const fixed: CSSPosition & Sizes & { position?: 'fixed' | 'absolute' } = { ...ZERO_POSITION }
   for (const layout of components) {
     if (layout.type === 'fixed') {
       styles.push(css`
@@ -315,6 +315,13 @@ const generateGridStyles = (components: ComponentLayout[]): StyleList => {
   // Some CSS engines are too dumb to figure out height/width from the fixed position offsets.
   fixed.width = `calc(100% - ${fixed.left + fixed.right}px)`
   fixed.height = `calc(100% - ${fixed.top + fixed.bottom}px)`
+  if (
+    navigator.userAgent.match(/chrome|chromium/i) &&
+    navigator.userAgent.match(/android/i) &&
+    'ontouchstart' in document.documentElement
+  ) {
+    fixed.position = 'fixed'
+  }
   styles.push(fixedKeyOrder.reduce(reduceToPx, fixed))
   // The last line is at +1, and another +1 to offset negative line numbers starting at -1.
   const lastRow = rows.length + 2

--- a/modules/cactus-web/src/Layout/grid.ts
+++ b/modules/cactus-web/src/Layout/grid.ts
@@ -271,6 +271,8 @@ const toComponentLayout = (role: string, position: Position, order: number): Com
 const ZERO_POSITION: CSSPosition = { top: 0, left: 0, bottom: 0, right: 0 }
 // Special case fix for a bug that is caused by the address bar disappearing on Chrome for Android.
 const IS_ANDROID_CHROME =
+  navigator !== undefined &&
+  document !== undefined &&
   navigator.userAgent.match(/chrome|chromium/i) &&
   navigator.userAgent.match(/android/i) &&
   'ontouchstart' in document.documentElement

--- a/modules/cactus-web/src/Layout/grid.ts
+++ b/modules/cactus-web/src/Layout/grid.ts
@@ -271,8 +271,8 @@ const toComponentLayout = (role: string, position: Position, order: number): Com
 const ZERO_POSITION: CSSPosition = { top: 0, left: 0, bottom: 0, right: 0 }
 // Special case fix for a bug that is caused by the address bar disappearing on Chrome for Android.
 const IS_ANDROID_CHROME =
-  navigator !== undefined &&
-  document !== undefined &&
+  typeof navigator !== 'undefined' &&
+  typeof document !== 'undefined' &&
   navigator.userAgent.match(/chrome|chromium/i) &&
   navigator.userAgent.match(/android/i) &&
   'ontouchstart' in document.documentElement


### PR DESCRIPTION
Ticket and UAT: https://repayonline.atlassian.net/browse/CACTUS-1063

I have tested this in _so many_ (probably more than necessary) different device/browser combinations that I'm feeling pretty confident at this point.

I tested channels admin, merchant, and customer apps with:
- Desktop Chrome
- Desktop Firefox
- Desktop Safari

I tested channels merchant and customer apps with:
- IE11
- Newest iOS/Chrome
- Various older iOS/Chrome combos
- Newest iOS/Safari
- Varying older iOS/Safari combos (including Safari 14)
- Newest Android/Chrome (Samsung, Google, and OnePlus devices)
- Various older Android/Chrome combos
- Newest Android/Firefox
- _Some_ older Android/Firefox combos (some older versions of firefox didn't allow me to access localhost)
- I even tested on some obscure Android browsers that I've never even heard of. (Anyone ever heard of UC Browser??)

I wasn't able to reproduce the original issue nor did I find any new issues with the layout in my testing with this fix. That being said, I would still appreciate it if you guys could test in as many device/browser combos as you can just to be safe; I'd rather catch any issues with this solution now than later.

@wilysword I'm sure there's a better, cleaner, less hacky way to do this, so if you'd like me to do it differently I can, but I probably won't go through the same rigorous testing that I did with this exact change that I have here.

Lastly I just want to say that this was hell and I know it's ugly to special case it this way, but at least it works as far as I can tell.