### PR TITLE
CACTUS-1069 Inline Styles

### DIFF
--- a/modules/cactus-icons/src/iconSizes.ts
+++ b/modules/cactus-icons/src/iconSizes.ts
@@ -4,14 +4,7 @@ const iconSizes = system({
   iconSize: {
     property: 'fontSize',
     scale: 'iconSizes',
-    transform: (size, scale): string => {
-      let iconSize: string | number = get(scale, size, size)
-      iconSize = iconSize.toString()
-      if (/^[0-9]+$/.test(iconSize)) {
-        iconSize += 'px'
-      }
-      return iconSize
-    },
+    transform: (size, scale) => get(scale, size, size),
   },
 })
 

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.test.tsx
@@ -43,13 +43,14 @@ describe('component: AccessibleField', () => {
     )
   })
 
-  test('supports flex item props', () => {
+  test('supports style props', () => {
     const { getByTestId } = renderWithTheme(
       <AccessibleField
         label="Accessible Label"
         name="text_field"
         data-testid="flex-field"
-        flex={1}
+        margin={4}
+        maxWidth="90%"
         flexGrow={1}
         flexShrink={0}
         flexBasis={0}
@@ -58,11 +59,13 @@ describe('component: AccessibleField', () => {
       </AccessibleField>
     )
 
-    const field = getByTestId('flex-field')
-    expect(field).toHaveStyle('flex: 1')
-    expect(field).toHaveStyle('flex-grow: 1')
-    expect(field).toHaveStyle('flex-shrink: 0')
-    expect(field).toHaveStyle('flex-basis: 0')
+    expect(getByTestId('flex-field')).toHaveStyle({
+      flexGrow: '1',
+      flexShrink: '0',
+      flexBasis: '0px',
+      margin: '16px',
+      maxWidth: '90%',
+    })
   })
 
   test('alternate prop types', () => {

--- a/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
+++ b/modules/cactus-web/src/AccessibleField/AccessibleField.tsx
@@ -1,14 +1,13 @@
 import { iconSize, space } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { margin, MarginProps, width, WidthProps } from 'styled-system'
+import { MarginProps } from 'styled-system'
 
 import { FieldWrapper } from '../FieldWrapper/FieldWrapper'
 import { Flex } from '../Flex/Flex'
 import { isFocusOut } from '../helpers/events'
-import { omitProps } from '../helpers/omit'
 import { Status } from '../helpers/status'
-import { flexItem, FlexItemProps, styledUnpoly, styledWithClass } from '../helpers/styled'
+import { allWidth, AllWidthProps, FlexItemProps, withStyles } from '../helpers/styled'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 import StatusMessage from '../StatusMessage/StatusMessage'
@@ -48,13 +47,15 @@ interface CommonProps {
 // These are the props commonly used by components that wrap AccessibleField.
 export interface FieldProps extends CommonProps, FlexItemProps, MarginProps {}
 
+interface FieldStyleProps extends AllWidthProps, FlexItemProps, MarginProps {}
+
 interface InnerProps
   extends CommonProps,
     Omit<React.HTMLAttributes<HTMLDivElement>, 'children' | 'defaultChecked' | 'defaultValue'> {
   children: React.ReactElement | RenderFunc
   disabled?: boolean
 }
-interface AccessibleFieldProps extends InnerProps, FlexItemProps, MarginProps, WidthProps {}
+interface AccessibleFieldProps extends InnerProps, FieldStyleProps {}
 
 interface AccessibleHookArgs {
   id?: string
@@ -213,13 +214,13 @@ function AccessibleFieldBase(props: InnerProps) {
     </div>
   )
 }
-AccessibleFieldBase.displayName = 'AccessibleField'
 
-export const AccessibleField = styledUnpoly(FieldWrapper, AccessibleFieldBase).withConfig(
-  omitProps<AccessibleFieldProps>(width, margin, flexItem)
-)`
+export const AccessibleField = withStyles(FieldWrapper, {
+  displayName: 'AccessibleField',
+  as: AccessibleFieldBase,
+  styles: [allWidth],
+})<FieldStyleProps>`
   position: relative;
-  ${width}
   display: flex;
   flex-direction: column;
 
@@ -232,9 +233,9 @@ export const AccessibleField = styledUnpoly(FieldWrapper, AccessibleFieldBase).w
   .field-status-row ${StatusMessage} {
     margin-top: ${space(2)};
   }
-` as React.FC<AccessibleFieldProps>
+`
 
-const FieldLabel = styledWithClass(Label, 'field-label')`
+const FieldLabel = withStyles(Label, { className: 'field-label' })`
   display: block;
   box-sizing: border-box;
   min-width: 1px;

--- a/modules/cactus-web/src/Alert/Alert.test.tsx
+++ b/modules/cactus-web/src/Alert/Alert.test.tsx
@@ -9,18 +9,18 @@ describe('component: Alert', (): void => {
     const { getByText } = renderWithTheme(<Alert>Message</Alert>)
     expect(getByText('Message')).toBeInTheDocument()
   })
-  test('should support flex item props', () => {
+  test('should support style props', () => {
     const { getByTestId } = renderWithTheme(
-      <Alert data-testid="flex-alert" flex={1} flexGrow={1} flexShrink={0} flexBasis={0}>
+      <Alert data-testid="flex-alert" margin={2} minWidth="300px" flex="2 3 400px">
         I have flex props
       </Alert>
     )
 
-    const alert = getByTestId('flex-alert')
-    expect(alert).toHaveStyle('flex: 1')
-    expect(alert).toHaveStyle('flex-grow: 1')
-    expect(alert).toHaveStyle('flex-shrink: 0')
-    expect(alert).toHaveStyle('flex-basis: 0')
+    expect(getByTestId('flex-alert')).toHaveStyle({
+      margin: '4px',
+      minWidth: '300px',
+      flex: '2 3 400px',
+    })
   })
   test('Should call the onClose fn after timeout', async () => {
     const setOpen = jest.fn()

--- a/modules/cactus-web/src/Alert/Alert.tsx
+++ b/modules/cactus-web/src/Alert/Alert.tsx
@@ -1,14 +1,12 @@
 import { NavigationClose } from '@repay/cactus-icons'
-import { CactusTheme } from '@repay/cactus-theme'
+import { CactusTheme, shadow } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import styled, { css, ThemeProps } from 'styled-components'
-import { margin, MarginProps, width, WidthProps } from 'styled-system'
+import { css, ThemeProps } from 'styled-components'
+import { margin, MarginProps } from 'styled-system'
 
 import Avatar from '../Avatar/Avatar'
-import { flexItem, FlexItemProps } from '../helpers/flexItem'
-import { omitProps } from '../helpers/omit'
-import { boxShadow } from '../helpers/theme'
+import { allWidth, AllWidthProps, flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import IconButton from '../IconButton/IconButton'
 
 export type Status = 'error' | 'warning' | 'info' | 'success'
@@ -21,7 +19,7 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   closeTimeout?: number
 }
 
-interface AlertStyleProps extends AlertProps, MarginProps, WidthProps, FlexItemProps {
+interface AlertStyleProps extends MarginProps, AllWidthProps, FlexItemProps {
   type?: Type
   shadow?: boolean
 }
@@ -109,9 +107,12 @@ const AlertBase = (props: AlertProps): React.ReactElement => {
   )
 }
 
-export const Alert = styled(AlertBase).withConfig(
-  omitProps<AlertStyleProps>(margin, width, flexItem, 'type', 'shadow')
-)`
+export const Alert = withStyles('div', {
+  displayName: 'Alert',
+  as: AlertBase,
+  transitiveProps: ['type', 'shadow'],
+  styles: [allWidth, margin, flexItem],
+})<AlertStyleProps>`
   box-sizing: border-box;
   display: flex;
   justify-content: flex-start;
@@ -120,11 +121,8 @@ export const Alert = styled(AlertBase).withConfig(
   background: ${backgroundColor};
   border: 2px solid ${borderColor};
   ${typeVariant}
-  ${(p): string => (p.shadow ? boxShadow(p.theme, 2) : '')};
+  ${(p) => (p.shadow ? shadow(p, 2) : '')};
   border-radius: 8px;
-  ${margin}
-  ${width}
-  ${flexItem}
 
   div:first-child {
     flex: 0 0 auto;

--- a/modules/cactus-web/src/Box/Box.test.tsx
+++ b/modules/cactus-web/src/Box/Box.test.tsx
@@ -70,6 +70,19 @@ describe('component: Box', () => {
     expect(boxStyles.borderRadius).toBe('25px')
   })
 
+  test('border radius props should accept responsive values', () => {
+    const { getByText } = renderWithTheme(
+      <Box borderRadius={['12px', '15px']} borderTopLeftRadius={['2px', '9px']}>
+        Content
+      </Box>
+    )
+
+    expect(getByText('Content')).toHaveStyle({
+      borderRadius: '15px',
+      borderTopLeftRadius: '9px',
+    })
+  })
+
   test('individual border radius props should accept custom shape definitions', () => {
     const { getByText, rerender } = renderWithTheme(
       <Box

--- a/modules/cactus-web/src/Box/Box.tsx
+++ b/modules/cactus-web/src/Box/Box.tsx
@@ -1,11 +1,10 @@
-import { TextStyleCollection } from '@repay/cactus-theme'
-import styled, { DefaultTheme, ThemedStyledProps } from 'styled-components'
+import { CactusTheme, radius, textStyle, TextStyleCollection } from '@repay/cactus-theme'
+import { ThemedStyledProps } from 'styled-components'
 import {
   border,
   BorderProps,
   colorStyle,
   ColorStyleProps,
-  compose,
   display,
   DisplayProps,
   layout,
@@ -16,9 +15,7 @@ import {
   SpaceProps,
 } from 'styled-system'
 
-import { getOmittableProps } from '../helpers/omit'
-import { allText, AllTextProps, flexItem, FlexItemProps } from '../helpers/styled'
-import { radius, textStyle } from '../helpers/theme'
+import { allText, AllTextProps, flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 
 interface CustomBR {
   square: string
@@ -26,21 +23,16 @@ interface CustomBR {
   round: string
 }
 
-interface CustomBorderProps
-  extends Omit<
-    BorderProps,
-    | 'borderRadius'
-    | 'borderTopLeftRadius'
-    | 'borderTopRightRadius'
-    | 'borderBottomRightRadius'
-    | 'borderBottomLeftRadius'
-  > {
-  borderRadius?: BorderProps['borderRadius'] | CustomBR | 'themed'
-  borderTopLeftRadius?: BorderProps['borderTopLeftRadius'] | CustomBR
-  borderTopRightRadius?: BorderProps['borderTopRightRadius'] | CustomBR
-  borderBottomRightRadius?: BorderProps['borderBottomRightRadius'] | CustomBR
-  borderBottomLeftRadius?: BorderProps['borderBottomLeftRadius'] | CustomBR
-}
+const radiusProps = [
+  'borderRadius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderBottomRightRadius',
+  'borderBottomLeftRadius',
+] as const
+
+type RadiusProp = typeof radiusProps[number]
+type BorderRadiusProps = { [K in RadiusProp]?: BorderProps[K] | CustomBR | 'themed' }
 
 export interface BoxProps
   extends PositionProps,
@@ -49,58 +41,40 @@ export interface BoxProps
     ColorStyleProps,
     DisplayProps,
     AllTextProps,
-    CustomBorderProps,
+    Omit<BorderProps, RadiusProp>,
+    BorderRadiusProps,
     FlexItemProps {
   textStyle?: keyof TextStyleCollection
 }
 
 const isInstanceOfCustomBR = (borderProp: any): borderProp is CustomBR => {
-  return borderProp !== null && borderProp !== undefined && borderProp.hasOwnProperty('square')
+  return borderProp?.hasOwnProperty?.('square')
 }
 
-const decideBorderRadius = (props: ThemedStyledProps<BoxProps, DefaultTheme>) => {
-  const {
-    borderRadius,
-    borderTopLeftRadius,
-    borderTopRightRadius,
-    borderBottomRightRadius,
-    borderBottomLeftRadius,
-  } = props
-
-  if (borderRadius && borderRadius === 'themed') {
-    return `border-radius: ${radius(8)(props)};`
-  } else if (isInstanceOfCustomBR(borderRadius)) {
-    return `border-radius: ${borderRadius[props.theme.shape]};`
+const getThemedRadius = (props: ThemedStyledProps<BoxProps, CactusTheme>) => {
+  let style: any = undefined
+  for (const key of radiusProps) {
+    const value = props[key]
+    if (!value) continue
+    if (value === 'themed') {
+      if (!style) style = {}
+      style[key] = radius(props, 8)
+    } else if (isInstanceOfCustomBR(value)) {
+      if (!style) style = {}
+      style[key] = value[props.theme.shape]
+    }
   }
-
-  let borderRadiusStyles = ''
-
-  if (isInstanceOfCustomBR(borderTopLeftRadius)) {
-    borderRadiusStyles += `border-top-left-radius: ${borderTopLeftRadius[props.theme.shape]};`
-  }
-  if (isInstanceOfCustomBR(borderTopRightRadius)) {
-    borderRadiusStyles += `border-top-right-radius: ${borderTopRightRadius[props.theme.shape]};`
-  }
-  if (isInstanceOfCustomBR(borderBottomRightRadius)) {
-    borderRadiusStyles += `border-bottom-right-radius: ${
-      borderBottomRightRadius[props.theme.shape]
-    };`
-  }
-  if (isInstanceOfCustomBR(borderBottomLeftRadius)) {
-    borderRadiusStyles += `border-bottom-left-radius: ${borderBottomLeftRadius[props.theme.shape]};`
-  }
-  return borderRadiusStyles
+  return style
 }
 
-const styleFn = compose(position, display, layout, space, colorStyle, allText, border, flexItem)
-const styleProps = getOmittableProps(styleFn, 'textStyle')
-export const Box = styled('div').withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const Box = withStyles('div', {
+  displayName: 'Box',
+  transitiveProps: ['textStyle'],
+  extraAttrs: getThemedRadius,
+  styles: [position, display, layout, space, colorStyle, allText, border, flexItem],
 })<BoxProps>`
   box-sizing: border-box;
-  ${styleFn}
-  ${(p) => p.textStyle && textStyle(p.theme, p.textStyle)}
-  ${decideBorderRadius}
+  ${(p) => p.textStyle && textStyle(p, p.textStyle)}
 `
 
 export default Box

--- a/modules/cactus-web/src/Button/Button.story.tsx
+++ b/modules/cactus-web/src/Button/Button.story.tsx
@@ -72,6 +72,9 @@ LoadingOnClick.args = { children: 'Submit' }
 LoadingOnClick.argTypes = { loading: HIDE_CONTROL }
 LoadingOnClick.parameters = { storyshots: false }
 
-export const AsLink: Story<typeof Button, { href: string }> = (args) => <Button {...args} as="a" />
+// Typescript doesn't like the args type because it has a `ref` to <button> instead of <a>.
+export const AsLink: Story<typeof Button, { href: string }> = (args: any) => (
+  <Button {...args} as="a" />
+)
 AsLink.storyName = 'As Link'
 AsLink.args = { children: 'Link Button', href: 'https://google.com' }

--- a/modules/cactus-web/src/Button/Button.test.tsx
+++ b/modules/cactus-web/src/Button/Button.test.tsx
@@ -6,12 +6,18 @@ import renderWithTheme from '../../tests/helpers/renderWithTheme'
 import Button from './Button'
 
 describe('component: Button', () => {
-  test('should support margin space props', () => {
-    const { getByText } = renderWithTheme(<Button mt={5}>I have margins!</Button>)
-    const button = getByText('I have margins!').parentElement
-    const styled = window.getComputedStyle(button as HTMLElement)
-
-    expect(styled.marginTop).toBe('24px')
+  test('should support style props', () => {
+    const { getByText } = renderWithTheme(
+      <Button mt={5} flex="5 4 6px">
+        I have margins!
+      </Button>
+    )
+    expect(getByText('I have margins!')).toHaveStyle({
+      marginTop: '24px',
+      flexGrow: '5',
+      flexShrink: '4',
+      flexBasis: '6px',
+    })
   })
 
   test('should support svgs as children', () => {
@@ -52,7 +58,7 @@ describe('component: Button', () => {
   })
   test('aria-live prop default and custom', () => {
     const { getByText, rerender } = renderWithTheme(<Button>Click me!</Button>)
-    const button = getByText('Click me!').parentElement
+    const button = getByText('Click me!')
 
     //aria-live should be assertive by default
     expect(button?.getAttribute('aria-live')).toBe('assertive')
@@ -66,7 +72,7 @@ describe('component: Button', () => {
 describe('With theme changes ', () => {
   test('should have 2px border', () => {
     const { getByText } = renderWithTheme(<Button>Click me!</Button>, { border: 'thick' })
-    const button = getByText('Click me!').parentElement
+    const button = getByText('Click me!')
     const styled = window.getComputedStyle(button as HTMLElement)
     expect(styled.borderWidth).toBe('2px')
   })
@@ -74,7 +80,7 @@ describe('With theme changes ', () => {
   test('Should have intermediate border radius', () => {
     const { getByText } = renderWithTheme(<Button>Click me!</Button>, { shape: 'intermediate' })
 
-    const button = getByText('Click me!').parentElement
+    const button = getByText('Click me!')
     const styled = window.getComputedStyle(button as HTMLElement)
     expect(styled.borderRadius).toBe('8px')
   })
@@ -82,14 +88,14 @@ describe('With theme changes ', () => {
   test('Should have square border radius', () => {
     const { getByText } = renderWithTheme(<Button>Click me!</Button>, { shape: 'square' })
 
-    const button = getByText('Click me!').parentElement
+    const button = getByText('Click me!')
     const styled = window.getComputedStyle(button as HTMLElement)
-    expect(styled.borderRadius).toBe('1px')
+    expect(styled.borderRadius).toBe('0px')
   })
 
   test('Should not have box shadows applied', () => {
     const { getByText } = renderWithTheme(<Button>Click me!</Button>, { boxShadows: false })
-    const button = getByText('Click me!').parentElement
+    const button = getByText('Click me!')
     const styled = window.getComputedStyle(button as HTMLElement)
     expect(styled.boxShadow).toBe('')
   })

--- a/modules/cactus-web/src/Button/Button.tsx
+++ b/modules/cactus-web/src/Button/Button.tsx
@@ -1,197 +1,155 @@
-import { BorderSize, ColorStyle, TextStyle } from '@repay/cactus-theme'
+import { border, color, colorStyle, radius, textStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, FlattenSimpleInterpolation } from 'styled-components'
+import { css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { AsProps, GenericComponent } from '../helpers/asProps'
-import { getOmittableProps } from '../helpers/omit'
-import { radius, textStyle } from '../helpers/theme'
+import { flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import Spinner from '../Spinner/Spinner'
 
 export type ButtonVariants = 'standard' | 'action' | 'danger' | 'warning' | 'success'
 
-interface ButtonProps extends MarginProps {
+interface ButtonProps extends FlexItemProps, MarginProps {
   variant?: ButtonVariants
-  /** !important */
   disabled?: boolean
   inverse?: boolean
   loading?: boolean
   loadingText?: string
-  type?: 'submit' | 'reset' | 'button'
 }
 
 type VariantMap = { [K in ButtonVariants]: ReturnType<typeof css> }
 
 const variantMap: VariantMap = {
   action: css`
-    ${(p): ColorStyle => p.theme.colorStyles.callToAction}
-    border-color: ${(p): string => p.theme.colors.callToAction};
+    ${colorStyle('callToAction')}
+    border-color: ${color('callToAction')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.base}
-      border-color: ${(p): string => p.theme.colors.base};
+      ${colorStyle('base')}
+      border-color: ${color('base')};
     }
   `,
   standard: css`
-    color: ${(p): string => p.theme.colors.base};
-    background-color: ${(p): string => p.theme.colors.white};
-    border-color: ${(p): string => p.theme.colors.base};
+    ${colorStyle('base', 'white')};
+    border-color: ${color('base')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.base}
-      border-color: ${(p): string => p.theme.colors.base};
+      ${colorStyle('base')}
     }
   `,
   danger: css`
-    ${(p): ColorStyle => p.theme.colorStyles.error}
-    border-color: ${(p): string => p.theme.colors.error};
+    ${colorStyle('error')}
+    border-color: ${color('error')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.errorDark}
-      border-color: ${(p): string => p.theme.colors.errorDark};
+      ${colorStyle('errorDark')}
+      border-color: ${color('errorDark')};
     }
   `,
   warning: css`
-    ${(p): ColorStyle => p.theme.colorStyles.warning}
-    border-color: ${(p): string => p.theme.colors.warning};
+    ${colorStyle('warning')}
+    border-color: ${color('warning')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.warningDark}
-      border-color: ${(p): string => p.theme.colors.warningDark};
+      ${colorStyle('warningDark')}
+      border-color: ${color('warningDark')};
     }
   `,
   success: css`
-    ${(p): ColorStyle => p.theme.colorStyles.success}
-    border-color: ${(p): string => p.theme.colors.success};
+    ${colorStyle('success')}
+    border-color: ${color('success')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.successDark}
-      border-color: ${(p): string => p.theme.colors.successDark};
+      ${colorStyle('successDark')}
+      border-color: ${color('successDark')};
     }
   `,
 }
 
 const inverseVariantMap: VariantMap = {
   action: css`
-    ${(p): ColorStyle => p.theme.colorStyles.callToAction};
-    border-color: ${(p): string => p.theme.colors.callToAction};
+    ${colorStyle('callToAction')};
+    border-color: ${color('callToAction')};
 
     &:hover {
-      color: ${(p): string => p.theme.colors.callToAction};
-      background-color: ${(p): string => p.theme.colors.white};
-      border-color: ${(p): string => p.theme.colors.white};
+      ${colorStyle('callToAction', 'white')};
+      border-color: ${color('white')};
     }
   `,
   standard: css`
-    ${(p): ColorStyle => p.theme.colorStyles.base};
-    border-color: ${(p): string => p.theme.colors.white};
+    ${colorStyle('base')};
+    border-color: ${color('white')};
 
     &:hover {
-      color: ${(p): string => p.theme.colors.base};
-      background-color: ${(p): string => p.theme.colors.white};
-      border-color: ${(p): string => p.theme.colors.white};
+      ${colorStyle('base', 'white')};
     }
   `,
   danger: css`
-    color: ${(p): string => p.theme.colors.error};
-    background-color: ${(p): string => p.theme.colors.white};
-    border-color: ${(p): string => p.theme.colors.error};
+    ${colorStyle('error', 'white')};
+    border-color: ${color('error')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.error}
+      ${colorStyle('error')}
     }
   `,
   warning: css`
-    color: ${(p): string => p.theme.colors.warning};
-    background-color: ${(p): string => p.theme.colors.white};
-    border-color: ${(p): string => p.theme.colors.warning};
+    ${colorStyle('warning', 'white')};
+    border-color: ${color('warning')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.warning}
-      border-color: ${(p): string => p.theme.colors.warning};
+      ${colorStyle('warning')}
     }
   `,
   success: css`
-    color: ${(p): string => p.theme.colors.success};
-    background-color: ${(p): string => p.theme.colors.white};
-    border-color: ${(p): string => p.theme.colors.success};
+    ${colorStyle('success', 'white')};
+    border-color: ${color('success')};
 
     &:hover {
-      ${(p): ColorStyle => p.theme.colorStyles.success}
-      border-color: ${(p): string => p.theme.colors.success};
+      ${colorStyle('success')}
     }
   `,
 }
 
 const disabledCss = css`
-  ${(p): ColorStyle => p.theme.colorStyles.disable};
-  border-color: ${(p): string => p.theme.colors.lightGray};
+  ${colorStyle('disable')};
+  border-color: ${color('lightGray')};
   cursor: not-allowed;
 `
 
-const borderMap = {
-  thin: css`
-    border: 1px solid;
-  `,
-  thick: css`
-    border: 2px solid;
-  `,
-}
-
-const getBorder = (size: BorderSize): FlattenSimpleInterpolation => borderMap[size]
-
-interface TransientButtonProps extends Omit<ButtonProps, 'inverse' | 'variant'> {
-  $inverse?: boolean
-  $variant?: ButtonVariants
-}
-
-const variantOrDisabled = (props: TransientButtonProps) => {
-  const map = props.$inverse ? inverseVariantMap : variantMap
+const variantOrDisabled = (props: ButtonProps) => {
+  const map = props.inverse ? inverseVariantMap : variantMap
   if (props.disabled) {
     return disabledCss
-  } else if (props.$variant !== undefined) {
-    return map[props.$variant]
+  } else if (props.variant !== undefined) {
+    return map[props.variant]
   }
 }
 
-function ButtonFunc<E, C extends GenericComponent = 'button'>(
-  props: AsProps<C> & ButtonProps,
-  ref: React.Ref<E>
-): React.ReactElement {
-  const {
-    loading,
-    children,
-    disabled,
-    loadingText,
-    inverse,
-    variant,
-    'aria-live': ariaLive,
-    ...rest
-  } = props
-  let spanProps = null
-  if (loading === true) {
-    spanProps = { style: { visibility: 'hidden' } as React.CSSProperties, 'aria-hidden': true }
+const SHOW_SPINNER = { visibility: 'visible' } as React.CSSProperties
+
+const buttonLoadingState = (props: ButtonProps) => {
+  if (props.loading) {
+    const { children, style } = props as React.HTMLAttributes<any>
+    return {
+      disabled: true,
+      'aria-label': props.loadingText,
+      style: { ...style, color: 'transparent' },
+      children: (
+        <>
+          {children}
+          <Spinner style={SHOW_SPINNER} iconSize="small" color="mediumGray" />
+        </>
+      ),
+    }
   }
-  return (
-    <StyledButton
-      {...(rest as any)}
-      ref={ref as any}
-      $inverse={inverse}
-      $variant={variant}
-      disabled={loading || disabled}
-      aria-live={ariaLive || 'assertive'}
-    >
-      <span {...spanProps}>{children}</span>
-      {loading && <Spinner iconSize="small" aria-label={loadingText} />}
-    </StyledButton>
-  )
 }
 
-const styleProps = getOmittableProps(margin)
-const StyledButton = styled.button.withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
-})<{ $inverse?: boolean; $variant?: ButtonVariants }>`
+export const Button = withStyles('button', {
+  displayName: 'Button',
+  styles: [flexItem, margin],
+  transitiveProps: ['inverse', 'variant', 'loading', 'loadingText'],
+  extraAttrs: buttonLoadingState,
+})<ButtonProps>`
   position: relative;
   padding: 2px 30px;
   outline: none;
@@ -200,9 +158,11 @@ const StyledButton = styled.button.withConfig({
   box-sizing: border-box;
   text-decoration: none;
   display: inline-block;
-  ${(p): FlattenSimpleInterpolation | TextStyle => textStyle(p.theme, 'body')};
-  ${(p): FlattenSimpleInterpolation => getBorder(p.theme.border)};
+  ${textStyle('body')};
+  border: ${border('transparent') /* color set with variant */};
   border-radius: ${radius(20)};
+
+  ${(p) => p.loading && `> * { visibility: hidden; }`}
 
   &::-moz-focus-inner {
     border: 0;
@@ -217,9 +177,8 @@ const StyledButton = styled.button.withConfig({
       width: calc(100% + 10px);
       top: -5px;
       left: -5px;
-      ${(p): FlattenSimpleInterpolation => getBorder(p.theme.border)};
+      border: ${border('callToAction')};
       border-radius: ${radius(20)};
-      border-color: ${(p): string => p.theme.colors.callToAction};
       box-sizing: border-box;
     }
   }
@@ -237,17 +196,10 @@ const StyledButton = styled.button.withConfig({
     margin-top: -8px;
   }
 
-  ${margin}
   ${variantOrDisabled}
 `
 
-type ButtonType = typeof ButtonFunc
-const ButtonFR = React.forwardRef(ButtonFunc)
-export const Button = ButtonFR as ButtonType
-
-ButtonFR.displayName = 'Button'
-
-ButtonFR.propTypes = {
+Button.propTypes = {
   variant: PropTypes.oneOf(['standard', 'action', 'danger', 'warning', 'success']),
   disabled: PropTypes.bool,
   inverse: PropTypes.bool,
@@ -255,10 +207,11 @@ ButtonFR.propTypes = {
   loadingText: PropTypes.string,
 }
 
-ButtonFR.defaultProps = {
+Button.defaultProps = {
   variant: 'standard',
   type: 'button',
   loadingText: 'loading',
+  'aria-live': 'assertive',
 }
 
 export default Button

--- a/modules/cactus-web/src/Calendar/Calendar.tsx
+++ b/modules/cactus-web/src/Calendar/Calendar.tsx
@@ -1,7 +1,6 @@
 import { NavigationChevronLeft, NavigationChevronRight } from '@repay/cactus-icons'
 import { colorStyle, radius, shadow } from '@repay/cactus-theme'
 import React from 'react'
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import Flex from '../Flex/Flex'
@@ -9,7 +8,7 @@ import { isActionKey } from '../helpers/a11y'
 import { dateParts, getFormatter } from '../helpers/dates'
 import { CactusChangeEvent, CactusEventTarget } from '../helpers/events'
 import generateId from '../helpers/generateId'
-import { omitProps } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 import IconButton from '../IconButton/IconButton'
 import DropDown from './DropDown'
 import CalendarGrid, { CalendarGridLabels, CalendarValue, FocusProps, initGridState } from './Grid'
@@ -59,7 +58,6 @@ interface InnerCalendarProps extends BaseProps, FocusProps {
   labels?: Partial<CalendarLabels>
   locale?: string
 }
-export type CalendarProps = InnerCalendarProps & MarginProps
 
 interface CalendarState extends SliderProps {
   value: CalendarValue
@@ -359,15 +357,16 @@ class CalendarBase extends React.Component<InnerCalendarProps, CalendarState> {
 }
 
 // TODO Disabled styles
-export const Calendar = styled(CalendarBase)
-  .withConfig(omitProps<CalendarProps>(margin))
-  .attrs({ as: CalendarBase })`
+export const Calendar = withStyles(CalendarBase, {
+  as: CalendarBase,
+  displayName: 'Calendar',
+  styles: [margin],
+})<MarginProps>`
   position: relative; /* Necessary for drop-down positioning. */
   display: flex;
   flex-direction: column;
   box-sizing: content-box;
   width: 300px;
-  ${margin}
   ${colorStyle('standard')};
   border-radius: ${radius(16, 0.6)};
   border-top-left-radius: ${radius(32, 0.6)};

--- a/modules/cactus-web/src/Calendar/Grid.tsx
+++ b/modules/cactus-web/src/Calendar/Grid.tsx
@@ -1,15 +1,14 @@
 import { border, color, colorStyle, insetBorder, radius, textStyle } from '@repay/cactus-theme'
 import { stubFalse } from 'lodash'
 import React from 'react'
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { clampDate, dateParts, getFormatter, toISODate } from '../helpers/dates'
 import { isFocusOut } from '../helpers/events'
 import { getCurrentFocusIndex } from '../helpers/focus'
 import generateId from '../helpers/generateId'
-import { omitProps } from '../helpers/omit'
 import { useValue } from '../helpers/react'
+import { withStyles } from '../helpers/styled'
 
 export type CalendarDate = string | Date
 export type CalendarValue = CalendarDate | string[] | Date[] | null
@@ -37,7 +36,7 @@ export interface CalendarGridLabels {
   weekdays?: string[] | WeekdayLabel[] | null
 }
 
-export interface BaseProps extends FocusProps, React.HTMLAttributes<HTMLDivElement> {
+export interface CalendarGridProps extends FocusProps, React.HTMLAttributes<HTMLDivElement> {
   children?: never
   locale?: string
   isValidDate?: (d: Date) => boolean
@@ -45,8 +44,6 @@ export interface BaseProps extends FocusProps, React.HTMLAttributes<HTMLDivEleme
   labels?: CalendarGridLabels
   onFocusOverflow?: (d: Date, e: React.SyntheticEvent) => void
 }
-
-export type CalendarGridProps = BaseProps & MarginProps
 
 interface GridState {
   overflow: string | null
@@ -193,7 +190,7 @@ const makeIsSelected = (...isoDates: ISODates): ((d: string) => boolean) => {
   return stubFalse
 }
 
-const compareSelected = (old: ISODates, selected: BaseProps['selected']): ISODates => {
+const compareSelected = (old: ISODates, selected: CalendarGridProps['selected']): ISODates => {
   const first = old[0] || ''
   let date = ''
   if (Array.isArray(selected)) {
@@ -228,7 +225,7 @@ const overflowReducer = (state: GridState, [str, dt]: [string, Date]): GridState
   day: dt.getDate(),
 })
 
-export const initGridState = (initialFocus: BaseProps['initialFocus']): GridState => {
+export const initGridState = (initialFocus: CalendarGridProps['initialFocus']): GridState => {
   let year: number, month: number, day: number
   if (typeof initialFocus === 'string') {
     ;[year, month, day] = dateParts(initialFocus)
@@ -272,7 +269,7 @@ const CalendarGridBase = ({
   onFocus,
   onBlur,
   ...rest
-}: BaseProps) => {
+}: CalendarGridProps) => {
   const gridRef = React.useRef<HTMLDivElement>(null)
   const [state, setOverflow] = React.useReducer(overflowReducer, initialFocus, initGridState)
   const year = yearProp ?? state.year
@@ -384,14 +381,15 @@ const CalendarGridBase = ({
 }
 
 const OUTLINE = { thin: '2px' }
-export const CalendarGrid = styled(CalendarGridBase)
-  .withConfig(omitProps<CalendarGridProps>(margin))
-  .attrs({ as: CalendarGridBase })`
+export const CalendarGrid = withStyles(CalendarGridBase, {
+  as: CalendarGridBase,
+  displayName: 'Calendar.Grid',
+  styles: [margin],
+})<MarginProps>`
   box-sizing: border-box;
   display: inline-block;
   width: 300px;
   padding: 0 10px;
-  ${margin}
   ${textStyle('small')}
   ${colorStyle('lightContrast')}
   border-radius: ${radius(20)};
@@ -451,6 +449,5 @@ export const CalendarGrid = styled(CalendarGridBase)
     }
   }
 `
-CalendarGrid.displayName = 'Calendar.Grid'
 
 export default CalendarGrid

--- a/modules/cactus-web/src/Card/Card.test.tsx
+++ b/modules/cactus-web/src/Card/Card.test.tsx
@@ -12,40 +12,38 @@ describe('component: Card', () => {
     expect(cardSyles.margin).toBe('4px')
   })
 
+  test('should support width props', () => {
+    const { getByText } = renderWithTheme(
+      <Card minWidth="10em" width="50%" maxWidth="500px">
+        Content
+      </Card>
+    )
+    expect(getByText('Content')).toHaveStyle({
+      minWidth: '10em',
+      width: '50%',
+      maxWidth: '500px',
+    })
+  })
+
   test('should support padding props', () => {
-    const { getByText, rerender } = renderWithTheme(<Card>Content</Card>)
-
-    let card = getByText('Content')
-    expect(window.getComputedStyle(card).padding).toBe('16px')
-
-    rerender(<Card padding={7}>Content</Card>)
-
-    card = getByText('Content')
-    expect(window.getComputedStyle(card).padding).toBe('40px')
-
-    rerender(
-      <Card padding={7} paddingX={5}>
-        Content
-      </Card>
+    const { getByText } = renderWithTheme(
+      <>
+        <Card>Default</Card>
+        <Card padding={7}>Shortcut</Card>
+        <Card paddingX={5} paddingTop={2}>
+          Separate
+        </Card>
+      </>
     )
 
-    card = getByText('Content')
-    expect(window.getComputedStyle(card).paddingTop).toBe('40px')
-    expect(window.getComputedStyle(card).paddingBottom).toBe('40px')
-    expect(window.getComputedStyle(card).paddingLeft).toBe('24px')
-    expect(window.getComputedStyle(card).paddingRight).toBe('24px')
-
-    rerender(
-      <Card padding={7} paddingY={5}>
-        Content
-      </Card>
-    )
-
-    card = getByText('Content')
-    expect(window.getComputedStyle(card).paddingTop).toBe('24px')
-    expect(window.getComputedStyle(card).paddingBottom).toBe('24px')
-    expect(window.getComputedStyle(card).paddingLeft).toBe('40px')
-    expect(window.getComputedStyle(card).paddingRight).toBe('40px')
+    expect(getByText('Default')).toHaveStyle({ padding: '16px' })
+    expect(getByText('Shortcut')).toHaveStyle({ padding: '40px' })
+    expect(getByText('Separate')).toHaveStyle({
+      paddingTop: '4px',
+      paddingBottom: '16px',
+      paddingLeft: '24px',
+      paddingRight: '24px',
+    })
   })
 
   describe('with theme customization', () => {

--- a/modules/cactus-web/src/Card/Card.tsx
+++ b/modules/cactus-web/src/Card/Card.tsx
@@ -1,20 +1,10 @@
 import { border, CactusTheme, colorStyle, radius, shadow, space } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import {
-  compose,
-  maxWidth,
-  MaxWidthProps,
-  space as marginPadding,
-  SpaceProps,
-  width,
-  WidthProps,
-} from 'styled-system'
+import { space as marginPadding, SpaceProps } from 'styled-system'
 
-import { getOmittableProps } from '../helpers/omit'
-import { flexItem, FlexItemProps } from '../helpers/styled'
+import { allWidth, AllWidthProps, flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 
-interface CardProps extends SpaceProps, WidthProps, MaxWidthProps, FlexItemProps {
+interface CardProps extends SpaceProps, AllWidthProps, FlexItemProps {
   useBoxShadow?: boolean
 }
 
@@ -29,18 +19,16 @@ const getBoxShadow = (props: CardProps & { theme: CactusTheme }) => {
     : `border: ${border(props, 'lightContrast')};`
 }
 
-const styleProps = getOmittableProps(flexItem, maxWidth, marginPadding, width, 'useBoxShadow')
-export const Card = styled.div.withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const Card = withStyles('div', {
+  displayName: 'Card',
+  transitiveProps: ['useBoxShadow'],
+  styles: [flexItem, allWidth, marginPadding],
 })<CardProps>`
   box-sizing: border-box;
   ${colorStyle('standard')};
   border-radius: ${radius(8)};
   padding: ${space(4)};
   ${getBoxShadow}
-  && {
-    ${compose(flexItem, maxWidth, marginPadding, width)}
-  }
 `
 
 Card.defaultProps = {

--- a/modules/cactus-web/src/CheckBox/CheckBox.test.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.test.tsx
@@ -70,9 +70,12 @@ describe('component: CheckBox', () => {
       const { getByTestId } = renderWithTheme(<CheckBox id="theme" data-testid="checkbox" />, {
         border: 'thick',
       })
-      const checkBox = getByTestId('checkbox')
-      const checkboxStyles = window.getComputedStyle(checkBox)
-      expect(checkboxStyles.borderWidth).toBe('0px')
+      expect(getByTestId('checkbox').nextElementSibling).toHaveStyle({ borderWidth: '2px' })
+    })
+
+    test('should support margin props', () => {
+      const { getByTestId } = renderWithTheme(<CheckBox m={5} data-testid="checkbox" />)
+      expect(getByTestId('checkbox').parentElement).toHaveStyle({ margin: '24px' })
     })
   })
 })

--- a/modules/cactus-web/src/CheckBox/CheckBox.tsx
+++ b/modules/cactus-web/src/CheckBox/CheckBox.tsx
@@ -5,18 +5,15 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { omitMargins } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 
-export interface CheckBoxProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
-  id?: string
-}
+export type CheckBoxProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const CheckBoxBase = React.forwardRef<HTMLInputElement, CheckBoxProps>((props, ref) => {
-  const componentProps = omitMargins<CheckBoxProps>(props)
-  const { id, className, ...checkBoxProps } = componentProps
+  const { style, className, ...checkBoxProps } = props
   return (
-    <label className={className} htmlFor={id}>
-      <HiddenCheckBox id={id} ref={ref} {...checkBoxProps} />
+    <label className={className} style={style} htmlFor={props.id}>
+      <HiddenCheckBox ref={ref} {...checkBoxProps} />
       <StyledCheckBox aria-hidden={true}>
         <StatusCheck />
       </StyledCheckBox>
@@ -49,14 +46,18 @@ const StyledCheckBox = styled.span`
   }
 `
 
-export const CheckBox = styled(CheckBoxBase)`
+export const CheckBox = withStyles(CheckBoxBase, {
+  as: CheckBoxBase,
+  displayName: 'CheckBox',
+  styles: [margin],
+})<MarginProps>`
   position: relative;
   display: inline-block;
   vertical-align: -1px;
   width: 16px;
   height: 16px;
   line-height: 16px;
-  cursor: ${(p): string => (p.disabled ? 'cursor' : 'pointer')};
+  cursor: ${(p) => (p.disabled ? 'cursor' : 'pointer')};
 
   input:checked ~ span {
     border-color: ${color('callToAction')};
@@ -74,8 +75,6 @@ export const CheckBox = styled(CheckBoxBase)`
     border-color: ${color('lightGray')};
     background-color: ${color('lightGray')};
   }
-
-  ${margin}
 `
 
 CheckBox.propTypes = {

--- a/modules/cactus-web/src/CheckBoxCard/CheckBoxCard.test.tsx
+++ b/modules/cactus-web/src/CheckBoxCard/CheckBoxCard.test.tsx
@@ -22,19 +22,24 @@ describe('component: CheckBoxCard', () => {
         value="quest"
         data-testid="mycheckbox"
         className="sup"
+        margin={3}
+        flexGrow="3"
         style={style}
       />
     )
+    const styles = [style, { margin: '8px' }, { flexGrow: 3 }]
     const input = getByTestId('mycheckbox')
     const wrapper = input.parentElement
     expect(input).toHaveAttribute('id', 'what')
     expect(input).toHaveAttribute('name', 'hope')
     expect(input).toHaveAttribute('value', 'quest')
     expect(input).toHaveAttribute('aria-labelledby', wrapper?.id)
-    expect(input).not.toHaveStyle(style)
     expect(input).not.toHaveClass('sup')
+    for (const s of styles) {
+      expect(input).not.toHaveStyle(s)
+      expect(wrapper).toHaveStyle(s)
+    }
     expect(wrapper?.id).not.toBe('what')
-    expect(wrapper).toHaveStyle(style)
     expect(wrapper).toHaveClass('sup', CheckBoxCard.toString().slice(1))
   })
 

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.test.tsx
@@ -39,6 +39,9 @@ describe('component: CheckBoxField', () => {
       ...blank,
       marginTop: '16px',
     })
+    // Make sure the margin props aren't passed through to the CheckBox component.
+    expect(getByTestId('default')).toHaveStyle(blank)
+    expect(getByTestId('default').parentElement).toHaveStyle(blank)
   })
 
   test('should support flex item props', () => {

--- a/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
+++ b/modules/cactus-web/src/CheckBoxField/CheckBoxField.tsx
@@ -1,15 +1,13 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
 
 import CheckBox, { CheckBoxProps } from '../CheckBox/CheckBox'
 import FieldWrapper from '../FieldWrapper/FieldWrapper'
-import { extractFieldStyleProps } from '../helpers/omit'
-import { FlexItemProps } from '../helpers/styled'
+import { withStyles } from '../helpers/styled'
 import useId from '../helpers/useId'
 import Label, { LabelProps } from '../Label/Label'
 
-export interface CheckBoxFieldProps extends CheckBoxProps, FlexItemProps {
+export interface CheckBoxFieldProps extends CheckBoxProps {
   label: React.ReactNode
   labelProps?: Omit<LabelProps, 'children' | 'htmlFor'>
   id?: string
@@ -18,27 +16,28 @@ export interface CheckBoxFieldProps extends CheckBoxProps, FlexItemProps {
 }
 
 const CheckBoxFieldBase = React.forwardRef<HTMLInputElement, CheckBoxFieldProps>((props, ref) => {
-  const { label, labelProps, id, name, ...checkboxProps } = props
-  const styleProps = extractFieldStyleProps(checkboxProps)
+  const { label, labelProps, id, name, className, style, ...checkboxProps } = props
   const checkboxId = useId(id, name)
 
   return (
-    <FieldWrapper {...styleProps} $gap={3}>
+    <div className={className} style={style}>
       <CheckBox {...checkboxProps} ref={ref} id={checkboxId} name={name} />
       <Label {...labelProps} htmlFor={checkboxId}>
         {label}
       </Label>
-    </FieldWrapper>
+    </div>
   )
 })
+CheckBoxFieldBase.displayName = 'CheckBoxField'
 
-export const CheckBoxField = styled(CheckBoxFieldBase)`
+export const CheckBoxField = withStyles(FieldWrapper, { as: CheckBoxFieldBase })`
   ${Label} {
     cursor: ${(p): string => (p.disabled ? 'not-allowed' : 'pointer')};
     padding-left: 8px;
     color: ${(p) => p.disabled && p.theme.colors.mediumGray};
   }
 `
+CheckBoxField.defaultProps = { $gap: 3 }
 
 CheckBoxField.propTypes = {
   label: PropTypes.node.isRequired,

--- a/modules/cactus-web/src/Checkable/Group.tsx
+++ b/modules/cactus-web/src/Checkable/Group.tsx
@@ -1,3 +1,4 @@
+import { border } from '@repay/cactus-theme'
 import { noop, pick } from 'lodash'
 import React from 'react'
 import styled from 'styled-components'
@@ -6,7 +7,7 @@ import AccessibleField, { ExtFieldProps } from '../AccessibleField/AccessibleFie
 import Box from '../Box/Box'
 import { isIE } from '../helpers/constants'
 import { cloneAll } from '../helpers/react'
-import { border } from '../helpers/theme'
+import { withStyles } from '../helpers/styled'
 
 const getCheckedFromValue = (value: Value, groupValue: GroupValue) =>
   Array.isArray(groupValue) ? groupValue.includes(value) : value === groupValue
@@ -101,14 +102,12 @@ type MakeGroup = (args: {
 }) => React.FC<GroupProps>
 
 export const makeGroup: MakeGroup = ({ component, displayName, role = 'group' }) => {
-  const Group: React.FC<GroupProps> = styled(component).attrs({ role, as: CheckableGroup })``
-  Group.displayName = displayName
-  return Group
+  return withStyles(component, { displayName, as: CheckableGroup, extraAttrs: { role } })``
 }
 
 export const Fieldset = styled(CheckableGroup)`
   .field-label-row {
-    border-bottom: ${(p) => border(p.theme, p.disabled ? 'mediumGray' : 'currentcolor')};
+    border-bottom: ${(p) => border(p, p.disabled ? 'mediumGray' : 'currentcolor')};
   }
   .field-input-group {
     margin: 0 ${(p) => p.theme.space[4]}px;

--- a/modules/cactus-web/src/Checkable/ToggleCard.tsx
+++ b/modules/cactus-web/src/Checkable/ToggleCard.tsx
@@ -1,15 +1,14 @@
+import { border, radius, shadow, textStyle } from '@repay/cactus-theme'
 import React from 'react'
 import styled from 'styled-components'
-import { margin, MarginProps } from 'styled-system'
+import { margin } from 'styled-system'
 
 import { PolyFCWithRef } from '../helpers/asProps'
 import { isIE } from '../helpers/constants'
 import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import generateId from '../helpers/generateId'
-import { omitProps } from '../helpers/omit'
 import { useBox } from '../helpers/react'
-import { styledWithClass } from '../helpers/styled'
-import { border, boxShadow, radius, textStyle } from '../helpers/theme'
+import { withStyles } from '../helpers/styled'
 import { FlexGroup, GroupProps, makeGroup } from './Group'
 import { CheckableProps, WrapperLabel } from './Wrapper'
 
@@ -99,14 +98,16 @@ type MakeToggleCard = (args: {
 }) => ToggleCardComponent
 
 export const makeToggleCard: MakeToggleCard = ({ type, displayName, groupRole }) => {
-  const Card: ToggleCardComponent = styled(StyledCard)
-    .withConfig(omitProps<MarginProps & FlexItemProps>(margin, flexItem))
-    .attrs({ type, as: ToggleCard })`
+  const Card: ToggleCardComponent = withStyles(StyledCard, {
+    displayName,
+    as: ToggleCard,
+    styles: [margin, flexItem],
+    extraAttrs: { type },
+  })`
     ${FlexGroup} .field-input-group > & {
       flex: 1 0 ${isIE ? 'auto' : '1px'};
     }
   ` as any
-  Card.displayName = displayName
   Card.Group = makeGroup({
     component: FlexGroup,
     displayName: `${displayName}.Group`,
@@ -116,7 +117,7 @@ export const makeToggleCard: MakeToggleCard = ({ type, displayName, groupRole })
   return Card
 }
 
-const CardSpan = styledWithClass('span', 'toggle-card-contents')`
+const CardSpan = withStyles('span', { className: 'toggle-card-contents' })`
   overflow: hidden;
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -126,17 +127,17 @@ const CardSpan = styledWithClass('span', 'toggle-card-contents')`
   width: 100%;
   height: 100%;
   padding: ${(p) => p.theme.space[4]}px;
-  border: ${(p) => border(p.theme, 'lightContrast')};
+  border: ${border('lightContrast')};
   border-radius: ${radius(8)};
   ${(p) => p.theme.colorStyles.standard};
-  ${(p) => textStyle(p.theme, 'h4')};
+  ${textStyle('h4')};
 
   label {
-    ${(p) => textStyle(p.theme, 'small')};
+    ${textStyle('small')};
   }
 `
 
-const Inverse = styledWithClass('span', 'toggle-card-inverse')`
+const Inverse = withStyles('span', { className: 'toggle-card-inverse' })`
   display: block;
   box-sizing: content-box;
   width: 100%;
@@ -149,14 +150,11 @@ const Inverse = styledWithClass('span', 'toggle-card-inverse')`
   :last-child {
     margin-bottom: -${(p) => p.theme.space[4]}px;
   }
-  ${(p) => textStyle(p.theme, 'small')};
+  ${textStyle('small')};
 `
 
 const StyledCard = styled(WrapperLabel)`
-  &&&& {
-    max-width: 100%;
-    ${flexItem}
-  }
+  max-width: 100%;
 
   input:focus + ${CardSpan} {
     border-color: ${(p) => p.theme.colors.callToAction};
@@ -172,7 +170,7 @@ const StyledCard = styled(WrapperLabel)`
     }
   }
   input:not(:disabled) + ${CardSpan}:hover {
-    ${(p) => boxShadow(p.theme, 2)};
+    ${shadow(2)};
   }
   input:disabled + ${CardSpan} {
     cursor: not-allowed;

--- a/modules/cactus-web/src/Checkable/Wrapper.ts
+++ b/modules/cactus-web/src/Checkable/Wrapper.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import { margin, MarginProps } from 'styled-system'
+import { MarginProps } from 'styled-system'
 
 export type CheckableProps = MarginProps &
   Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'ref'>
@@ -9,7 +9,6 @@ export const WrapperLabel = styled.label`
   display: inline-block;
   position: relative;
   cursor: pointer;
-  ${margin}
 
   > input {
     position: absolute;

--- a/modules/cactus-web/src/DataGrid/DataGrid.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.tsx
@@ -1,12 +1,11 @@
 import { identity } from 'lodash'
 import PropTypes from 'prop-types'
 import React, { ReactElement, useContext, useEffect, useState } from 'react'
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
+import { withStyles } from '../helpers/styled'
 import { useControllableValue } from '../hooks'
 import { ScreenSizeContext, Size, SIZES } from '../ScreenSizeProvider/ScreenSizeProvider'
-import { TableVariant } from '../Table/Table'
 import BottomSection from './BottomSection'
 import DataGridColumn, { useColumns } from './DataGridColumn'
 import DataGridTable from './DataGridTable'
@@ -14,9 +13,9 @@ import { DataGridContext, getMediaQuery, initialPageState } from './helpers'
 import PageSizeSelect from './PageSizeSelect'
 import { calcPageState, DataGridPagination, DataGridPrevNext, pageStateReducer } from './Pagination'
 import TopSection from './TopSection'
-import { PageStateAction, PaginationOptions, Pagisort, SortOption, TransientProps } from './types'
+import { PageStateAction, PaginationOptions, Pagisort, SortOption, TableProps } from './types'
 
-interface DataGridProps extends MarginProps {
+interface DataGridProps extends MarginProps, Partial<TableProps> {
   paginationOptions?: PaginationOptions
   sortOptions?: SortOption[]
   initialSort?: SortOption[]
@@ -24,12 +23,9 @@ interface DataGridProps extends MarginProps {
   onPageChange?: (newPageOptions: PaginationOptions) => void
   onSort?: (newSortOptions: SortOption[]) => void
   children: React.ReactNode
-  fullWidth?: boolean
-  cardBreakpoint?: Size
-  variant?: TableVariant
 }
 
-export const DataGrid = (props: DataGridProps): ReactElement => {
+const BaseDataGrid = (props: DataGridProps): ReactElement => {
   const {
     children,
     onPagisort,
@@ -89,12 +85,7 @@ export const DataGrid = (props: DataGridProps): ReactElement => {
   }, [children])
 
   return (
-    <StyledDataGrid
-      fullWidth={fullWidth}
-      $isCardView={isCardView}
-      $cardBreakpoint={cardBreakpoint}
-      {...rest}
-    >
+    <div {...rest}>
       <DataGridContext.Provider
         value={{
           ...columnState,
@@ -112,11 +103,15 @@ export const DataGrid = (props: DataGridProps): ReactElement => {
         {!topSectionRendered && <TopSection />}
         {children}
       </DataGridContext.Provider>
-    </StyledDataGrid>
+    </div>
   )
 }
 
-const StyledDataGrid = styled.div<DataGridProps & TransientProps>`
+export const DataGrid: DataGridType = withStyles('div', {
+  displayName: 'DataGrid',
+  as: BaseDataGrid,
+  styles: [margin],
+})<DataGridProps>`
   display: inline;
   flex-direction: column;
   width: ${(p): string => (p.fullWidth ? '100%' : 'auto')};
@@ -126,9 +121,11 @@ const StyledDataGrid = styled.div<DataGridProps & TransientProps>`
   ${getMediaQuery} {
     display: inline-flex;
   }
-`
+` as any
 
 DataGrid.propTypes = {
+  // TODO When we make `currentPage` & `pageSize` optional, fix this.
+  // @ts-expect-error
   paginationOptions: PropTypes.shape({
     currentPage: PropTypes.number,
     pageSize: PropTypes.number,
@@ -138,6 +135,7 @@ DataGrid.propTypes = {
   }),
   sortOptions: PropTypes.arrayOf(
     PropTypes.shape({ id: PropTypes.string.isRequired, sortAscending: PropTypes.bool.isRequired })
+      .isRequired
   ),
   onPageChange: PropTypes.func,
   onSort: PropTypes.func,
@@ -166,6 +164,4 @@ DataGrid.BottomSection = BottomSection
 DataGrid.Pagination = DataGridPagination
 DataGrid.PrevNext = DataGridPrevNext
 
-DataGrid.displayName = 'DataGrid'
-
-export default DataGrid as DataGridType
+export default DataGrid

--- a/modules/cactus-web/src/DataGrid/PageSizeSelect.tsx
+++ b/modules/cactus-web/src/DataGrid/PageSizeSelect.tsx
@@ -1,24 +1,23 @@
-import { ColorStyle } from '@repay/cactus-theme'
+import { border, ColorStyle, fontSize } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React, { ReactElement, useContext } from 'react'
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { keyDownAsClick } from '../helpers/a11y'
-import { border, fontSize } from '../helpers/theme'
+import { withStyles } from '../helpers/styled'
 import { DataGridContext } from './helpers'
 
-export interface PageSizeSelectProps extends MarginProps {
+export interface PageSizeSelectProps {
   pageSize?: number
   initialPageSize?: number
   makePageSizeLabel?: (pageSize: number) => string
-  pageSizeSelectLabel?: React.ReactChild
+  pageSizeSelectLabel?: React.ReactNode
   pageSizeOptions: number[]
 }
 
 const defaultPageSizeLabel = (pageSize: number): string => `View ${pageSize} rows per page`
 
-const PageSizeSelect = (props: PageSizeSelectProps): ReactElement => {
+const BasePageSizeSelect = (props: PageSizeSelectProps): ReactElement => {
   const { pageState, updatePageState } = useContext(DataGridContext)
   const {
     pageSizeSelectLabel,
@@ -32,7 +31,7 @@ const PageSizeSelect = (props: PageSizeSelectProps): ReactElement => {
     updatePageState({ pageSize: currentPageSize })
   }, [currentPageSize]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
-    <StyledPageSizeSelect {...rest}>
+    <div {...rest}>
       <span>{pageSizeSelectLabel || 'View'}</span>
       <ol className="page-options-list">
         {pageSizeOptions?.map((pageSize): ReactElement => {
@@ -53,13 +52,16 @@ const PageSizeSelect = (props: PageSizeSelectProps): ReactElement => {
           )
         })}
       </ol>
-    </StyledPageSizeSelect>
+    </div>
   )
 }
 
-const StyledPageSizeSelect = styled.div`
+const PageSizeSelect = withStyles('div', {
+  as: BasePageSizeSelect,
+  displayName: 'PageSizeSelect',
+  styles: [margin],
+})<MarginProps>`
   display: inline-box;
-  ${margin}
 
   span {
     margin-right: 8px;
@@ -82,16 +84,16 @@ const StyledPageSizeSelect = styled.div`
     padding: 2px 8px;
     display: block;
 
-    border-left: ${(p): string => border(p.theme, 'lightContrast')};
+    border-left: ${border('lightContrast')};
 
     &:last-child {
-      border-right: ${(p): string => border(p.theme, 'lightContrast')};
+      border-right: ${border('lightContrast')};
     }
 
     &,
     a {
       color: ${(p): string => p.theme.colors.darkestContrast};
-      ${(p): string => fontSize(p.theme, 'small')};
+      ${fontSize('small')};
       line-height: 18px;
       text-decoration: none;
     }
@@ -133,9 +135,7 @@ PageSizeSelect.defaultProps = {
 PageSizeSelect.propTypes = {
   makePageSizeLabel: PropTypes.func,
   pageSizeSelectLabel: PropTypes.node,
-  pageSizeOptions: PropTypes.arrayOf(PropTypes.number),
+  pageSizeOptions: PropTypes.arrayOf(PropTypes.number.isRequired).isRequired,
 }
-
-PageSizeSelect.displayName = 'PageSizeSelect'
 
 export default PageSizeSelect

--- a/modules/cactus-web/src/DataGrid/helpers.ts
+++ b/modules/cactus-web/src/DataGrid/helpers.ts
@@ -2,10 +2,10 @@ import { noop } from 'lodash'
 import { createContext } from 'react'
 import { DefaultTheme, ThemedStyledProps } from 'styled-components'
 
-import { DataGridContextType, PaginationOptions, TransientProps } from './types'
+import { DataGridContextType, PaginationOptions, TableProps } from './types'
 
 export const getMediaQuery = (
-  props: ThemedStyledProps<TransientProps, DefaultTheme>
+  props: ThemedStyledProps<Partial<TableProps>, DefaultTheme>
 ): string | undefined => {
   // Media queries in the theme were built using "min-width", meaning if a user wants
   // the card breakpoint to be at "medium", we will add a media query to apply different
@@ -13,11 +13,11 @@ export const getMediaQuery = (
   // for the next screen size up. For "extraLarge", we can just return a media query for
   // an absurdly large screen that would probably never even occur.
   const {
-    $cardBreakpoint,
+    cardBreakpoint,
     theme: { mediaQueries },
   } = props
   if (mediaQueries !== undefined) {
-    switch ($cardBreakpoint) {
+    switch (cardBreakpoint) {
       case 'tiny':
         return mediaQueries.small
       case 'small':

--- a/modules/cactus-web/src/DataGrid/types.ts
+++ b/modules/cactus-web/src/DataGrid/types.ts
@@ -16,6 +16,12 @@ export interface TransientProps {
   $variant?: TableVariant
 }
 
+export interface TableProps {
+  fullWidth: boolean
+  cardBreakpoint: Size
+  variant: TableVariant | undefined
+}
+
 export interface CellInfo {
   id?: string
   value?: any
@@ -93,14 +99,11 @@ export interface ColumnProps extends Omit<TableCellProps, 'as' | 'children' | 't
   as?: React.ComponentType<any>
 }
 
-export interface DataGridContextType extends ColumnState {
+export interface DataGridContextType extends ColumnState, TableProps {
   columnDispatch: ColumnDispatch
   sortOptions: SortOption[]
   onSort: (newSortOptions: SortOption[]) => void
   pageState: PaginationOptions
   updatePageState: (action: PageStateAction, raiseEvent?: boolean) => void
-  fullWidth: boolean
-  cardBreakpoint: Size
   isCardView: boolean
-  variant: TableVariant | undefined
 }

--- a/modules/cactus-web/src/Dimmer/Dimmer.tsx
+++ b/modules/cactus-web/src/Dimmer/Dimmer.tsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { ResponsiveValue, system } from 'styled-system'
 
-import { styledUnpoly } from '../helpers/styled'
+import { withStyles } from '../helpers/styled'
 
 type Opacity = string | number
 interface DimmerStyleProps {
@@ -17,7 +17,6 @@ interface DimmerProps extends React.HTMLAttributes<HTMLDivElement> {
 const DimmerBase = React.forwardRef<HTMLDivElement, DimmerProps>(({ active, ...props }, ref) => {
   return active ? <div {...props} ref={ref} /> : null
 })
-DimmerBase.displayName = 'Dimmer'
 
 const background = (opacity?: Opacity) => `rgba(46, 53, 56, ${opacity || '0.9'})`
 
@@ -29,9 +28,11 @@ const dimmerStyles = system({
   },
 })
 
-export const Dimmer = styledUnpoly(DimmerBase).withConfig<DimmerStyleProps>({
-  shouldForwardProp: (prop) => prop !== 'position' && prop !== 'opacity',
-})`
+export const Dimmer = withStyles('div', {
+  displayName: 'Dimmer',
+  as: DimmerBase,
+  styles: [dimmerStyles],
+})<DimmerStyleProps>`
   position: fixed;
   display: flex;
   background-color: ${background()};

--- a/modules/cactus-web/src/FieldWrapper/FieldWrapper.test.tsx
+++ b/modules/cactus-web/src/FieldWrapper/FieldWrapper.test.tsx
@@ -20,4 +20,11 @@ describe('component: FormField', () => {
 
     expect(styles.marginTop).toBe('16px')
   })
+
+  test('should support style props', () => {
+    const { getByTestId } = renderWithTheme(
+      <FieldWrapper data-testid="fieldWrapper" m={2} flexGrow="5" />
+    )
+    expect(getByTestId('fieldWrapper')).toHaveStyle({ margin: '4px', flexGrow: '5' })
+  })
 })

--- a/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
+++ b/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
@@ -1,21 +1,16 @@
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { flexItem, FlexItemProps } from '../helpers/flexItem'
-import { getOmittableProps } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 
 type StyleProps = MarginProps & FlexItemProps & { $gap?: number }
-const styleProps = getOmittableProps(margin, flexItem)
-export const FieldWrapper = styled.div.withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const FieldWrapper = withStyles('div', {
+  displayName: 'FieldWrapper',
+  styles: [margin, flexItem],
 })<StyleProps>`
   min-width: 1px; /* IE Fix for some situations. */
   :not(:first-child) {
     margin-top: ${(p) => p.theme.space[p.$gap ?? 4]}px;
-  }
-  && {
-    ${margin}
-    ${flexItem}
   }
 `
 

--- a/modules/cactus-web/src/Flex/Flex.tsx
+++ b/modules/cactus-web/src/Flex/Flex.tsx
@@ -1,10 +1,15 @@
 import { CactusTheme } from '@repay/cactus-theme'
-import styled, { StyledComponentBase } from 'styled-components'
-import { compose } from 'styled-system'
+import { StyledComponentBase } from 'styled-components'
 
 import { Box, BoxProps } from '../Box/Box'
-import { getOmittableProps } from '../helpers/omit'
-import { flexContainer, flexItem, FlexItemProps, FlexProps, gapWorkaround } from '../helpers/styled'
+import {
+  flexContainer,
+  flexItem,
+  FlexItemProps,
+  FlexProps,
+  gapWorkaround,
+  withStyles,
+} from '../helpers/styled'
 
 export interface FlexBoxProps extends BoxProps, FlexProps, FlexItemProps {}
 
@@ -25,21 +30,19 @@ export const justifyOptions = [
 ] as const
 export type JustifyContent = typeof justifyOptions[number]
 
-const styleProps = getOmittableProps(flexContainer, flexItem)
-export const Flex: FlexComponent = styled(Box).withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const Flex: FlexComponent = withStyles(Box, {
+  displayName: 'Flex',
+  transitiveProps: gapWorkaround?.propNames,
+  styles: [flexContainer, flexItem],
 })<FlexBoxProps>`
   display: flex;
   flex-wrap: wrap;
   ${gapWorkaround}
-  ${compose(flexContainer, flexItem)}
 ` as any
 Flex.supportsGap = !gapWorkaround
 
-const itemStyleProps = getOmittableProps(flexItem)
-Flex.Item = styled.div.withConfig({
-  shouldForwardProp: (p) => !itemStyleProps.has(p),
-})<FlexItemProps>(flexItem)
-Flex.Item.displayName = 'Flex.Item'
+Flex.Item = withStyles('div', { displayName: 'Flex.Item', styles: [flexItem] })<FlexItemProps>(
+  flexItem
+)
 
 export default Flex

--- a/modules/cactus-web/src/Footer/Footer.test.tsx
+++ b/modules/cactus-web/src/Footer/Footer.test.tsx
@@ -19,4 +19,64 @@ describe('component: Footer', () => {
 
     expect(getByTestId('image')).toBeInTheDocument()
   })
+
+  test('should support style props', () => {
+    const { getByTestId, rerender } = renderWithTheme(<Footer data-testid="footer" />)
+    const footer = getByTestId('footer')
+    expect(footer).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      paddingTop: '24px',
+      paddingBottom: '24px',
+      paddingLeft: '40px',
+      paddingRight: '40px',
+    })
+    expect(footer.firstElementChild).toHaveClass('footer-content')
+    rerender(<Footer flexFlow="row" alignItems="stretch" padding="2rem" />)
+    expect(footer).toHaveStyle({
+      display: 'flex',
+      flexFlow: 'row',
+      alignItems: 'stretch',
+      paddingTop: '2rem',
+      paddingBottom: '2rem',
+      paddingLeft: '2rem',
+      paddingRight: '2rem',
+    })
+    expect(footer.firstElementChild).toBe(null)
+  })
+
+  describe('component: Footer.Logo', () => {
+    test('should support style props', () => {
+      const { getByTestId, rerender } = renderWithTheme(<Footer.Logo data-testid="logo" />)
+      const logo = getByTestId('logo')
+      expect(logo).toHaveStyle({
+        flexBasis: '',
+        marginBottom: '24px',
+        minHeight: '',
+        minWidth: '',
+        position: '',
+        left: '',
+      })
+      expect(logo).toHaveClass('footer-logo')
+      rerender(
+        <Footer.Logo
+          flexBasis="20%"
+          m={4}
+          minHeight="24px"
+          minWidth="24px"
+          position="absolute"
+          left="10px"
+        />
+      )
+      expect(logo).toHaveStyle({
+        flexBasis: '20%',
+        marginBottom: '16px',
+        minHeight: '24px',
+        minWidth: '24px',
+        position: 'absolute',
+        left: '10px',
+      })
+    })
+  })
 })

--- a/modules/cactus-web/src/Footer/Footer.tsx
+++ b/modules/cactus-web/src/Footer/Footer.tsx
@@ -10,18 +10,9 @@ import {
 import PropTypes from 'prop-types'
 import React from 'react'
 import { css } from 'styled-components'
-import {
-  compose,
-  margin,
-  MarginProps,
-  padding,
-  PaddingProps,
-  position,
-  PositionProps,
-} from 'styled-system'
+import { margin, MarginProps, padding, PaddingProps, position, PositionProps } from 'styled-system'
 
 import { isIE } from '../helpers/constants'
-import omit, { omitProps } from '../helpers/omit'
 import {
   classes,
   flexContainerOption,
@@ -31,8 +22,7 @@ import {
   gapWorkaround,
   sizing,
   SizingProps,
-  styledUnpoly,
-  styledWithClass,
+  withStyles,
 } from '../helpers/styled'
 import { useLayout } from '../Layout/Layout'
 
@@ -48,18 +38,11 @@ interface FooterComponent extends React.FC<FooterProps> {
 
 type LogoProps = FlexItemProps & MarginProps & PositionProps & SizingProps
 
-const stylePropNames = [
-  'variant',
-  ...(flexContainerOption.propNames as string[]),
-  ...(padding.propNames as string[]),
-]
-
-const FooterBase = ({ logo, children, className, ...rest }: FooterProps) => {
+const FooterBase = ({ logo, children, className, flexFlow, ...rest }: FooterProps) => {
   const layoutClass = useLayout('footer', { grid: 'footer' })
-  const isCustomFlex = !!rest.flexFlow
-  const props = omit(rest, stylePropNames)
+  const isCustomFlex = !!flexFlow
   return (
-    <footer {...props} role="contentinfo" className={classes(className, layoutClass)}>
+    <footer {...rest} role="contentinfo" className={classes(className, layoutClass)}>
       {logo && (
         <FooterLogo>{typeof logo === 'string' ? <img alt="Logo" src={logo} /> : logo}</FooterLogo>
       )}
@@ -67,11 +50,11 @@ const FooterBase = ({ logo, children, className, ...rest }: FooterProps) => {
     </footer>
   )
 }
-FooterBase.displayName = 'Footer'
 
-const FooterLogo = styledWithClass('div', 'footer-logo').withConfig(
-  omitProps<LogoProps>(flexItem, margin, position, sizing)
-)`
+const FooterLogo = withStyles('div', {
+  className: 'footer-logo',
+  styles: [flexItem, margin, position, sizing],
+})<LogoProps>`
   margin-bottom: ${space(5)};
   ${mediaGTE('small')} {
     margin-bottom: 0;
@@ -84,13 +67,10 @@ const FooterLogo = styledWithClass('div', 'footer-logo').withConfig(
     max-width: 200px;
     max-height: 40px;
   }
-  &&& {
-    ${compose(flexItem, margin, position, sizing)};
-  }
 `
 FooterLogo.displayName = 'Footer.Logo'
 
-const ContentWrapper = styledWithClass('div', 'footer-content')`
+const ContentWrapper = withStyles('div', { className: 'footer-content' })`
   min-width: 1px;
   max-width: 100%;
   overflow-wrap: break-word;
@@ -121,7 +101,12 @@ const variants: VariantMap = {
   `,
 }
 
-export const Footer = styledUnpoly(FooterBase as FooterComponent)`
+export const Footer: FooterComponent = withStyles('footer', {
+  displayName: 'Footer',
+  as: FooterBase,
+  styles: [flexContainerOption, padding],
+  preserveProps: ['flexFlow'],
+})<FooterProps>`
   ${textStyle('body')};
   position: relative;
   display: flex;
@@ -171,10 +156,7 @@ export const Footer = styledUnpoly(FooterBase as FooterComponent)`
   }
 
   ${gapWorkaround}
-  &&& {
-    ${compose(flexContainerOption, padding)}
-  }
-`
+` as any
 
 Footer.Logo = FooterLogo
 

--- a/modules/cactus-web/src/Grid/Grid.test.tsx
+++ b/modules/cactus-web/src/Grid/Grid.test.tsx
@@ -32,7 +32,7 @@ describe('component: Grid', () => {
           <Grid.Item tiny={6} small={3} data-testid="item" />
         </Grid>
       )
-      expect(getByTestId('item')).toHaveStyle({ gridColumnEnd: 'span 6' })
+      expect(getByTestId('item')).toHaveStyle({ gridColumnEnd: 'span 3' })
     })
   })
 
@@ -75,8 +75,7 @@ describe('component: Grid', () => {
       gridAutoColumns: 'test6',
       rowGap: '14px',
       columnGap: '24px',
-      // `width` isn't overridden properly, possibly because it's defined in Box...
-      width: '100%',
+      width: '500px',
     })
   })
 

--- a/modules/cactus-web/src/Grid/Grid.test.tsx
+++ b/modules/cactus-web/src/Grid/Grid.test.tsx
@@ -19,7 +19,6 @@ describe('component: Grid', () => {
         flexWrap: 'wrap',
         // Original to Grid:
         display: 'grid',
-        gap: '16px',
         justifyItems: 'normal',
         width: '100%',
         gridTemplateColumns: 'repeat(12,minmax(1px,1fr))',

--- a/modules/cactus-web/src/Grid/Grid.tsx
+++ b/modules/cactus-web/src/Grid/Grid.tsx
@@ -8,7 +8,7 @@ import * as SS from 'styled-system'
 import Flex, { FlexBoxProps } from '../Flex/Flex'
 import { isIE } from '../helpers/constants'
 import { useMergedRefs } from '../helpers/react'
-import { FlexItemProps, withStyles } from '../helpers/styled'
+import { FlexItemProps, gapWorkaround, withStyles } from '../helpers/styled'
 import { screenSizes, useScreenSize } from '../ScreenSizeProvider/ScreenSizeProvider'
 
 const DEFAULT_GAP = 4
@@ -293,6 +293,11 @@ export const Grid: GridComponent = (function (): any {
     styles.width = '100%'
     styles.display = css.grid
     styles[css.gridTemplateColumns] = pseudoFlexColumns
+    if (gapWorkaround) {
+      Object.assign(styles, gapWorkaround({ gap: DEFAULT_GAP, theme: props.theme }))
+    } else {
+      styles.gap = props.theme.space[DEFAULT_GAP]
+    }
 
     const { gridAreas } = props
     if (gridAreas) {
@@ -311,8 +316,6 @@ export const Grid: GridComponent = (function (): any {
     styles: [SS.system(gridStyleConfig)],
   })(gridStyles)
 })()
-
-Grid.defaultProps = { gap: DEFAULT_GAP }
 
 Grid.Item = GridItem
 Grid.supportsGap = Flex.supportsGap

--- a/modules/cactus-web/src/Grid/Grid.tsx
+++ b/modules/cactus-web/src/Grid/Grid.tsx
@@ -7,9 +7,8 @@ import * as SS from 'styled-system'
 
 import Flex, { FlexBoxProps } from '../Flex/Flex'
 import { isIE } from '../helpers/constants'
-import { getOmittableProps } from '../helpers/omit'
 import { useMergedRefs } from '../helpers/react'
-import { FlexItemProps } from '../helpers/styled'
+import { FlexItemProps, withStyles } from '../helpers/styled'
 import { screenSizes, useScreenSize } from '../ScreenSizeProvider/ScreenSizeProvider'
 
 const DEFAULT_GAP = 4
@@ -179,26 +178,21 @@ const gridItemStyles = (function () {
   return SS.system(itemStyleConfig)
 })()
 
-const pseudoFlexStyles = (function (): SS.styleFn {
-  const parser: SS.styleFn = (props: GridItemProps & { theme: CactusTheme }) => {
+const pseudoFlexStyles = (props: GridItemProps) => {
+  if (!props.colEnd && !props.columnEnd) {
     const spans = screenSizes.map((size) => props[size] && `span ${props[size]}`)
-    return gridItemStyles({ colEnd: spans, theme: props.theme })
+    if (spans.some(Boolean)) {
+      return { ...props, colEnd: spans }
+    }
   }
-  parser.propNames = [...screenSizes]
-  return parser
-})()
+}
 
-const itemStyleProps = getOmittableProps(gridItemStyles, pseudoFlexStyles)
-
-export const GridItem = styled(Flex.Item).withConfig({
-  shouldForwardProp: (p: any) => !itemStyleProps.has(p),
-})`
-  ${pseudoFlexStyles}
-  && {
-    ${gridItemStyles}
-  }
-` as GridComponent['Item']
-GridItem.displayName = 'Grid.Item'
+export const GridItem = withStyles(Flex.Item, {
+  displayName: 'Grid.Item',
+  styles: [gridItemStyles],
+  transitiveProps: screenSizes,
+  extraAttrs: pseudoFlexStyles,
+})`` as GridComponent['Item']
 
 const ColumnPropType = PropTypes.oneOf<ColumnNum>(COLUMN_NUMS)
 GridItem.propTypes = {
@@ -209,9 +203,9 @@ GridItem.propTypes = {
   extraLarge: ColumnPropType,
 }
 
-export const Grid: GridComponent = (function () {
+export const Grid: GridComponent = (function (): any {
   const repeat = (count: number, text: string) => {
-    if (!isIE) return `repeat(${count}, ${text})`
+    if (!isIE) return `repeat(${count},${text})`
     const result: string[] = []
     for (let i = 0; i < count; i++) result.push(text)
     return result.join(' ')
@@ -235,7 +229,7 @@ export const Grid: GridComponent = (function () {
   gridStyleConfig.columns = gridStyleConfig.cols
   gridStyleConfig.autoColumns = gridStyleConfig.autoCols
 
-  let gridTag: any
+  let GridBase: React.ComponentType = Flex
   let justifyStyles: SS.styleFn
 
   if (isIE) {
@@ -273,12 +267,11 @@ export const Grid: GridComponent = (function () {
         return <Flex {...props} ref={ref} />
       }
     )
-    gridTag = styled(gridBase).attrs(isPseudoFlexMode)
 
     const applyJustifyToChildren = (value: unknown) => {
       if (value) return { '& > *': { [css.justifySelf]: value } }
     }
-    // Keeping this separate in case we implement inline styles, see CACTUS-975.
+    // Keeping this separate from the inline styles because it applies to children.
     justifyStyles = SS.system({
       justify: applyJustifyToChildren,
       justifyItems: applyJustifyToChildren,
@@ -288,20 +281,18 @@ export const Grid: GridComponent = (function () {
         if (value) return { '&>*': { [css.alignSelf]: value } }
       },
     })
+    GridBase = styled(gridBase).attrs(isPseudoFlexMode)``
   } else {
-    gridTag = styled(Flex)
     // Could be a constant, but it makes things more symmetrical with the IE code.
     justifyStyles = () => ({ justifyItems: 'normal' })
   }
 
   const pseudoFlexColumns = repeat(PSEUDO_FLEX_COLS, 'minmax(1px, 1fr)')
-  const systemStyles = SS.system(gridStyleConfig)
   const gridStyles = (props: GridBoxProps & { theme: CactusTheme }) => {
     const styles = justifyStyles(props)
     styles.width = '100%'
     styles.display = css.grid
     styles[css.gridTemplateColumns] = pseudoFlexColumns
-    styles['&&'] = systemStyles(props)
 
     const { gridAreas } = props
     if (gridAreas) {
@@ -314,11 +305,10 @@ export const Grid: GridComponent = (function () {
     }
     return styles
   }
-
-  const styleProps = getOmittableProps(systemStyles, 'gridAreas')
-  return gridTag.withConfig({
+  return withStyles(GridBase, {
     displayName: 'Grid',
-    shouldForwardProp: (p: any) => !styleProps.has(p),
+    transitiveProps: ['gridAreas'],
+    styles: [SS.system(gridStyleConfig)],
   })(gridStyles)
 })()
 

--- a/modules/cactus-web/src/IconButton/IconButton.test.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.test.tsx
@@ -13,17 +13,25 @@ describe('component: IconButton', () => {
       </IconButton>
     )
 
-    expect(getByLabelText('uchiha-itachi')).toBeInTheDocument()
+    // Test the default styles while we're at it.
+    expect(getByLabelText('uchiha-itachi')).toHaveStyle({
+      display: 'inline-flex',
+      fontSize: '24px',
+      margin: '',
+    })
   })
-  test('should support margin space props', () => {
+
+  test('should support style props', () => {
     const { getByLabelText } = renderWithTheme(
-      <IconButton label="boolest" mb={4}>
+      <IconButton label="boolest" m={4} display="flex" iconSize="small">
         <StatusCheck />
       </IconButton>
     )
-    const iconButton = getByLabelText('boolest')
-    const styles = window.getComputedStyle(iconButton)
-    expect(styles.marginBottom).toBe('16px')
+    expect(getByLabelText('boolest')).toHaveStyle({
+      display: 'flex',
+      fontSize: '16px',
+      margin: '16px',
+    })
   })
 
   test('should trigger onClick', () => {

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -1,22 +1,17 @@
 import { iconSizes } from '@repay/cactus-icons'
-import { CactusTheme } from '@repay/cactus-theme'
+import { border, CactusTheme } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import React from 'react'
-import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
+import { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps, system } from 'styled-system'
 
 import { isIE } from '../helpers/constants'
-import { getOmittableProps } from '../helpers/omit'
-import { borderSize } from '../helpers/theme'
+import { withStyles } from '../helpers/styled'
 
 export type IconButtonVariants = 'standard' | 'action' | 'danger' | 'warning' | 'success' | 'dark'
 export type IconButtonSizes = 'tiny' | 'small' | 'medium' | 'large'
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  label?: string
-}
-
 interface IconStyleProps extends MarginProps {
+  label?: string
   iconSize?: IconButtonSizes
   variant?: IconButtonVariants
   disabled?: boolean
@@ -149,17 +144,6 @@ const variantOrDisabled = (
   }
 }
 
-const IconButtonBase = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (props, ref): React.ReactElement => {
-    const { label, children, ...buttonProps } = props
-    return (
-      <button aria-label={label} ref={ref} {...buttonProps}>
-        {children}
-      </button>
-    )
-  }
-)
-
 const focusOutline = system({
   iconSize: (value: IconButtonSizes) => {
     const offset = focusOutlineSpacing[value] || focusOutlineSpacing.medium
@@ -176,11 +160,13 @@ const focusOutline = system({
   },
 })
 
-const styleProps = getOmittableProps(margin, 'display', 'inverse', 'variant', 'iconSize')
-export const IconButton = styled(IconButtonBase).withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const IconButton = withStyles('button', {
+  displayName: 'IconButton',
+  transitiveProps: ['inverse', 'variant', 'label'],
+  styles: [margin, iconSizes, system({ display: true })],
+  extraAttrs: (props) => (props.label ? { 'aria-label': props.label } : undefined),
 })<IconStyleProps>`
-  display: ${(p): string => p.display || 'inline-flex'};
+  display: inline-flex;
   box-sizing: border-box;
   align-items: center;
   justify-content: center;
@@ -202,23 +188,20 @@ export const IconButton = styled(IconButtonBase).withConfig({
       display: block;
       position: absolute;
       ${focusOutline}
-      ${(p) => `border: ${borderSize(p)} solid;`}
+      border: ${border('callToAction')};
       ${(p) => shapeMap[p.theme.shape]}
-      border-color: ${(p): string => p.theme.colors.callToAction};
       box-sizing: border-box;
     }
   }
 
   ${variantOrDisabled}
-  ${margin}
-  ${iconSizes}
 `
 
 IconButton.propTypes = {
   iconSize: PropTypes.oneOf(['tiny', 'small', 'medium', 'large']),
   variant: PropTypes.oneOf(['standard', 'action', 'danger', 'warning', 'success', 'dark']),
   disabled: PropTypes.bool,
-  label: (props: ButtonProps, propName: string, componentName: string): Error | null => {
+  label: (props: any, propName: string, componentName: string): Error | null => {
     if (!props.label && !props['aria-label'] && !props['aria-labelledby']) {
       return new Error(
         `One of props 'label' or 'aria-labelledby' was not specified in ${componentName}.`
@@ -238,7 +221,6 @@ IconButton.propTypes = {
 IconButton.defaultProps = {
   variant: 'standard',
   iconSize: 'medium',
-  display: 'inline-flex',
   type: 'button',
 }
 

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -1,5 +1,5 @@
 import { iconSizes } from '@repay/cactus-icons'
-import { border, CactusTheme } from '@repay/cactus-theme'
+import { border, CactusTheme, iconSize } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps, system } from 'styled-system'
@@ -177,6 +177,7 @@ export const IconButton = withStyles('button', {
   cursor: pointer;
   position: relative;
   overflow: visible;
+  font-size: ${iconSize('medium')};
 
   &::-moz-focus-inner {
     border: 0;
@@ -220,7 +221,6 @@ IconButton.propTypes = {
 
 IconButton.defaultProps = {
   variant: 'standard',
-  iconSize: 'medium',
   type: 'button',
 }
 

--- a/modules/cactus-web/src/Layout/Layout.tsx
+++ b/modules/cactus-web/src/Layout/Layout.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import styled from 'styled-components'
 // @ts-ignore The types library doesn't have `overflowX` & `overflowY` for some reason.
 import { overflow, OverflowProps, overflowX, overflowY } from 'styled-system'
 
 import ActionProvider from '../ActionBar/ActionProvider'
-import { getDataProps, omitProps } from '../helpers/omit'
-import { classes, styledWithClass } from '../helpers/styled'
+import { getDataProps } from '../helpers/omit'
+import { classes, withStyles } from '../helpers/styled'
 import ScreenSizeProvider from '../ScreenSizeProvider/ScreenSizeProvider'
 import useGridLayout, { LayoutContext, useLayout } from './grid'
 
@@ -16,7 +15,10 @@ interface LayoutProps {
   styles: StyleList
 }
 
-const LayoutWrapper = styledWithClass('div', 'cactus-layout')<LayoutProps>((p) => p.styles)
+const LayoutWrapper = withStyles('div', {
+  className: 'cactus-layout',
+  transitiveProps: ['styles'],
+})<LayoutProps>((p) => p.styles)
 
 export const Layout: React.FC<{ children: React.ReactNode }> = ({ children, ...rest }) => {
   const layout = useGridLayout()
@@ -33,24 +35,22 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children, ...r
   )
 }
 
-type MainProps = React.HTMLAttributes<HTMLElement>
-const MainImpl = React.forwardRef<HTMLElement, MainProps>((p, ref) => {
+const useMainLayout = (p: { className?: string }) => {
   const layoutClass = useLayout('main', {
     width: 'minmax(1px, 1fr)',
     height: 'minmax(max-content, 1fr)',
   })
-  return <main {...p} ref={ref} className={classes(p.className, layoutClass)} />
-})
+  return { className: classes(p.className, layoutClass) }
+}
 
-const Main = styled(MainImpl).withConfig(
-  omitProps<MainProps & OverflowProps>(overflow, overflowX, overflowY)
-)`
+const Main = withStyles('main', {
+  displayName: 'Main',
+  extraAttrs: useMainLayout,
+  styles: [overflow, overflowX, overflowY],
+})<OverflowProps>`
   display: block;
   box-sizing: border-box;
   width: 100%;
-  ${overflow};
-  ${overflowX};
-  ${overflowY};
 `
 Main.defaultProps = { role: 'main' }
 

--- a/modules/cactus-web/src/Link/Link.tsx
+++ b/modules/cactus-web/src/Link/Link.tsx
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { getOmittableProps } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 
 interface AnchorProps extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
   to: string
@@ -21,9 +20,10 @@ const LinkBase = React.forwardRef<HTMLAnchorElement, AnchorProps>((props, ref) =
   return <a ref={ref} href={to} {...rest} />
 })
 
-const styleProps = getOmittableProps(margin, 'variant')
-export const Link = styled(LinkBase).withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const Link = withStyles(LinkBase, {
+  displayName: 'Link',
+  transitiveProps: ['variant'],
+  styles: [margin],
 })<LinkStyleProps>`
   font-style: italic;
   outline: none;
@@ -46,8 +46,6 @@ export const Link = styled(LinkBase).withConfig({
     color: ${(p): string => p.theme.colors.callToAction};
     background-color: ${(p): string => p.theme.colors.lightCallToAction};
   }
-
-  ${margin};
 `
 
 Link.propTypes = {

--- a/modules/cactus-web/src/Pagination/Pagination.test.tsx
+++ b/modules/cactus-web/src/Pagination/Pagination.test.tsx
@@ -142,4 +142,24 @@ describe('component: Pagination', () => {
     }
     expect(func).toHaveBeenCalledTimes(1)
   })
+
+  test('should support style props', () => {
+    const { getByTestId } = renderWithTheme(
+      <Pagination
+        pageCount={1}
+        currentPage={1}
+        onPageChange={() => undefined}
+        data-testid="pages"
+        margin={3}
+        width="300px"
+        maxWidth="70%"
+      />
+    )
+    expect(getByTestId('pages')).toHaveStyle({
+      margin: '8px',
+      width: '300px',
+      maxWidth: '70%',
+      minWidth: '160px',
+    })
+  })
 })

--- a/modules/cactus-web/src/RadioCard/RadioCard.test.tsx
+++ b/modules/cactus-web/src/RadioCard/RadioCard.test.tsx
@@ -14,19 +14,24 @@ describe('component: RadioCard', () => {
         value="quest"
         data-testid="myradio"
         className="sup"
+        margin={3}
+        flexGrow="3"
         style={style}
       />
     )
+    const styles = [style, { margin: '8px' }, { flexGrow: 3 }]
     const input = getByTestId('myradio')
     const wrapper = input.parentElement
     expect(input).toHaveAttribute('id', 'what')
     expect(input).toHaveAttribute('name', 'hope')
     expect(input).toHaveAttribute('value', 'quest')
     expect(input).toHaveAttribute('aria-labelledby', wrapper?.id)
-    expect(input).not.toHaveStyle(style)
     expect(input).not.toHaveClass('sup')
+    for (const s of styles) {
+      expect(input).not.toHaveStyle(s)
+      expect(wrapper).toHaveStyle(s)
+    }
     expect(wrapper?.id).not.toBe('what')
-    expect(wrapper).toHaveStyle(style)
     expect(wrapper).toHaveClass('sup', RadioCard.toString().slice(1))
   })
 

--- a/modules/cactus-web/src/Range/Range.tsx
+++ b/modules/cactus-web/src/Range/Range.tsx
@@ -2,18 +2,10 @@ import { color, colorStyle, lineHeight, shadow, space, textStyle } from '@repay/
 import PropTypes from 'prop-types'
 import React from 'react'
 import { CSSObject } from 'styled-components'
-import { compose, margin, MarginProps } from 'styled-system'
+import { margin, MarginProps } from 'styled-system'
 
-import { omitProps } from '../helpers/omit'
 import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
-import {
-  flexItem,
-  FlexItemProps,
-  sizing,
-  SizingProps,
-  styledUnpoly,
-  styledWithClass,
-} from '../helpers/styled'
+import { flexItem, FlexItemProps, sizing, SizingProps, withStyles } from '../helpers/styled'
 
 // TODO For the tickmarks (future ticket), I'd suggest the following API:
 // <Range>
@@ -120,7 +112,6 @@ const BaseRange = React.forwardRef<HTMLInputElement, InputProps>(
     )
   }
 )
-BaseRange.displayName = 'Range'
 
 // All browsers have a "null zone" on each end, half the size of the value indicator,
 // so that when the indicator is at max/min the value is centered without overflowing.
@@ -178,9 +169,12 @@ const applyStatusStyles = (styles: CSSObject | undefined) => {
   }
 }
 
-export const Range = styledUnpoly(BaseRange).withConfig(
-  omitProps<RangeProps>(margin, sizing, flexItem)
-)`
+export const Range = withStyles('span', {
+  displayName: 'Range',
+  as: BaseRange,
+  transitiveProps: ['status'],
+  styles: [margin, sizing, flexItem],
+})<MarginProps & SizingProps & FlexItemProps>`
   display: inline-flex;
   flex-direction: column;
   position: relative;
@@ -194,10 +188,6 @@ export const Range = styledUnpoly(BaseRange).withConfig(
   .range-slider {
     ${(p) => applyStatusStyles(getStatusStyles(p))}
   }
-
-  &&& {
-    ${compose(margin, sizing, flexItem)}
-  }
 `
 
 Range.propTypes = {
@@ -208,7 +198,10 @@ Range.propTypes = {
   status: StatusPropType,
 }
 
-const RangeInput = styledWithClass('input', 'range-input').attrs({ type: 'range' })`
+const RangeInput = withStyles('input', {
+  className: 'range-input',
+  extraAttrs: { type: 'range' },
+})`
   ${() => NULL_ZONE_STYLES}
   height: 100%;
   margin: 0;
@@ -237,7 +230,7 @@ const RangeInput = styledWithClass('input', 'range-input').attrs({ type: 'range'
   }
 `
 
-const RangeSlider = styledWithClass('span', 'range-slider')`
+const RangeSlider = withStyles('span', { className: 'range-slider' })`
   flex: 1 0 ${VALUE_SIZE}px;
   display: flex;
   position: relative;

--- a/modules/cactus-web/src/StepAvatar/StepAvatar.test.tsx
+++ b/modules/cactus-web/src/StepAvatar/StepAvatar.test.tsx
@@ -4,10 +4,10 @@ import renderWithTheme from '../../tests/helpers/renderWithTheme'
 import StepAvatar from './StepAvatar'
 
 describe('component: StepAvatar', () => {
-  test('exists', () => {
+  test('should support margin props', () => {
     const { getByTestId } = renderWithTheme(
-      <StepAvatar status="inProcess" data-testid="stepAvatar" />
+      <StepAvatar status="inProcess" m={4} data-testid="stepAvatar" />
     )
-    expect(getByTestId('stepAvatar')).toBeInTheDocument()
+    expect(getByTestId('stepAvatar')).toHaveStyle({ margin: '16px' })
   })
 })

--- a/modules/cactus-web/src/StepAvatar/StepAvatar.tsx
+++ b/modules/cactus-web/src/StepAvatar/StepAvatar.tsx
@@ -1,9 +1,8 @@
-import { ColorStyle } from '@repay/cactus-theme'
-import styled, { css, DefaultTheme, FlattenInterpolation, ThemeProps } from 'styled-components'
+import { colorStyle, fontSize, shadow } from '@repay/cactus-theme'
+import { css, DefaultTheme, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { getOmittableProps } from '../helpers/omit'
-import { boxShadow, fontSize } from '../helpers/theme'
+import { withStyles } from '../helpers/styled'
 
 export type AvatarStep = 'notDone' | 'inProcess' | 'done'
 
@@ -15,14 +14,14 @@ type StepColor = { [K in AvatarStep]: FlattenInterpolation<ThemeProps<DefaultThe
 
 const stepColorMap: StepColor = {
   notDone: css`
-    ${(p): ColorStyle => p.theme.colorStyles.lightContrast};
+    ${colorStyle('lightContrast')};
   `,
   inProcess: css`
-    ${(p): ColorStyle => p.theme.colorStyles.callToAction};
-    ${(p): string => boxShadow(p.theme, 1)};
+    ${colorStyle('callToAction')};
+    ${shadow(1)};
   `,
   done: css`
-    ${(p): ColorStyle => p.theme.colorStyles.base};
+    ${colorStyle('base')};
   `,
 }
 
@@ -34,23 +33,23 @@ const variant = (
   return stepColorMap[stepType]
 }
 
-const styleProps = getOmittableProps(margin, 'status')
-export const StepAvatar = styled.div.withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const StepAvatar = withStyles('div', {
+  displayName: 'StepAvatar',
+  transitiveProps: ['status'],
+  styles: [margin],
 })<StepAvatarProps>`
   box-sizing: border-box;
   border-radius: 50%;
   width: 48px;
   height: 48px;
   line-height: 49px;
-  ${(p): string => fontSize(p.theme, 'h2')}
+  ${fontSize('h2')}
   font-weight: 400;
   text-align: center;
   appearance: none;
   padding: 0px;
   border: none;
 
-  ${margin}
   ${variant}
 `
 StepAvatar.defaultProps = {

--- a/modules/cactus-web/src/Text/Text.test.tsx
+++ b/modules/cactus-web/src/Text/Text.test.tsx
@@ -18,6 +18,15 @@ describe('component: Text', () => {
       </Text>
     )
 
-    expect(container.firstChild).not.toBeNull()
+    expect(container.firstChild).toHaveStyle({
+      fontWeight: '600',
+      fontStyle: 'italic',
+      textAlign: 'right',
+      fontSize: '15px',
+      lineHeight: '1.6',
+      color: 'rgb(255, 255, 255)',
+      // JSDOM converts the background color incorrectly, should be (1, 37, 55).
+      backgroundColor: 'rgb(1, 1, 1)',
+    })
   })
 })

--- a/modules/cactus-web/src/Text/Text.tsx
+++ b/modules/cactus-web/src/Text/Text.tsx
@@ -1,9 +1,14 @@
 import { textStyle, TextStyleCollection } from '@repay/cactus-theme'
-import styled from 'styled-components'
-import { colorStyle, ColorStyleProps, compose, space, SpaceProps } from 'styled-system'
+import { colorStyle, ColorStyleProps, space, SpaceProps } from 'styled-system'
 
-import { getOmittableProps } from '../helpers/omit'
-import { allText, AllTextProps, flexItem, FlexItemProps, omitStyles } from '../helpers/styled'
+import {
+  allText,
+  AllTextProps,
+  flexItem,
+  FlexItemProps,
+  omitStyles,
+  withStyles,
+} from '../helpers/styled'
 
 // These are covered by `textStyle` instead.
 type FontProps = Omit<AllTextProps, 'fontSize' | 'lineHeight'>
@@ -13,15 +18,15 @@ export interface TextProps extends SpaceProps, ColorStyleProps, FontProps, FlexI
   textStyle?: keyof TextStyleCollection
 }
 
-const styleProps = getOmittableProps(space, colorStyle, font, flexItem, 'textStyle')
-export const Text = styled('span').withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const Text = withStyles('span', {
+  displayName: 'Text',
+  transitiveProps: ['textStyle'],
+  styles: [space, colorStyle, font, flexItem],
 })<TextProps>`
   &:not(p) {
     margin: 0;
   }
   &&& {
-    ${compose(space, colorStyle, font, flexItem)}
     ${(p) => p.textStyle && textStyle(p, p.textStyle)}
   }
 `

--- a/modules/cactus-web/src/TextButton/TextButton.tsx
+++ b/modules/cactus-web/src/TextButton/TextButton.tsx
@@ -1,14 +1,13 @@
-import { CactusTheme } from '@repay/cactus-theme'
+import { border, CactusTheme, radius, textStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
-import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components'
+import { css, FlattenInterpolation, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { getOmittableProps } from '../helpers/omit'
-import { border, radius, textStyle } from '../helpers/theme'
+import { withStyles } from '../helpers/styled'
 
 export type TextButtonVariants = 'standard' | 'action' | 'danger' | 'dark'
 
-interface TextButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, MarginProps {
+interface TextButtonProps extends MarginProps {
   variant?: TextButtonVariants
   /** !important */
   disabled?: boolean
@@ -75,16 +74,17 @@ export const focusStyle = css`
     width: 100%;
     top: 0px;
     left: 0px;
-    border: ${(p) => border(p.theme, 'callToAction')};
+    border: ${border('callToAction')};
     border-radius: ${radius(20)};
   }
 `
 
-const styleProps = getOmittableProps(margin, 'variant', 'inverse')
-export const TextButton = styled.button.withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const TextButton = withStyles('button', {
+  displayName: 'TextButton',
+  transitiveProps: ['variant', 'inverse'],
+  styles: [margin],
 })<TextButtonProps>`
-  ${(p) => textStyle(p.theme, 'body')};
+  ${textStyle('body')};
   position: relative;
   border: none;
   padding: 4px;
@@ -95,7 +95,7 @@ export const TextButton = styled.button.withConfig({
   box-sizing: border-box;
 
   &:hover {
-    text-decoration: ${(p): string => (!p.disabled ? 'underline' : '')};
+    ${(p): string => (!p.disabled ? 'text-decoration: underline;' : '')}
   }
 
   &:focus {
@@ -113,7 +113,6 @@ export const TextButton = styled.button.withConfig({
   }
 
   ${variantOrDisabled}
-  ${margin}
 `
 
 TextButton.propTypes = {

--- a/modules/cactus-web/tests/inlineStyles.test.tsx
+++ b/modules/cactus-web/tests/inlineStyles.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import { margin, MarginProps, shadow, ShadowProps } from 'styled-system'
+
+import { Flex } from '../src'
+import { withStyles } from '../src/helpers/styled'
+import { ScreenSizeContext, SIZES } from '../src/ScreenSizeProvider/ScreenSizeProvider'
+import renderWithTheme from './helpers/renderWithTheme'
+
+type Styles = MarginProps & ShadowProps
+
+const PropRenderer = ({ className, 'data-testId': id, ...props }: any) => {
+  return (
+    <div className={className} data-testid={id}>
+      {JSON.stringify(props)}
+    </div>
+  )
+}
+
+// These tests are both to ensure correct functionality, as well as to fail if
+// the 3rd party libs change some of the internals the inline parser relies on.
+describe('styled-components + inline responsive styles', () => {
+  test('should combine styles from multiple sources (Box, Flex, `style` prop)', () => {
+    const { getByTestId } = renderWithTheme(
+      <Flex
+        data-testid="src"
+        m={3}
+        flexDirection="column"
+        style={{ padding: '10px', flexDirection: 'row' }}
+      />
+    )
+    expect(getByTestId('src')).toHaveStyle({
+      flexDirection: 'column',
+      margin: '8px',
+      padding: '10px',
+    })
+  })
+
+  test('should correctly parse responsive styles', () => {
+    const margins = { mt: [3], ml: [1, 2], mb: [4, 5, 6], mr: ['1em', null, '3vw', '4%'] }
+    const { getByTestId, rerender } = renderWithTheme(
+      <ScreenSizeContext.Provider value={SIZES.tiny}>
+        <Flex data-testid="responsive" {...margins} />
+      </ScreenSizeContext.Provider>
+    )
+    const flex = getByTestId('responsive')
+    expect(flex).toHaveStyle({
+      marginTop: '8px',
+      marginLeft: '2px',
+      marginBottom: '16px',
+      marginRight: '1em',
+    })
+
+    rerender(
+      <ScreenSizeContext.Provider value={SIZES.small}>
+        <Flex data-testid="responsive" {...margins} />
+      </ScreenSizeContext.Provider>
+    )
+    expect(flex).toHaveStyle({
+      marginTop: '8px',
+      marginLeft: '4px',
+      marginBottom: '24px',
+      marginRight: '1em',
+    })
+
+    rerender(
+      <ScreenSizeContext.Provider value={SIZES.medium}>
+        <Flex data-testid="responsive" {...margins} />
+      </ScreenSizeContext.Provider>
+    )
+    expect(flex).toHaveStyle({
+      marginTop: '8px',
+      marginLeft: '4px',
+      marginBottom: '32px',
+      marginRight: '3vw',
+    })
+
+    rerender(
+      <ScreenSizeContext.Provider value={SIZES.large}>
+        <Flex data-testid="responsive" {...margins} />
+      </ScreenSizeContext.Provider>
+    )
+    expect(flex).toHaveStyle({
+      marginTop: '8px',
+      marginLeft: '4px',
+      marginBottom: '32px',
+      marginRight: '4%',
+    })
+  })
+
+  test('should not be polymorphic when `as` is specified', () => {
+    const UnPoly = withStyles('span', { as: PropRenderer, styles: [margin, shadow] })<Styles>``
+    // UnPoly isn't polymorphic so it doesn't process the flex styles...
+    const { container, rerender } = renderWithTheme(
+      <UnPoly as={Flex} flexWrap="nowrap" textShadow="small" />
+    )
+    expect(JSON.parse(container.textContent as string)).toEqual({
+      flexWrap: 'nowrap',
+      style: { textShadow: 'small' },
+    })
+    // ...but Flex IS polymorphic, so it DOES render the JSON.
+    rerender(<Flex as={UnPoly} flexWrap="nowrap" textShadow="small" />)
+    expect(JSON.parse(container.textContent as string)).toEqual({
+      style: { flexWrap: 'nowrap', textShadow: 'small' },
+    })
+  })
+
+  test('should correctly drop `transitiveProps`', () => {
+    const opts = { transitiveProps: ['dropMe'], styles: [margin, shadow] }
+    const Dropper = withStyles(PropRenderer, opts)<Styles>``
+    const { container } = renderWithTheme(<Dropper dropMe="now" keepMe="always" />)
+    expect(JSON.parse(container.textContent as string)).toEqual({ keepMe: 'always' })
+  })
+
+  test('should correctly keep `preserveProps`', () => {
+    const opts = { preserveProps: ['margin'], styles: [margin, shadow] }
+    const Keeper = withStyles(PropRenderer, opts)<Styles>``
+    const { container } = renderWithTheme(<Keeper margin={[3, 4]} mt={1} />)
+    expect(JSON.parse(container.textContent as string)).toEqual({
+      margin: [3, 4],
+      style: { margin: 16, marginTop: 2 },
+    })
+  })
+
+  test('should have displayName when specified', () => {
+    const Display1 = withStyles('div', { displayName: 'Argh' })``
+    const Display2 = withStyles(Display1, {})``
+    const Display3 = withStyles(PropRenderer, {})``
+    expect(Display1.displayName).toBe('Argh')
+    expect(Display2.displayName).toBe('Argh')
+    // There's an auto-generated name, don't care what it is as long as it exists.
+    expect(Display3.displayName).toBeTruthy()
+  })
+
+  test('should have custom class when specified', () => {
+    const Custom = withStyles('div', { componentId: 'test-class' })``
+    const { getByTestId } = renderWithTheme(<Custom data-testid="class" className="custom" />)
+    expect(getByTestId('class')).toHaveClass('custom')
+    expect(getByTestId('class')).toHaveClass('test-class')
+  })
+})


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-1069

This took way longer than I thought it would, so we'll definitely need at least one more ticket to finish. Part of that was because I can't leave well enough alone, so I was also converting some of the static styles to use theme helpers. Part of it was because I started out swapping certain components (e.g. Pagination) from "inner styled components" to being styled components themselves (slightly more efficient, easier to make style overrides), before realizing that I was just muddying the waters and making things harder for reviewers. (I didn't go back and undo the ones I already did, though.) I kind of have a secondary goal with these changes to get rid of `styledWithClass` & `styledUnpoly` (since `withStyles` can do the same things), and also to get rid of `helpers/theme`.

The third breaking change (listed in the ticket) does give me some pause, though. I was not expecting there to be such a limitation with the `style` prop, and it's giving me some second thoughts. If any of you think it's a deal breaker, we should discuss it before making the second ticket.

Finally, I recommend going through one commit at a time; several of the commits have extra notes in the commit messages.