### PR TITLE
CACTUS-1008: fix missing import

### DIFF
--- a/modules/cactus-web/src/Dimmer/Dimmer.mdx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.mdx
@@ -3,6 +3,7 @@ name: Dimmer
 menu: Components
 ---
 
+import Dimmer from './Dimmer'
 import PropsTable from 'website-src/components/PropsTable'
 
 # Dimmer


### PR DESCRIPTION
Follow up fix for [CACTUS-1008](https://repayonline.atlassian.net/browse/CACTUS-1008). It's strange, I know when I make changes to the docs I usually test them, especially such extensive changes; I wonder if I removed the imports _after_ starting Gatsby, and it continued using a cached version or something.