### PR TITLE
CACTUS-1088: correct drop-down positioning

### DIFF
--- a/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.story.tsx
@@ -302,7 +302,7 @@ const DataGridContainer: Story<typeof DataGrid, Args> = ({
               mainActionLabel="Edit"
             >
               <SplitButton.Action onSelect={() => clone(rowIndex + itemOffset)}>
-                Clone
+                Clone this row
               </SplitButton.Action>
               <SplitButton.Action onSelect={() => deleteRow(rowIndex + itemOffset)}>
                 Delete


### PR DESCRIPTION
UAT: https://repayonline.atlassian.net/browse/CACTUS-1088

The scroll container changes I made last time broke positioning. I switched from setting top/left OR bottom/right to only ever setting top & left, which gives more consistent behavior.

Also slightly changed the DataGrid story to make it easier to verify that the bug is actually fixed.