### PR TITLE
fix(cactus-web): datagrid dropdown issues

### DIFF
--- a/modules/cactus-web/src/DataGrid/DataGrid.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.tsx
@@ -117,9 +117,10 @@ export const DataGrid = (props: DataGridProps): ReactElement => {
 }
 
 const StyledDataGrid = styled.div<DataGridProps & TransientProps>`
-  display: inline;
+  display: inline-block;
   flex-direction: column;
   width: ${(p): string => (p.fullWidth ? '100%' : 'auto')};
+  overflow-x: auto;
   ${margin}
 
   ${getMediaQuery} {

--- a/modules/cactus-web/src/DataGrid/DataGrid.tsx
+++ b/modules/cactus-web/src/DataGrid/DataGrid.tsx
@@ -120,7 +120,6 @@ const StyledDataGrid = styled.div<DataGridProps & TransientProps>`
   display: inline;
   flex-direction: column;
   width: ${(p): string => (p.fullWidth ? '100%' : 'auto')};
-  overflow-x: auto;
   ${margin}
 
   ${getMediaQuery} {


### PR DESCRIPTION
Ticket: [CACTUS-1099](https://repayonline.atlassian.net/browse/CACTUS-1099)


The issue:

`MenuButton` uses `usePositioning` and passes `positionDropDown` to it which in turn tries to get the scrollParent using a `getScrollParent` function. In the MenuButton, this works as expected, but in DataGrid, it was returning the outermost DataGrid element (StyledDataGrid) because of `overflow-x: auto;`.  Since StyledDataGrid was set to `display: inline;` the clientWidth was 0 (https://www.w3.org/TR/cssom-view/#dom-element-clientwidth). This was causing the min-width to be set to 0.   
```
  const visibleWidth = Math.min(scrollParent.clientWidth, view.clientWidth)
  const minWidth = Math.min(visibleWidth, button.offsetWidth)
```

I'm a little worried that other things might be set to `display: inline` and also have an overflow style, so maybe we should rethink how the scroll works. But I'm unprepared to undo any of Glen's changes before I understand what he was trying to fix better.