### PR TITLE
CACTUS-765 Reach-less Modal

### DIFF
--- a/modules/cactus-web/src/Dimmer/Dimmer.tsx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.tsx
@@ -1,30 +1,25 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
+
+import { styledUnpoly } from '../helpers/styled'
 
 export interface DimmerProps extends React.HTMLAttributes<HTMLDivElement> {
   active: boolean
 }
 
-// TODO Use the idea from Modal of having separate scroll & flex elements? Also scroll trap.
-class DimmerBase extends React.Component<DimmerProps> {
-  public static propTypes = {
-    active: PropTypes.bool.isRequired,
-  }
-  componentDidUpdate(prevProps: DimmerProps): void {
-    if (prevProps.active === false && this.props.active === true && document.activeElement) {
+const DimmerBase = React.forwardRef<HTMLDivElement, DimmerProps>(({ active, ...props }, ref) => {
+  React.useEffect(() => {
+    if (active && document.activeElement) {
       try {
         ;(document.activeElement as HTMLElement).blur()
       } catch {}
     }
-  }
-  render(): React.ReactElement | null {
-    const { active, ...rest } = this.props
-    return active ? <div {...rest} /> : null
-  }
-}
+  }, [active])
+  return active ? <div {...props} ref={ref} /> : null
+})
+DimmerBase.displayName = 'Dimmer'
 
-export const Dimmer = styled(DimmerBase).attrs({ as: DimmerBase })`
+export const Dimmer = styledUnpoly(DimmerBase)`
   position: fixed;
   display: flex;
   background: rgba(46, 53, 56, 0.9);
@@ -32,10 +27,14 @@ export const Dimmer = styled(DimmerBase).attrs({ as: DimmerBase })`
   left: 0;
   width: 100vw;
   height: 100vh;
+  box-sizing: border-box;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   z-index: 100;
 `
+Dimmer.propTypes = {
+  active: PropTypes.bool.isRequired,
+}
 
 export default Dimmer

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -3,7 +3,7 @@ import { CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
-import { margin, MarginProps } from 'styled-system'
+import { margin, MarginProps, system } from 'styled-system'
 
 import { isIE } from '../helpers/constants'
 import { getOmittableProps } from '../helpers/omit'
@@ -160,6 +160,22 @@ const IconButtonBase = React.forwardRef<HTMLButtonElement, ButtonProps>(
   }
 )
 
+const focusOutline = system({
+  iconSize: (value: IconButtonSizes) => {
+    const offset = focusOutlineSpacing[value] || focusOutlineSpacing.medium
+    const styles: Record<string, string> = {
+      height: `calc(100% + ${offset}px)`,
+      width: `calc(100% + ${offset}px)`,
+    }
+    if (isIE) {
+      const ieOffset = offset / 2
+      styles.top = `-${ieOffset + 1}px`
+      styles.left = `-${ieOffset}px`
+    }
+    return styles
+  },
+})
+
 const styleProps = getOmittableProps(margin, 'display', 'inverse', 'variant', 'iconSize')
 export const IconButton = styled(IconButtonBase).withConfig({
   shouldForwardProp: (p) => !styleProps.has(p),
@@ -185,19 +201,7 @@ export const IconButton = styled(IconButtonBase).withConfig({
       content: '';
       display: block;
       position: absolute;
-      ${(p) => `
-        height: calc(100% + ${focusOutlineSpacing[p.iconSize || 'medium']}px);
-        width: calc(100% + ${focusOutlineSpacing[p.iconSize || 'medium']}px);
-      `}
-      ${(p) => {
-        if (isIE) {
-          const IEOffset = focusOutlineSpacing[p.iconSize || 'medium'] / 2
-          return `
-            top: -${IEOffset + 1}px;
-            left: -${IEOffset}px;
-          `
-        }
-      }}
+      ${focusOutline}
       ${(p) => `border: ${borderSize(p)} solid;`}
       ${(p) => shapeMap[p.theme.shape]}
       border-color: ${(p): string => p.theme.colors.callToAction};

--- a/modules/cactus-web/src/helpers/portal.ts
+++ b/modules/cactus-web/src/helpers/portal.ts
@@ -1,0 +1,22 @@
+import { ReactNode, ReactPortal, useRef } from 'react'
+import { createPortal } from 'react-dom'
+
+const ID = 'cactus-portal-root'
+
+export const getPortalRoot = (): HTMLElement => {
+  let div = document.getElementById(ID)
+  if (!div) {
+    div = document.createElement('div')
+    div.id = ID
+    document.body.appendChild(div)
+  }
+  return div
+}
+
+export const usePortal = (contents: ReactNode, key?: string | null): ReactPortal | null => {
+  const ref = useRef<HTMLElement>()
+  if (!ref.current) {
+    ref.current = getPortalRoot()
+  }
+  return contents ? createPortal(contents, ref.current, key) : null
+}


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-765

The biggest things Reach did were scroll trapping (although they did it in a really weird way that broke our layout), focus lock, and handling visibility/events. We already had scroll trapping code, a focus lock, and the Dimmer that controls visibility; that just left the events, which are quite simple. The only really new thing here is the portal.

Also, there's one thing they did which I didn't, because it seemed like overkill: they set `aria-hidden` on everything _but_ the open modal.