### PR TITLE
CACTUS-1091 :: Snyk/SonarQube Fixes

### DIFF
--- a/modules/cactus-fwk/src/ErrorBoundary.tsx
+++ b/modules/cactus-fwk/src/ErrorBoundary.tsx
@@ -65,13 +65,11 @@ const withErrorBoundary = <BaseProps extends Record<string, any>>(
     throw new Error('You must pass the `onError` prop when using `withErrorBoundary`!')
   }
 
-  const Wrapped = (props: BaseProps): ReactElement => (
+  return (props: BaseProps): ReactElement => (
     <ErrorBoundary onError={onError} errorView={errorView}>
       <BaseComponent {...props} />
     </ErrorBoundary>
   )
-
-  return Wrapped
 }
 
 export default withErrorBoundary

--- a/modules/cactus-i18n/tests/helpers/MockPromise.ts
+++ b/modules/cactus-i18n/tests/helpers/MockPromise.ts
@@ -37,12 +37,14 @@ class MockPromise {
 
   public then(callback: (params: any) => any): MockPromise {
     this._then = callback
-    return (this._chain = new MockPromise())
+    this._chain = new MockPromise()
+    return this._chain
   }
 
   public catch(callback: (params: any) => any): MockPromise {
     this._catch = callback
-    return (this._chain = new MockPromise())
+    this._chain = new MockPromise()
+    return this._chain
   }
 
   public static resolve(value: unknown): MockPromise {

--- a/modules/cactus-web/src/Accordion/Accordion.test.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.test.tsx
@@ -437,7 +437,7 @@ describe('component: Accordion', () => {
 
       const a1 = getAccordionButton('Accordion 1')
       fireEvent.focus(a1)
-      fireEvent.keyUp(a1, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(a1, { key: KeyCodes.DOWN })
       expect(document.activeElement).toBe(getAccordionButton('Accordion 2'))
     })
 
@@ -446,7 +446,7 @@ describe('component: Accordion', () => {
 
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a2)
-      fireEvent.keyUp(a2, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyUp(a2, { key: KeyCodes.UP })
       expect(document.activeElement).toBe(getAccordionButton('Accordion 1'))
     })
 
@@ -456,9 +456,9 @@ describe('component: Accordion', () => {
       const a1 = getAccordionButton('Accordion 1')
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a1)
-      fireEvent.keyUp(a1, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyUp(a1, { key: KeyCodes.UP })
       expect(document.activeElement).toBe(a2)
-      fireEvent.keyUp(a2, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(a2, { key: KeyCodes.DOWN })
       expect(document.activeElement).toBe(a1)
     })
 
@@ -467,9 +467,9 @@ describe('component: Accordion', () => {
 
       const a = getAccordionButton('Accordion 1')
       fireEvent.focus(a)
-      fireEvent.keyUp(a, { keyCode: KeyCodes.SPACE, charCode: KeyCodes.SPACE })
+      fireEvent.keyUp(a, { key: KeyCodes.SPACE })
       expect(a.getAttribute('aria-expanded')).toBe('true')
-      fireEvent.keyUp(a, { keyCode: KeyCodes.SPACE, charCode: KeyCodes.SPACE })
+      fireEvent.keyUp(a, { key: KeyCodes.SPACE })
       expect(a.getAttribute('aria-expanded')).toBe('false')
     })
 
@@ -478,9 +478,9 @@ describe('component: Accordion', () => {
 
       const a = getAccordionButton('Accordion 1')
       fireEvent.focus(a)
-      fireEvent.keyUp(a, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
+      fireEvent.keyUp(a, { key: KeyCodes.RETURN })
       expect(a.getAttribute('aria-expanded')).toBe('true')
-      fireEvent.keyUp(a, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
+      fireEvent.keyUp(a, { key: KeyCodes.RETURN })
       expect(a.getAttribute('aria-expanded')).toBe('false')
     })
 
@@ -490,7 +490,7 @@ describe('component: Accordion', () => {
       const a1 = getAccordionButton('Accordion 1')
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a2)
-      fireEvent.keyUp(a2, { keyCode: KeyCodes.HOME, charCode: KeyCodes.HOME })
+      fireEvent.keyUp(a2, { key: KeyCodes.HOME })
       expect(document.activeElement).toBe(a1)
     })
 
@@ -500,7 +500,7 @@ describe('component: Accordion', () => {
       const a1 = getAccordionButton('Accordion 1')
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a1)
-      fireEvent.keyUp(a1, { keyCode: KeyCodes.END, charCode: KeyCodes.END })
+      fireEvent.keyUp(a1, { key: KeyCodes.END })
       expect(document.activeElement).toBe(a2)
     })
   })
@@ -511,7 +511,7 @@ describe('component: Accordion', () => {
 
       const a1 = getAccordionButton('Accordion 1')
       fireEvent.focus(a1)
-      fireEvent.keyUp(a1, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(a1, { key: KeyCodes.DOWN })
       expect(document.activeElement).toBe(getAccordionButton('Accordion 2'))
     })
 
@@ -520,7 +520,7 @@ describe('component: Accordion', () => {
 
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a2)
-      fireEvent.keyUp(a2, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyUp(a2, { key: KeyCodes.UP })
       expect(document.activeElement).toBe(getAccordionButton('Accordion 1'))
     })
 
@@ -530,9 +530,9 @@ describe('component: Accordion', () => {
       const a1 = getAccordionButton('Accordion 1')
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a1)
-      fireEvent.keyUp(a1, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyUp(a1, { key: KeyCodes.UP })
       expect(document.activeElement).toBe(a2)
-      fireEvent.keyUp(a2, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(a2, { key: KeyCodes.DOWN })
       expect(document.activeElement).toBe(a1)
     })
 
@@ -541,9 +541,9 @@ describe('component: Accordion', () => {
 
       const a = getAccordionButton('Accordion 1')
       fireEvent.focus(a)
-      fireEvent.keyUp(a, { keyCode: KeyCodes.SPACE, charCode: KeyCodes.SPACE })
+      fireEvent.keyUp(a, { key: KeyCodes.SPACE })
       expect(a.getAttribute('aria-expanded')).toBe('true')
-      fireEvent.keyUp(a, { keyCode: KeyCodes.SPACE, charCode: KeyCodes.SPACE })
+      fireEvent.keyUp(a, { key: KeyCodes.SPACE })
       expect(a.getAttribute('aria-expanded')).toBe('false')
     })
 
@@ -552,9 +552,9 @@ describe('component: Accordion', () => {
 
       const a = getAccordionButton('Accordion 1')
       fireEvent.focus(a)
-      fireEvent.keyUp(a, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
+      fireEvent.keyUp(a, { key: KeyCodes.RETURN })
       expect(a.getAttribute('aria-expanded')).toBe('true')
-      fireEvent.keyUp(a, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
+      fireEvent.keyUp(a, { key: KeyCodes.RETURN })
       expect(a.getAttribute('aria-expanded')).toBe('false')
     })
 
@@ -564,7 +564,7 @@ describe('component: Accordion', () => {
       const a1 = getAccordionButton('Accordion 1')
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a2)
-      fireEvent.keyUp(a2, { keyCode: KeyCodes.HOME, charCode: KeyCodes.HOME })
+      fireEvent.keyUp(a2, { key: KeyCodes.HOME })
       expect(document.activeElement).toBe(a1)
     })
 
@@ -574,7 +574,7 @@ describe('component: Accordion', () => {
       const a1 = getAccordionButton('Accordion 1')
       const a2 = getAccordionButton('Accordion 2')
       fireEvent.focus(a1)
-      fireEvent.keyUp(a1, { keyCode: KeyCodes.END, charCode: KeyCodes.END })
+      fireEvent.keyUp(a1, { key: KeyCodes.END })
       expect(document.activeElement).toBe(a2)
     })
   })

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -43,7 +43,7 @@ interface AccordionHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
 
 interface AccordionBodyProps extends MarginProps, React.HTMLAttributes<HTMLDivElement> {}
 
-interface AccordionContext {
+interface AccordionContextType {
   isOpen: boolean
   variant?: string
   bodyId?: string
@@ -86,7 +86,7 @@ interface AccordionProviderContext {
   unregisterAccordion?: (id: string) => void
 }
 
-const AccordionContext = createContext<AccordionContext>({
+const AccordionContext = createContext<AccordionContextType>({
   isOpen: false,
   variant: undefined,
   bodyId: undefined,
@@ -115,15 +115,24 @@ const AccordionHeaderBase = (props: AccordionHeaderProps): ReactElement => {
 
   // Used to prevent default behavior/propagation
   const handleHeaderKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
-    const key = event.which || event.keyCode
-    if ([KeyCodes.UP, KeyCodes.DOWN, KeyCodes.HOME, KeyCodes.END, KeyCodes.RETURN].includes(key)) {
+    const key = event.key
+    if (
+      [
+        KeyCodes.UP,
+        KeyCodes.DOWN,
+        KeyCodes.HOME,
+        KeyCodes.END,
+        KeyCodes.RETURN,
+        KeyCodes.SPACE,
+      ].includes(key)
+    ) {
       event.preventDefault()
       event.stopPropagation()
     }
   }
 
   const handleHeaderKeyUp = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
-    const key = event.which || event.keyCode
+    const key = event.key
     switch (key) {
       case KeyCodes.SPACE:
       case KeyCodes.RETURN: {

--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -465,20 +465,22 @@ const DropdownPopup = styled(BasePopup)`
   ${(p) => p.$isTiny && 'width: 100%;'}
 `
 
-const StyledBrandBar = styled.div<{ $isTiny: boolean }>`
+const getLayout = (props: { $isTiny: boolean }) =>
+  props.$isTiny
+    ? `
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+`
+    : `
+flex-direction: row;
+justify-content: space-between;
+align-items: stretch;
+`
+
+const StyledBrandBar = styled.div`
   display: flex;
-  ${(p) =>
-    p.$isTiny
-      ? `
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-  `
-      : `
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: stretch;
-  `}
+  ${getLayout}
   width: 100%;
   ${(p): string => insetBorder(p.theme, 'lightContrast', 'bottom')};
 `

--- a/modules/cactus-web/src/BrandBar/BrandBar.tsx
+++ b/modules/cactus-web/src/BrandBar/BrandBar.tsx
@@ -1,4 +1,5 @@
 import { DescriptiveProfile, NavigationChevronDown } from '@repay/cactus-icons'
+import { mediaGTE } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
@@ -122,7 +123,7 @@ export const BrandBar: BrandBarType = ({ logo, children, className, ...props }) 
 
   const layoutClass = useLayout('brandbar', { grid: 'header' })
   return (
-    <StyledBrandBar {...props} className={classes(className, layoutClass)} $isTiny={isTiny}>
+    <StyledBrandBar {...props} className={classes(className, layoutClass)}>
       <Flex justifyContent={justify} flexWrap="nowrap">
         {logo && (
           <LogoWrapper>
@@ -465,22 +466,16 @@ const DropdownPopup = styled(BasePopup)`
   ${(p) => p.$isTiny && 'width: 100%;'}
 `
 
-const getLayout = (props: { $isTiny: boolean }) =>
-  props.$isTiny
-    ? `
+const StyledBrandBar = styled.div`
+  display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-`
-    : `
-flex-direction: row;
-justify-content: space-between;
-align-items: stretch;
-`
-
-const StyledBrandBar = styled.div`
-  display: flex;
-  ${getLayout}
+  ${mediaGTE('small')} {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: stretch;
+  }
   width: 100%;
   ${(p): string => insetBorder(p.theme, 'lightContrast', 'bottom')};
 `

--- a/modules/cactus-web/src/Calendar/Calendar.tsx
+++ b/modules/cactus-web/src/Calendar/Calendar.tsx
@@ -75,7 +75,8 @@ const memoize = <A extends any[], R>(func: (...a: A) => R): ((...a: A) => R) => 
       return result
     }
     key = args
-    return (result = func(...args))
+    result = func(...args)
+    return result
   }
 }
 

--- a/modules/cactus-web/src/Checkable/Group.tsx
+++ b/modules/cactus-web/src/Checkable/Group.tsx
@@ -1,7 +1,7 @@
-import { CactusTheme, space } from '@repay/cactus-theme'
+import { space } from '@repay/cactus-theme'
 import { noop, pick } from 'lodash'
 import React from 'react'
-import styled, { ThemedStyledProps } from 'styled-components'
+import styled from 'styled-components'
 
 import AccessibleField, { ExtFieldProps } from '../AccessibleField/AccessibleField'
 import Box from '../Box/Box'

--- a/modules/cactus-web/src/Checkable/Group.tsx
+++ b/modules/cactus-web/src/Checkable/Group.tsx
@@ -117,13 +117,10 @@ export const Fieldset = styled(CheckableGroup)`
   }
 `
 
-const getSpacing = (props: ThemedStyledProps<CheckableGroupProps, CactusTheme>) =>
-  !isIE ? `gap: ${space(props, 3)};` : `> * { margin: ${space(props, 2)}; }`
-
 export const FlexGroup = styled(CheckableGroup)`
   .field-input-group {
     display: flex;
     flex-wrap: wrap;
-    ${getSpacing}
+    ${(p) => (!isIE ? `gap: ${space(p, 3)};` : `> * { margin: ${space(p, 2)}; }`)}
   }
 `

--- a/modules/cactus-web/src/Checkable/Group.tsx
+++ b/modules/cactus-web/src/Checkable/Group.tsx
@@ -1,6 +1,7 @@
+import { CactusTheme, space } from '@repay/cactus-theme'
 import { noop, pick } from 'lodash'
 import React from 'react'
-import styled from 'styled-components'
+import styled, { ThemedStyledProps } from 'styled-components'
 
 import AccessibleField, { ExtFieldProps } from '../AccessibleField/AccessibleField'
 import Box from '../Box/Box'
@@ -111,15 +112,18 @@ export const Fieldset = styled(CheckableGroup)`
     border-bottom: ${(p) => border(p.theme, p.disabled ? 'mediumGray' : 'currentcolor')};
   }
   .field-input-group {
-    margin: 0 ${(p) => p.theme.space[4]}px;
-    padding-top: ${(p) => p.theme.space[3]}px;
+    margin: 0 ${space(4)};
+    padding-top: ${space(3)};
   }
 `
+
+const getSpacing = (props: ThemedStyledProps<CheckableGroupProps, CactusTheme>) =>
+  !isIE ? `gap: ${space(props, 3)};` : `> * { margin: ${space(props, 2)}; }`
 
 export const FlexGroup = styled(CheckableGroup)`
   .field-input-group {
     display: flex;
     flex-wrap: wrap;
-    ${(p) => (!isIE ? `gap: ${p.theme.space[3]}px;` : `> * { margin: ${p.theme.space[2]}px; }`)}
+    ${getSpacing}
   }
 `

--- a/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
+++ b/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
@@ -214,7 +214,20 @@ const HueWrapper = styled.div`
   margin-top: 32px;
 `
 
-const Pointer = styled.div<{ $type: 'hue' | 'saturation'; $hsl: HSLColor }>`
+const translate = (props: { $type: 'hue' | 'saturation'; $hsl: HSLColor }) => {
+  const { $type: type, $hsl: hsl } = props
+  // Adjust pointer translation based on where the pointer is at so it
+  // doesn't leave the hue/saturation element visually
+  if (type === 'hue') {
+    const xOffset = hsl.h > 160 ? '-24px' : '-8px'
+    return `transform: translate(${xOffset}, -8px);`
+  } else {
+    const xOffset = hsl.s > 0.3 ? '-24px' : '-8px'
+    const yOffset = hsl.l > 0.25 ? '-8px' : '-24px'
+    return `transform: translate(${xOffset}, ${yOffset});`
+  }
+}
+const Pointer = styled.div`
   box-sizing: border-box;
   width: 32px;
   height: 32px;
@@ -222,18 +235,7 @@ const Pointer = styled.div<{ $type: 'hue' | 'saturation'; $hsl: HSLColor }>`
   background-color: transparent;
   border: 8px solid ${themeColor('white')};
   ${boxShadow(0, 'mediumGray')};
-  ${(p) => {
-    // Adjust pointer translation based on where the pointer is at so it
-    // doesn't leave the hue/saturation element visually
-    if (p.$type === 'hue') {
-      const xOffset = p.$hsl.h > 160 ? '-24px' : '-8px'
-      return `transform: translate(${xOffset}, -8px);`
-    } else {
-      const xOffset = p.$hsl.s > 0.3 ? '-24px' : '-8px'
-      const yOffset = p.$hsl.l > 0.25 ? '-8px' : '-24px'
-      return `transform: translate(${xOffset}, ${yOffset});`
-    }
-  }}
+  ${translate}
 `
 
 const blackHsl: HSLColor = { h: 0, s: 0, l: 0 }

--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -249,7 +249,7 @@ describe('component: Select', () => {
         <Select id="test-id" name="city" options={['phoenix', 'tucson', 'flagstaff']} />
       )
       const trigger = getByText('Select an option') // default placeholder
-      fireEvent.keyUp(trigger, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyUp(trigger, { key: KeyCodes.UP })
       await animationRender()
       const list = getByRole('listbox')
       expect(document.activeElement).toBe(list)
@@ -261,7 +261,7 @@ describe('component: Select', () => {
         <Select id="test-id" name="city" options={['phoenix', 'tucson', 'flagstaff']} />
       )
       const trigger = getByText('Select an option') // default placeholder
-      fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
       await animationRender()
       const list = getByRole('listbox')
       expect(document.activeElement).toBe(list)
@@ -274,11 +274,10 @@ describe('component: Select', () => {
       )
       // @ts-ignore
       const trigger: HTMLElement = getByText('Select an option').parentElement // default placeholder
-      fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(getByRole('listbox'), { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(getByRole('listbox'), { key: KeyCodes.DOWN })
       fireEvent.keyDown(getByRole('listbox'), {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
       })
       await animationRender()
       expect(document.activeElement).toEqual(trigger)
@@ -290,10 +289,9 @@ describe('component: Select', () => {
       )
       // @ts-ignore
       const trigger: HTMLElement = getByText('Select an option').parentElement // default placeholder
-      fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
       fireEvent.keyDown(getByRole('listbox'), {
-        keyCode: KeyCodes.ESC,
-        charCode: KeyCodes.ESC,
+        key: KeyCodes.ESC,
       })
       await animationRender()
       expect(document.activeElement).toEqual(trigger)
@@ -304,10 +302,10 @@ describe('component: Select', () => {
         <Select id="test-id" name="city" options={['phoenix', 'tucson', 'flagstaff']} />
       )
       const trigger = getByText('Select an option') // default placeholder
-      fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
       await animationRender()
       const list = getByRole('listbox')
-      fireEvent.keyDown(list, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(list, { key: KeyCodes.DOWN })
       // @ts-ignore
       expect(getActiveValue()).toEqual('tucson')
     })
@@ -324,25 +322,23 @@ describe('component: Select', () => {
         />
       )
       const trigger = getByText('Select an option')
-      fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
       expect(box).toEqual({})
       const list = getByRole('listbox')
-      fireEvent.keyDown(list, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(list, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(list, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(list, { key: KeyCodes.DOWN })
       fireEvent.keyDown(list, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
       })
       await animationRender()
       expect(onChange).toHaveBeenCalledTimes(1)
       expect(box).toEqual({ name: 'city', value: 'flagstaff' })
 
       const newTrigger = getByRole('button', { name: 'flagstaff' })
-      fireEvent.keyUp(newTrigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(list, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyUp(newTrigger, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(list, { key: KeyCodes.UP })
       fireEvent.keyDown(list, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
       })
       await animationRender()
       expect(onChange).toHaveBeenCalledTimes(2)
@@ -361,24 +357,22 @@ describe('component: Select', () => {
         />
       )
       const trigger = getByText('Select an option')
-      fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
       expect(box).toEqual({})
       const list = getByRole('listbox')
-      fireEvent.keyDown(list, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(list, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(list, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(list, { key: KeyCodes.DOWN })
       fireEvent.keyDown(list, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
       })
       await animationRender()
       expect(onChange).toHaveBeenCalledTimes(1)
       expect(box).toEqual({ name: 'city', value: 'flagstaff' })
 
       const newTrigger = getByRole('button', { name: 'flagstaff' })
-      fireEvent.keyUp(newTrigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyUp(newTrigger, { key: KeyCodes.DOWN })
       fireEvent.keyDown(list, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
       })
       await animationRender()
       expect(onChange).toHaveBeenCalledTimes(1)
@@ -413,14 +407,14 @@ describe('component: Select', () => {
       const thirdActive = getByText('Third active')
 
       expect(listbox.getAttribute('aria-activedescendant')).toBe(firstActive.id)
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(listbox, { key: KeyCodes.DOWN })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(secondActive.id)
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(listbox, { key: KeyCodes.DOWN })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(thirdActive.id)
 
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyDown(listbox, { key: KeyCodes.UP })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(secondActive.id)
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyDown(listbox, { key: KeyCodes.UP })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(firstActive.id)
     })
 
@@ -434,10 +428,10 @@ describe('component: Select', () => {
       const firstOption = getByText('first')
       const lastOption = getByText('last')
 
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.END, charCode: KeyCodes.END })
+      fireEvent.keyDown(listbox, { key: KeyCodes.END })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(lastOption.id)
 
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.HOME, charCode: KeyCodes.HOME })
+      fireEvent.keyDown(listbox, { key: KeyCodes.HOME })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(firstOption.id)
     })
 
@@ -458,10 +452,10 @@ describe('component: Select', () => {
       const firstEnabled = getByText('first enabled')
       const lastEnabled = getByText('last enabled')
 
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.END, charCode: KeyCodes.END })
+      fireEvent.keyDown(listbox, { key: KeyCodes.END })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(lastEnabled.id)
 
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.HOME, charCode: KeyCodes.HOME })
+      fireEvent.keyDown(listbox, { key: KeyCodes.HOME })
       expect(listbox.getAttribute('aria-activedescendant')).toBe(firstEnabled.id)
     })
 
@@ -471,11 +465,10 @@ describe('component: Select', () => {
           <Select id="test-id" name="city" options={['phoenix', 'tucson', 'flagstaff']} />
         )
         const trigger = getByText('Select an option') // default placeholder
-        fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+        fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
         await animationRender()
         const list = getByRole('listbox')
-        // keycode 84 = t
-        fireEvent.keyDown(list, { keyCode: 84, charCode: 84 })
+        fireEvent.keyDown(list, { key: 't' })
         expect(getActiveValue()).toEqual('tucson')
       })
 
@@ -484,13 +477,11 @@ describe('component: Select', () => {
           <Select id="test-id" name="city" options={['phoenix', 'toledo', 'tucson', 'flagstaff']} />
         )
         const trigger = getByText('Select an option') // default placeholder
-        fireEvent.keyUp(trigger, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+        fireEvent.keyUp(trigger, { key: KeyCodes.DOWN })
         await animationRender()
         const list = getByRole('listbox')
-        // keycode 84 = t
-        fireEvent.keyDown(list, { keyCode: 84, charCode: 84 })
-        // keycode 85 = u
-        fireEvent.keyDown(list, { keyCode: 85, charCode: 85 })
+        fireEvent.keyDown(list, { key: 't' })
+        fireEvent.keyDown(list, { key: 'u' })
         expect(getActiveValue()).toEqual('tucson')
       })
     })
@@ -758,8 +749,7 @@ describe('component: Select', () => {
       expect(box.name).toEqual('city')
       onFocus.mockReset()
       fireEvent.keyDown(getByRole('listbox'), {
-        keyCode: KeyCodes.ESC,
-        charCode: KeyCodes.ESC,
+        key: KeyCodes.ESC,
       })
       expect(onFocus).not.toHaveBeenCalled()
     })
@@ -919,12 +909,10 @@ describe('component: Select', () => {
       const listbox = getByRole('listbox')
       expect(getActiveValue()).toBe('phoenix')
       fireEvent.keyDown(listbox, {
-        keyCode: KeyCodes.DOWN,
-        charCode: KeyCodes.DOWN,
+        key: KeyCodes.DOWN,
       })
       fireEvent.keyDown(listbox, {
-        keyCode: KeyCodes.SPACE,
-        charCode: KeyCodes.SPACE,
+        key: KeyCodes.SPACE,
       })
       expect(onChange).toHaveBeenCalledTimes(1)
       expect(box).toEqual({ name: 'city', value: ['tucson'] })
@@ -935,8 +923,7 @@ describe('component: Select', () => {
       await animationRender()
       expect(getActiveValue()).toBe('tucson')
       fireEvent.keyDown(listbox, {
-        keyCode: KeyCodes.SPACE,
-        charCode: KeyCodes.SPACE,
+        key: KeyCodes.SPACE,
       })
       await animationRender()
       expect(onChange).toHaveBeenCalledTimes(2)
@@ -959,10 +946,9 @@ describe('component: Select', () => {
       const trigger = getByRole('button')
       userEvent.click(trigger)
       const listbox = getByRole('listbox')
-      fireEvent.keyDown(listbox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(listbox, { key: KeyCodes.DOWN })
       fireEvent.keyDown(listbox, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
         metaKey: true,
       })
       await animationRender()
@@ -974,8 +960,7 @@ describe('component: Select', () => {
       await animationRender()
       expect(getActiveValue()).toBe('tucson')
       fireEvent.keyDown(listbox, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
         metaKey: true,
       })
       await animationRender()
@@ -1078,12 +1063,12 @@ describe('component: Select', () => {
       userEvent.click(trigger)
       await animationRender()
       const searchBox: HTMLElement = document.activeElement as HTMLElement
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
       expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-phoenix')
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
       expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-flagstaff')
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.UP })
       expect(searchBox.getAttribute('aria-activedescendant')).toBe('test-id-tucson')
     })
 
@@ -1110,14 +1095,14 @@ describe('component: Select', () => {
       const firstActive = getByText('No skip')
       const secondActive = getByText("Don't skip me")
 
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
       expect(searchBox.getAttribute('aria-activedescendant')).toBe(firstActive.id)
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
       expect(searchBox.getAttribute('aria-activedescendant')).toBe(secondActive.id)
 
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.UP })
       expect(searchBox.getAttribute('aria-activedescendant')).toBe(firstActive.id)
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.UP })
       expect(searchBox.getAttribute('aria-activedescendant')).toBe(firstActive.id)
     })
 
@@ -1129,8 +1114,8 @@ describe('component: Select', () => {
       userEvent.click(trigger)
       await animationRender()
       const searchBox: HTMLElement = document.activeElement as HTMLElement
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.RETURN })
       await animationRender()
       trigger = getByRole('button')
       expect(trigger).toHaveTextContent('phoenix')
@@ -1145,7 +1130,7 @@ describe('component: Select', () => {
       userEvent.click(trigger)
       await animationRender()
       const searchBox: HTMLElement = document.activeElement as HTMLElement
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.ESC, charCode: KeyCodes.ESC })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.ESC })
       await animationRender()
       trigger = getByRole('button')
       expect(document.activeElement).toBe(trigger)
@@ -1252,10 +1237,10 @@ describe('component: Select', () => {
       userEvent.click(trigger)
       await animationRender()
       const searchBox: HTMLElement = document.activeElement as HTMLElement
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.RETURN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.RETURN })
       const phoenix = getByText('phoenix')
       const tucson = getByText('tucson')
       expect(phoenix.getAttribute('aria-selected')).toBe('true')
@@ -1264,8 +1249,8 @@ describe('component: Select', () => {
       expect(box).toEqual({ name: 'city', value: ['phoenix', 'tucson'] })
       expect(getByRole('listbox')).not.toBeNull()
 
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.UP, charCode: KeyCodes.UP })
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.RETURN, charCode: KeyCodes.RETURN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.UP })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.RETURN })
       expect(phoenix.getAttribute('aria-selected')).toBe('false')
       expect(tucson.getAttribute('aria-selected')).toBe('true')
       expect(onChange).toHaveBeenCalledTimes(3)
@@ -1290,10 +1275,9 @@ describe('component: Select', () => {
       userEvent.click(trigger)
       await animationRender()
       let searchBox: HTMLElement = document.activeElement as HTMLElement
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
       fireEvent.keyDown(searchBox, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
         metaKey: true,
       })
       await animationRender()
@@ -1306,10 +1290,9 @@ describe('component: Select', () => {
       userEvent.click(trigger)
       await animationRender()
       searchBox = document.activeElement as HTMLElement
-      fireEvent.keyDown(searchBox, { keyCode: KeyCodes.DOWN, charCode: KeyCodes.DOWN })
+      fireEvent.keyDown(searchBox, { key: KeyCodes.DOWN })
       fireEvent.keyDown(searchBox, {
-        keyCode: KeyCodes.RETURN,
-        charCode: KeyCodes.RETURN,
+        key: KeyCodes.RETURN,
         metaKey: true,
       })
       await animationRender()

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -576,7 +576,7 @@ class List extends React.Component<ListProps, ListState> {
   }
 
   private handleKeyDown = (event: React.KeyboardEvent<HTMLUListElement>): void => {
-    const key = event.which || event.keyCode
+    const key = event.key
     const active = this.getActiveOpt()
     const options = this.state.options
     if (active === null || options.length === 0) {
@@ -668,8 +668,7 @@ class List extends React.Component<ListProps, ListState> {
     return this.state.options.find((o): boolean => o.id === activeDescendant) || null
   }
 
-  private findOptionToFocus(key: number): ExtendedOptionType | null {
-    const character = String.fromCharCode(key)
+  private findOptionToFocus(character: string): ExtendedOptionType | null {
     const options = this.state.options
     const selected = this.getActiveOpt()
     if (!this.pendingChars && selected !== null) {
@@ -1242,7 +1241,7 @@ class SelectBase extends React.Component<SelectPropsWithTheme, SelectState> {
   }
 
   private handleKeyUp = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
-    const key = event.which || event.keyCode
+    const key = event.key
 
     switch (key) {
       case KeyCodes.UP:
@@ -1349,7 +1348,7 @@ class SelectBase extends React.Component<SelectPropsWithTheme, SelectState> {
   }
 
   private handleComboInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
-    const key = event.which || event.keyCode
+    const key = event.key
     if (this.state.isOpen && this.listRef.current !== null) {
       const active = this.listRef.current.getActiveOpt()
       const options = this.listRef.current.state.options

--- a/modules/cactus-web/src/helpers/keyCodes.ts
+++ b/modules/cactus-web/src/helpers/keyCodes.ts
@@ -1,18 +1,16 @@
-const KeyCodes = {
-  BACKSPACE: 8,
-  TAB: 9,
-  RETURN: 13,
-  ESC: 27,
-  SPACE: 32,
-  PAGE_UP: 33,
-  PAGE_DOWN: 34,
-  END: 35,
-  HOME: 36,
-  LEFT: 37,
-  UP: 38,
-  RIGHT: 39,
-  DOWN: 40,
-  DELETE: 46,
+export default {
+  BACKSPACE: 'Backspace',
+  TAB: 'Tab',
+  RETURN: 'Enter',
+  ESC: 'Escape',
+  SPACE: ' ',
+  PAGE_UP: 'PageUp',
+  PAGE_DOWN: 'PageDown',
+  END: 'End',
+  HOME: 'Home',
+  LEFT: 'ArrowLeft',
+  UP: 'ArrowUp',
+  RIGHT: 'ArrowRight',
+  DOWN: 'ArrowDown',
+  DELETE: 'Delete',
 }
-
-export default KeyCodes

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-dom": "^17.0.0",
     "react-is": "^17.0.0",
     "deep-object-diff": "1.1.0",
-    "devcert": "1.2.0"
+    "devcert": "1.2.0",
+    "shell-quote": "^1.7.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1656,12 +1656,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.10.0, @babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.0, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.19.0
   resolution: "@babel/runtime@npm:7.19.0"
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: fa69c351bb05e1db3ceb9a02fdcf620c234180af68cdda02152d3561015f6d55277265d3109815992f96d910f3db709458cae4f8df1c3def66f32e0867d82294
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.3.1":
+  version: 7.20.6
+  resolution: "@babel/runtime@npm:7.20.6"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 42a8504db21031b1859fbc0f52d698a3d2f5ada9519eb76c6f96a7e657d8d555732a18fe71ef428a67cc9fc81ca0d3562fb7afdc70549c5fec343190cbaa9b03
   languageName: node
   linkType: hard
 
@@ -7454,9 +7463,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^14.0.10":
-  version: 14.18.28
-  resolution: "@types/node@npm:14.18.28"
-  checksum: 44225b3d8f13f4aba9a7bffec8dbc9be8fd396d26b8a1f58b1389da83fdc7485edb5642639e23b34f0efa349dafe4df618294122f0b39c8726df2b9e11413768
+  version: 14.18.34
+  resolution: "@types/node@npm:14.18.34"
+  checksum: 25ac3b456a0b7b82c76b37276ec86845849e8276fc81d1470a87227c105c619e299aa7165b6148aa11a4ea156b1452f6d3327935f3e7dc0067ff54dde0e3d4e0
   languageName: node
   linkType: hard
 
@@ -7562,12 +7571,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/reach__router@npm:^1.3.10, @types/reach__router@npm:^1.3.7":
+"@types/reach__router@npm:^1.3.10":
   version: 1.3.10
   resolution: "@types/reach__router@npm:1.3.10"
   dependencies:
     "@types/react": "*"
   checksum: fdcb761d3b8cd74530c00490a7b5b1868e82b742e05b03d8fc09d88cc135ec6377556bcc8b345bf0f3aa8c99259e6cecbccf912ef8c9da12611c274a5ffb3fa9
+  languageName: node
+  linkType: hard
+
+"@types/reach__router@npm:^1.3.7":
+  version: 1.3.11
+  resolution: "@types/reach__router@npm:1.3.11"
+  dependencies:
+    "@types/react": "*"
+  checksum: 6bcf40714e0dafff66cbf10a534320eae35dae8344f616d2ddf077937287a0df188dfbfb32fb8045cbc641139d1ab69ee5bb258a51642823cadefbcda020a044
   languageName: node
   linkType: hard
 
@@ -9504,7 +9522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:^8.1.0, babel-loader@npm:^8.2.2, babel-loader@npm:^8.2.3":
+"babel-loader@npm:^8.1.0, babel-loader@npm:^8.2.3":
   version: 8.2.5
   resolution: "babel-loader@npm:8.2.5"
   dependencies:
@@ -9516,6 +9534,21 @@ __metadata:
     "@babel/core": ^7.0.0
     webpack: ">=2"
   checksum: a6605557885eabbc3250412405f2c63ca87287a95a439c643fdb47d5ea3d5326f72e43ab97be070316998cb685d5dfbc70927ce1abe8be7a6a4f5919287773fb
+  languageName: node
+  linkType: hard
+
+"babel-loader@npm:^8.2.2":
+  version: 8.3.0
+  resolution: "babel-loader@npm:8.3.0"
+  dependencies:
+    find-cache-dir: ^3.3.1
+    loader-utils: ^2.0.0
+    make-dir: ^3.1.0
+    schema-utils: ^2.6.5
+  peerDependencies:
+    "@babel/core": ^7.0.0
+    webpack: ">=2"
+  checksum: d48bcf9e030e598656ad3ff5fb85967db2eaaf38af5b4a4b99d25618a2057f9f100e6b231af2a46c1913206db506115ca7a8cbdf52c9c73d767070dae4352ab5
   languageName: node
   linkType: hard
 
@@ -10798,10 +10831,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001125, caniuse-lite@npm:^1.0.30001179, caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001399":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001179, caniuse-lite@npm:^1.0.30001370, caniuse-lite@npm:^1.0.30001399":
   version: 1.0.30001399
   resolution: "caniuse-lite@npm:1.0.30001399"
   checksum: dd105b06fbbdc89867780a2f4debc3ecb184cff82f35b34aaac486628fcc9cf6bacf37573a9cc22dedc661178d460fa8401374a933cb9d2f8ee67316d98b2a8f
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001125":
+  version: 1.0.30001436
+  resolution: "caniuse-lite@npm:1.0.30001436"
+  checksum: 7928ac7d93741a81b3005ca4623b133e7d790828be70b26ee55e4860facc59bc344f4092e20034981070a4714f70814c8be4929be4b22728031784f267f69099
   languageName: node
   linkType: hard
 
@@ -11654,9 +11694,9 @@ __metadata:
   linkType: hard
 
 "compute-scroll-into-view@npm:^1.0.17":
-  version: 1.0.17
-  resolution: "compute-scroll-into-view@npm:1.0.17"
-  checksum: b20c05a10c37813c5a6e4bf053c00f65c88d23afed7a6bd7a2a69e05e2ffc2df3483ecfe407d36bf16b8cec8be21ae1966c9c523093a03117e567156cd79a51e
+  version: 1.0.20
+  resolution: "compute-scroll-into-view@npm:1.0.20"
+  checksum: f15fab29221953620735393ac1866541aab0d27d28078bedbba071a291ee9c8cc1a72bee302cf0bc06ed83c5e55afb74ebcbd634a63671ba33cf1fb1c51d3308
   languageName: node
   linkType: hard
 
@@ -11896,12 +11936,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.1.0, convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
+"convert-source-map@npm:^1.1.0, convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
   version: 1.8.0
   resolution: "convert-source-map@npm:1.8.0"
   dependencies:
     safe-buffer: ~5.1.1
   checksum: 985d974a2d33e1a2543ada51c93e1ba2f73eaed608dc39f229afc78f71dcc4c8b7d7c684aa647e3c6a3a204027444d69e53e169ce94e8d1fa8d7dee80c9c8fed
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^1.5.0":
+  version: 1.9.0
+  resolution: "convert-source-map@npm:1.9.0"
+  checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
   languageName: node
   linkType: hard
 
@@ -11948,11 +11995,11 @@ __metadata:
   linkType: hard
 
 "copy-to-clipboard@npm:^3.3.1":
-  version: 3.3.2
-  resolution: "copy-to-clipboard@npm:3.3.2"
+  version: 3.3.3
+  resolution: "copy-to-clipboard@npm:3.3.3"
   dependencies:
     toggle-selection: ^1.0.6
-  checksum: 968ec7ec3d0cf3067542b63dd244ba5d05e743899d7a0361fb0a3130e731d277f5ea54ea4d90fc88cc66eea2e4c67dc2dd8698e4ed360f921af5aa7c60b889ac
+  checksum: e0a325e39b7615108e6c1c8ac110ae7b829cdc4ee3278b1df6a0e4228c490442cc86444cd643e2da344fbc424b3aab8909e2fec82f8bc75e7e5b190b7c24eecf
   languageName: node
   linkType: hard
 
@@ -11975,10 +12022,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-pure@npm:^3.20.2, core-js-pure@npm:^3.8.1, core-js-pure@npm:^3.8.2":
+"core-js-pure@npm:^3.20.2, core-js-pure@npm:^3.8.1":
   version: 3.25.1
   resolution: "core-js-pure@npm:3.25.1"
   checksum: 0123131ec7ab3a1e56f0b4df4ae659de03d9c245ce281637d4d0f18f9839d8e0cfbfa989bd577ce1b67826f889a7dcc734421f697cf1bbe59f605f29c537a678
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.8.2":
+  version: 3.26.1
+  resolution: "core-js-pure@npm:3.26.1"
+  checksum: d88c40e5e29e413c11d1ef991a8d5b6a63f00bd94707af0f649d3fc18b3524108b202f4ae75ce77620a1557d1ba340bc3362b4f25d590eccc37cf80fc75f7cd4
   languageName: node
   linkType: hard
 
@@ -12570,9 +12624,9 @@ __metadata:
   linkType: hard
 
 "csstype@npm:^2.5.7":
-  version: 2.6.20
-  resolution: "csstype@npm:2.6.20"
-  checksum: cb5d5ded49c3390909e93b20b285d4a63d0ba5b10294bdfbc4cf911f80e91d6cf367ea671f99f09570762535c14ea7074a2c7fa73f02008203f01328dea8968b
+  version: 2.6.21
+  resolution: "csstype@npm:2.6.21"
+  checksum: 2ce8bc832375146eccdf6115a1f8565a27015b74cce197c35103b4494955e9516b246140425ad24103864076aa3e1257ac9bab25a06c8d931dd87a6428c9dccf
   languageName: node
   linkType: hard
 
@@ -12748,9 +12802,9 @@ __metadata:
   linkType: hard
 
 "decode-uri-component@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "decode-uri-component@npm:0.2.0"
-  checksum: f3749344ab9305ffcfe4bfe300e2dbb61fc6359e2b736812100a3b1b6db0a5668cba31a05e4b45d4d63dbf1a18dfa354cd3ca5bb3ededddabb8cd293f4404f94
+  version: 0.2.2
+  resolution: "decode-uri-component@npm:0.2.2"
+  checksum: 95476a7d28f267292ce745eac3524a9079058bbb35767b76e3ee87d42e34cd0275d2eb19d9d08c3e167f97556e8a2872747f5e65cbebcac8b0c98d83e285f139
   languageName: node
   linkType: hard
 
@@ -13592,8 +13646,8 @@ __metadata:
   linkType: hard
 
 "downshift@npm:^6.0.15":
-  version: 6.1.9
-  resolution: "downshift@npm:6.1.9"
+  version: 6.1.12
+  resolution: "downshift@npm:6.1.12"
   dependencies:
     "@babel/runtime": ^7.14.8
     compute-scroll-into-view: ^1.0.17
@@ -13602,7 +13656,7 @@ __metadata:
     tslib: ^2.3.0
   peerDependencies:
     react: ">=16.12.0"
-  checksum: 5b888b6ebd2083334758d49e9e7b669eb8d0475273cdb5af2aa5f8c363b62f56c79aeca43758c99642056e94f68cbd8086f79a0a96726b3e8b8726cb24fd1d1b
+  checksum: c623dc436f332fefddc332b42ca4a267b3f5b47aaf1372a61212678d7ecbe22698fdb63f61373bcbd3773fa526eb4f210cf7f044cd5642b689dbd37ba27e9aaf
   languageName: node
   linkType: hard
 
@@ -13674,7 +13728,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.3.564, electron-to-chromium@npm:^1.4.202":
+"electron-to-chromium@npm:^1.3.564":
+  version: 1.4.284
+  resolution: "electron-to-chromium@npm:1.4.284"
+  checksum: be496e9dca6509dbdbb54dc32146fc99f8eb716d28a7ee8ccd3eba0066561df36fc51418d8bd7cf5a5891810bf56c0def3418e74248f51ea4a843d423603d10a
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.202":
   version: 1.4.249
   resolution: "electron-to-chromium@npm:1.4.249"
   checksum: 830a35a157af7ae226f1528d727e369bb13f53bc7a4edefdf718651ace09d7d7b4bd7b70d33b5018b8eff6cf99ee58409b6c4140cd6d56350c1966f280ac5c93
@@ -18106,10 +18167,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.1.1, ignore@npm:^5.1.4, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
+"ignore@npm:^5.1.1, ignore@npm:^5.1.8, ignore@npm:^5.2.0":
   version: 5.2.0
   resolution: "ignore@npm:5.2.0"
   checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.1.4":
+  version: 5.2.1
+  resolution: "ignore@npm:5.2.1"
+  checksum: 7251d00cba49fe88c4f3565fadeb4aa726ba38294a9a79ffed542edc47bafd989d4b2ccf65700c5b1b26a1e91dfc7218fb23017937c79216025d5caeec0ee9d5
   languageName: node
   linkType: hard
 
@@ -20810,24 +20878,24 @@ __metadata:
   linkType: hard
 
 "loader-utils@npm:^1.2.3, loader-utils@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "loader-utils@npm:1.4.0"
+  version: 1.4.2
+  resolution: "loader-utils@npm:1.4.2"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^1.0.1
-  checksum: d150b15e7a42ac47d935c8b484b79e44ff6ab4c75df7cc4cb9093350cf014ec0b17bdb60c5d6f91a37b8b218bd63b973e263c65944f58ca2573e402b9a27e717
+  checksum: eb6fb622efc0ffd1abdf68a2022f9eac62bef8ec599cf8adb75e94d1d338381780be6278534170e99edc03380a6d29bc7eb1563c89ce17c5fed3a0b17f1ad804
   languageName: node
   linkType: hard
 
 "loader-utils@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "loader-utils@npm:2.0.2"
+  version: 2.0.4
+  resolution: "loader-utils@npm:2.0.4"
   dependencies:
     big.js: ^5.2.2
     emojis-list: ^3.0.0
     json5: ^2.1.2
-  checksum: 9078d1ed47cadc57f4c6ddbdb2add324ee7da544cea41de3b7f1128e8108fcd41cd3443a85b7ee8d7d8ac439148aa221922774efe4cf87506d4fb054d5889303
+  checksum: a5281f5fff1eaa310ad5e1164095689443630f3411e927f95031ab4fb83b4a98f388185bb1fe949e8ab8d4247004336a625e9255c22122b815bb9a4c5d8fc3b7
   languageName: node
   linkType: hard
 
@@ -21479,11 +21547,11 @@ __metadata:
   linkType: hard
 
 "markdown-to-jsx@npm:^7.1.3":
-  version: 7.1.7
-  resolution: "markdown-to-jsx@npm:7.1.7"
+  version: 7.1.8
+  resolution: "markdown-to-jsx@npm:7.1.8"
   peerDependencies:
     react: ">= 0.14.0"
-  checksum: b2c0ea7d0988fad0c709989b3b1b3a5600d1e80b60266f9618386f7afead4a6b5eba9ee1a3943df6a3dcb1599ea89e58467d1b17b6dd3af3c60984c60a85d06d
+  checksum: 4823f90e8bd6734b9a4ad206d217c55358268974e219e0edf3c64407336a14116921cad8c577c54b4bf0349412751ab25f3b6265c8b5a99207a5f6e364716636
   languageName: node
   linkType: hard
 
@@ -26056,15 +26124,15 @@ __metadata:
   linkType: hard
 
 "react-textarea-autosize@npm:^8.3.0":
-  version: 8.3.4
-  resolution: "react-textarea-autosize@npm:8.3.4"
+  version: 8.4.0
+  resolution: "react-textarea-autosize@npm:8.4.0"
   dependencies:
     "@babel/runtime": ^7.10.2
     use-composed-ref: ^1.3.0
     use-latest: ^1.2.1
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 87360d4392276d4e87511a73be9b0634b8bcce8f4f648cf659334d993f25ad3d4062f468f1e1944fc614123acae4299580aad00b760c6a96cec190e076f847f5
+  checksum: 055fb51b74e1ab6b286490cfcd8ed77a760f6fc90706053b5dfcb138199d02c56289a1060a1daf9f3ae37ffd66f73e9553f026d0fad446bc2243b713acf48e05
   languageName: node
   linkType: hard
 
@@ -26389,6 +26457,13 @@ __metadata:
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 3317a09b2f802da8db09aa276e469b57a6c0dd818347e05b8862959c6193408242f150db5de83c12c3fa99091ad95fb42a6db2c3329bfaa12a0ea4cbbeb30cb0
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
   languageName: node
   linkType: hard
 
@@ -27692,13 +27767,6 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 1a2bcae50de99034fcd92ad4212d8e01eedf52c7ec7830eedcf886622804fe36884278f2be8be0ea5fde3fd1c23911643a4e0f726c8685b61871c8908af01222
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:1.7.2":
-  version: 1.7.2
-  resolution: "shell-quote@npm:1.7.2"
-  checksum: efad426fb25d8a54d06363f1f45774aa9e195f62f14fa696d542b44bfe418ab41206448b63af18d726c62e099e66d9a3f4f44858b9ea2ce4b794b41b802672d1
   languageName: node
   linkType: hard
 
@@ -31572,13 +31640,13 @@ __metadata:
   linkType: hard
 
 "webpack-hot-middleware@npm:^2.25.0":
-  version: 2.25.2
-  resolution: "webpack-hot-middleware@npm:2.25.2"
+  version: 2.25.3
+  resolution: "webpack-hot-middleware@npm:2.25.3"
   dependencies:
     ansi-html-community: 0.0.8
     html-entities: ^2.1.0
     strip-ansi: ^6.0.0
-  checksum: 9bbcb4a3109d5efc3fedc41ab84209745e47770a205897324adff9126196d9cd086237288161d71cd7273a0154e09046d025a3c30c6938bd04e58d3b379fdcca
+  checksum: 74fe5d15f3120742cf0f88a4af7e72f3678f2d05905676e37ab4e85c559f2c21d8aa72b0efe7c262993370bfc83fbe5a8d42561bcd10b370fac88640f87c463a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-1091

Upgraded some dependencies to get rid of some security vulnerabilities. I couldn't get rid of all of them; some required a storybook upgrade and after working on that for several hours yesterday, I decided it wasn't worth the time for this ticket since I only had 2 days and those vulnerabilities only affect storybook and gatsby.

Other than that, there are a few other minor refactors in here to address some code smells. `event.keyCode` and `event.which` are both deprecated, so I got rid of the last references to them in this repo.


### Testing
I'd say the main thing to test would be the keyboard interactions on accordions and the select component. Make sure the arrows, home/end, space/enter keys all work as expected for the accordions and the select (both regular and combobox select).

If you want to test in IE11 you'll probably have to use the `mock-ebpp` app, because storybook appears to be broken in IE11 again (shocking, I know), which I'm going to make a ticket for.