### PR TITLE
CACTUS-1060 :: Remove `vh` styles from Dimmer

### DIFF
--- a/modules/cactus-web/src/Dimmer/Dimmer.tsx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.tsx
@@ -27,6 +27,7 @@ export const Dimmer = styledUnpoly(DimmerBase)`
   left: 0;
   width: 100vw;
   height: 100vh;
+  padding-bottom: calc(100vh-100%);
   box-sizing: border-box;
   flex-direction: column;
   justify-content: center;

--- a/modules/cactus-web/src/Dimmer/Dimmer.tsx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.tsx
@@ -26,8 +26,7 @@ export const Dimmer = styledUnpoly(DimmerBase)`
   top: 0;
   left: 0;
   width: 100vw;
-  height: 100vh;
-  padding-bottom: calc(100vh-100%);
+  height: 100%;
   box-sizing: border-box;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
[CACTUS-1060](https://repayonline.atlassian.net/browse/CACTUS-1060)

I guess the title of this should be different. 

I spent more time struggling with how to build a local version of the `react-ui-base-image` to test this in channels. But I got it and it worked. 

Feel free to test by yourself. I did it with iOS and android. 

