### PR TITLE
CACTUS-970 :: ScreenSizeProvider using deprecated function

### DIFF
--- a/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.test.tsx
+++ b/modules/cactus-web/src/ScreenSizeProvider/ScreenSizeProvider.test.tsx
@@ -15,8 +15,8 @@ const Size: React.FC = () => {
 interface MQ {
   minPx: number
   matches: boolean
-  removeListener: (x: () => void) => void
-  addListener: (x: () => void) => void
+  removeEventListener: (evtType: string, x: () => void) => void
+  addEventListener: (evtType: string, x: () => void) => void
 }
 
 describe('component: ScreenSizeProvider', () => {
@@ -39,10 +39,10 @@ describe('component: ScreenSizeProvider', () => {
       const result: MQ = {
         minPx: minPxMatch ? parseInt(minPxMatch[0]) : 0,
         matches: false,
-        removeListener: () => {
+        removeEventListener: () => {
           return
         },
-        addListener: (listener) => {
+        addEventListener: (_, listener) => {
           media.listener = listener
         },
       }


### PR DESCRIPTION
[CACTUS-970](https://repayonline.atlassian.net/browse/CACTUS-970)

I tested this using `mock-ebpp`, just added a local version of `cactus-web` (previously built) using yalc, ran `yarn && yarn install`, and ensure the app isn't broken in our loved IE11

