### PR TITLE
CACTUS-1093 inline styles continued

### DIFF
--- a/examples/theme-components/src/containers/IconButton.tsx
+++ b/examples/theme-components/src/containers/IconButton.tsx
@@ -1,19 +1,18 @@
 import { RouteComponentProps } from '@reach/router'
 import icons from '@repay/cactus-icons'
-import NavigationChevronLeft from '@repay/cactus-icons/i/navigation-chevron-left'
+import { NavigationChevronLeft } from '@repay/cactus-icons'
 import cactusTheme from '@repay/cactus-theme'
 import { Flex, Grid, IconButton, SelectField, Text, ToggleField } from '@repay/cactus-web'
-import { IconButtonSizes, IconButtonVariants } from '@repay/cactus-web/src/IconButton/IconButton'
 import React, { useCallback, useState } from 'react'
 
 import Link from '../components/Link'
 
-const iconButtonVariants: IconButtonVariants[] = ['standard', 'action', 'danger']
-const iconButtonSizes: IconButtonSizes[] = ['tiny', 'small', 'medium', 'large']
+const iconButtonVariants = ['standard', 'action', 'danger'] as const
+const iconButtonSizes = ['tiny', 'small', 'medium', 'large'] as const
 
 interface PropTypes {
-  variant: IconButtonVariants
-  iconSize: IconButtonSizes
+  variant: typeof iconButtonVariants[number]
+  iconSize: typeof iconButtonSizes[number]
   disabled: boolean
   inverse: boolean
 }

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -295,7 +295,6 @@ export const AccordionBody = withStyles('div', {
 })`
   margin-top: ${space(5)};
   margin-bottom: ${space(7)};
-  width: auto;
 `
 
 const ProviderContext = createContext<AccordionProviderContext>({

--- a/modules/cactus-web/src/Accordion/Accordion.tsx
+++ b/modules/cactus-web/src/Accordion/Accordion.tsx
@@ -13,11 +13,10 @@ import React, {
 } from 'react'
 import { Transition } from 'react-transition-group'
 import styled, { StyledComponentBase } from 'styled-components'
-import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 'styled-system'
+import { margin, MarginProps } from 'styled-system'
 
-import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import KeyCodes from '../helpers/keyCodes'
-import { omitProps } from '../helpers/omit'
+import { allWidth, AllWidthProps, flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import useId from '../helpers/useId'
 import IconButton from '../IconButton/IconButton'
 
@@ -25,8 +24,7 @@ export type AccordionVariants = 'simple' | 'outline'
 
 interface AccordionProps
   extends MarginProps,
-    MaxWidthProps,
-    WidthProps,
+    AllWidthProps,
     FlexItemProps,
     React.HTMLAttributes<HTMLDivElement> {
   /** Does not apply when Accordion descends from a controlled Provider.  If true, the
@@ -290,15 +288,14 @@ const AccordionBodyBase = (props: AccordionBodyProps): ReactElement | null => {
   )
 }
 
-export const AccordionBody = styled(AccordionBodyBase).withConfig(
-  omitProps<AccordionBodyProps>(margin, 'width')
-)`
+export const AccordionBody = withStyles('div', {
+  as: AccordionBodyBase,
+  displayName: 'Accordion.Body',
+  styles: [margin],
+})`
   margin-top: ${space(5)};
   margin-bottom: ${space(7)};
-  // The extra specificity is to override the defaults in variantStyles.
-  &&& {
-    ${margin}
-  }
+  width: auto;
 `
 
 const ProviderContext = createContext<AccordionProviderContext>({
@@ -649,17 +646,16 @@ const variantStyles = (props: AccordionProps & { theme: CactusTheme }): string =
   `
 }
 
-export const Accordion = styled(AccordionBase).withConfig(
-  omitProps<AccordionProps>(flexItem, margin, width, maxWidth, 'useBoxShadows')
-)`
+export const Accordion = withStyles('div', {
+  as: AccordionBase,
+  displayName: 'Accordion',
+  styles: [allWidth, flexItem, margin],
+  transitiveProps: ['useBoxShadows'],
+})`
   box-sizing: border-box;
   width: 100%;
 
   ${variantStyles}
-  ${margin}
-  ${width}
-  ${maxWidth}
-  ${flexItem}
 ` as any
 
 Accordion.defaultProps = {

--- a/modules/cactus-web/src/ActionBar/ActionBar.test.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.test.tsx
@@ -133,4 +133,22 @@ describe('Component: ActionBar', () => {
     userEvent.click(checkbox)
     expect(panel).toHaveAttribute('aria-hidden', 'true')
   })
+
+  test('should support style props', () => {
+    const { container } = renderWithTheme(
+      <ActionBar>
+        <ActionBar.Panel
+          id="one"
+          icon={<ActionsGear />}
+          aria-label="test"
+          width="777px"
+          padding={5}
+        >
+          <p>I am a helpful message of some sort.</p>
+        </ActionBar.Panel>
+      </ActionBar>
+    )
+    const popup = container.querySelector('#one-popup')
+    expect(popup).toHaveStyle({ width: '777px', padding: '24px' })
+  })
 })

--- a/modules/cactus-web/src/ActionBar/ActionBar.tsx
+++ b/modules/cactus-web/src/ActionBar/ActionBar.tsx
@@ -7,6 +7,7 @@ import { layout, LayoutProps, padding, PaddingProps } from 'styled-system'
 
 import { usePositioning } from '../helpers/positionPopover'
 import { useMergedRefs } from '../helpers/react'
+import { withStyles } from '../helpers/styled'
 import usePopup, { PopupType, PositionPopup, TogglePopup } from '../helpers/usePopup'
 import { Sidebar } from '../Layout/Sidebar'
 import { OrderHint, OrderHintKey, useAction, useActionBarItems } from './ActionProvider'
@@ -159,9 +160,7 @@ PanelPopup.displayName = 'ActionBar.PanelPopup'
 PanelPopup.defaultProps = { position: positionPanel }
 
 // The box shadow is #2, but shifted to be only on the right side.
-const StyledPopup = styled.div.withConfig({
-  shouldForwardProp: (p) => (p as string) === 'width' || !stylePropNames.includes(p),
-})<StyleProps>`
+const StyledPopup = withStyles('div', { styles: [layout, padding] })<StyleProps>`
   ${(p) => p.theme.colorStyles.standard};
   box-sizing: border-box;
   position: absolute;
@@ -177,10 +176,7 @@ const StyledPopup = styled.div.withConfig({
   height: auto;
   width: auto;
   overflow: auto;
-  ${layout}
-
   padding: 8px;
-  ${padding}
 `
 
 interface ActionBarType extends React.FC<React.HTMLAttributes<HTMLDivElement>> {

--- a/modules/cactus-web/src/Avatar/Avatar.tsx
+++ b/modules/cactus-web/src/Avatar/Avatar.tsx
@@ -7,10 +7,10 @@ import {
 import { CactusTheme, ColorStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css, ThemeProps } from 'styled-components'
+import { css, ThemeProps } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { omitProps } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 
 export type AvatarType = 'alert' | 'feedback'
 export type AvatarStatus = 'error' | 'warning' | 'info' | 'success'
@@ -69,9 +69,12 @@ const AvatarBase = (props: AvatarProps): React.ReactElement => {
   )
 }
 
-export const Avatar = styled(AvatarBase).withConfig(
-  omitProps<AvatarStyleProps>(margin, 'type', 'disabled')
-)`
+export const Avatar = withStyles('div', {
+  as: AvatarBase,
+  displayName: 'Avatar',
+  styles: [margin],
+  transitiveProps: ['type', 'disabled'],
+})<AvatarStyleProps>`
   box-sizing: border-box;
   width: 40px;
   height: 40px;
@@ -84,7 +87,6 @@ export const Avatar = styled(AvatarBase).withConfig(
     padding-bottom: 4px;
   }
 
-  ${margin}
   ${avaColor}
 `
 

--- a/modules/cactus-web/src/Checkable/ToggleCard.tsx
+++ b/modules/cactus-web/src/Checkable/ToggleCard.tsx
@@ -5,10 +5,9 @@ import { margin } from 'styled-system'
 
 import { PolyFCWithRef } from '../helpers/asProps'
 import { isIE } from '../helpers/constants'
-import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import generateId from '../helpers/generateId'
 import { useBox } from '../helpers/react'
-import { withStyles } from '../helpers/styled'
+import { flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import { FlexGroup, GroupProps, makeGroup } from './Group'
 import { CheckableProps, WrapperLabel } from './Wrapper'
 

--- a/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
+++ b/modules/cactus-web/src/ColorPicker/ColorPicker.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { ColorChangeHandler, CustomPicker, HSLColor, HSVColor } from 'react-color'
 import { EditableInput, Hue, Saturation } from 'react-color/lib/components/common'
 import styled from 'styled-components'
-import { compose, margin, MarginProps } from 'styled-system'
+import { margin, MarginProps } from 'styled-system'
 import tinycolor from 'tinycolor2'
 
 import Button from '../Button/Button'
@@ -16,7 +16,7 @@ import { usePositioning } from '../helpers/positionPopover'
 import positionPortal from '../helpers/positionPortal'
 import { SemiControlled } from '../helpers/react'
 import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
-import { allWidth, AllWidthProps, flexItem, FlexItemProps } from '../helpers/styled'
+import { allWidth, AllWidthProps, flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import { popupBoxShadow, popupShape } from '../helpers/theme'
 import usePopup, { TogglePopup } from '../helpers/usePopup'
 import IconButton from '../IconButton/IconButton'
@@ -165,7 +165,11 @@ const PickerDialog = styled(({ handleClose, color, setColor, phrases, ...props }
   }
 `
 
-const InputWrapper = styled.div<{ status?: Status | null }>`
+const InputWrapper = withStyles('div', {
+  displayName: 'ColorPicker',
+  styles: [margin, allWidth, flexItem],
+  transitiveProps: ['status'],
+})<{ status?: Status | null }>`
   box-sizing: border-box;
   display: inline-flex;
   justify-content: space-between;
@@ -178,7 +182,6 @@ const InputWrapper = styled.div<{ status?: Status | null }>`
   outline: none;
   padding: 0 16px 0 12px;
   min-width: 160px;
-  ${margin}
 
   &:focus-within {
     border-color: ${themeColor('callToAction')};
@@ -201,10 +204,6 @@ const InputWrapper = styled.div<{ status?: Status | null }>`
     cursor: not-allowed;
     ${colorStyle('disable')}
     border-color: ${themeColor('lightGray')};
-  }
-
-  &&& {
-    ${compose(allWidth, flexItem)}
   }
 `
 

--- a/modules/cactus-web/src/DateInput/DateInput.story.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.story.tsx
@@ -2,7 +2,15 @@ import { Page } from 'puppeteer'
 import React, { useState } from 'react'
 
 import { Button, DateInput, Flex, StatusMessage } from '../'
-import { Action, actions, HIDE_CONTROL, HIDE_STYLED, Story, STRING } from '../helpers/storybook'
+import {
+  Action,
+  actions,
+  HIDE_CONTROL,
+  HIDE_STYLED,
+  SPACE,
+  Story,
+  STRING,
+} from '../helpers/storybook'
 
 export default {
   title: 'DateInput',
@@ -39,32 +47,37 @@ type DateStory = Story<
 export const BasicUsage: DateStory = (args) => {
   const [invalidDate, setInvalidDate] = useState<boolean>(false)
   return (
-    <Flex flexDirection="column" alignItems="flex-start">
-      <DateInput
-        {...args}
-        name={args.name || args.type}
-        onInvalidDate={args.onInvalidDate.wrap(setInvalidDate)}
-        data-testid="testing"
-      />
+    <>
+      <div>
+        <DateInput
+          {...args}
+          name={args.name || args.type}
+          onInvalidDate={args.onInvalidDate.wrap(setInvalidDate)}
+          data-testid="testing"
+        />
+      </div>
       {invalidDate && (
         <StatusMessage status="error" style={{ marginTop: '4px' }}>
           The date you've selected is invalid. Please pick another date.
         </StatusMessage>
       )}
-    </Flex>
+    </>
   )
 }
+BasicUsage.argTypes = { width: STRING, margin: SPACE }
 
 export const ControlledWithDate: DateStory = (args) => {
   const [value, setValue] = React.useState<Date | string | null>(new Date('10/1/2020'))
   return (
     <>
-      <DateInput
-        {...args}
-        name={args.name || args.type}
-        value={value}
-        onChange={args.onChange.wrap(setValue, true)}
-      />
+      <div>
+        <DateInput
+          {...args}
+          name={args.name || args.type}
+          value={value}
+          onChange={args.onChange.wrap(setValue, true)}
+        />
+      </div>
       <Button mt={4} onClick={() => setValue(null)}>
         Clear
       </Button>

--- a/modules/cactus-web/src/DateInput/DateInput.test.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.test.tsx
@@ -613,7 +613,7 @@ describe('component: DateInput', () => {
         <DateInput name="thin" id="not-thicc" value="2020-01-01" data-testid="dateInput" />,
         { border: 'thick' }
       )
-      const dateInput = asFragment().firstElementChild?.firstElementChild?.firstElementChild
+      const dateInput = asFragment().firstElementChild
       const styles = window.getComputedStyle(dateInput as Element)
       expect(styles.borderWidth).toBe('2px')
     })
@@ -623,7 +623,7 @@ describe('component: DateInput', () => {
         <DateInput name="intermediate" id="not-round" value="2020-01-01" />,
         { shape: 'intermediate' }
       )
-      const dateInput = asFragment().firstElementChild?.firstElementChild?.firstElementChild
+      const dateInput = asFragment().firstElementChild
       const styles = window.getComputedStyle(dateInput as Element)
 
       expect(styles.borderRadius).toBe('8px')
@@ -635,7 +635,7 @@ describe('component: DateInput', () => {
         { shape: 'square' }
       )
 
-      const dateInput = asFragment().firstElementChild?.firstElementChild?.firstElementChild
+      const dateInput = asFragment().firstElementChild
       const styles = window.getComputedStyle(dateInput as Element)
 
       expect(styles.borderRadius).toBe('0px')
@@ -647,10 +647,29 @@ describe('component: DateInput', () => {
         { boxShadows: false }
       )
 
-      const dateInput = asFragment().firstElementChild?.firstElementChild?.firstElementChild
+      const dateInput = asFragment().firstElementChild
       const styles = window.getComputedStyle(dateInput as Element)
 
       expect(styles.boxShadow).toBe('')
+    })
+
+    test('should support style props', () => {
+      const { getByTestId } = renderWithTheme(
+        <DateInput
+          id="dumb"
+          name="dumb"
+          data-testid="style"
+          margin={5}
+          flex="1 1 15em"
+          minWidth="12em"
+        />
+      )
+      const input = getByTestId('style')
+      expect(input).toHaveStyle({
+        margin: '24px',
+        flex: '1 1 15em',
+        minWidth: '12em',
+      })
     })
   })
 })

--- a/modules/cactus-web/src/DateInputField/DateInputField.test.tsx
+++ b/modules/cactus-web/src/DateInputField/DateInputField.test.tsx
@@ -42,13 +42,13 @@ describe('component: DateInputField', () => {
     )
 
     const blank = { marginTop: '', marginRight: '', marginBottom: '', marginLeft: '' }
-    expect(getByTestId('first').parentElement?.parentElement?.parentElement).toHaveStyle(blank)
-    expect(getByTestId('default').parentElement?.parentElement?.parentElement).toHaveStyle({
+    expect(getByTestId('first').parentElement).toHaveStyle(blank)
+    expect(getByTestId('default').parentElement).toHaveStyle({
       ...blank,
       marginTop: '16px',
       marginBottom: '4px',
     })
-    expect(getByTestId('override').parentElement?.parentElement?.parentElement).toHaveStyle({
+    expect(getByTestId('override').parentElement).toHaveStyle({
       ...blank,
       marginTop: '2px',
     })

--- a/modules/cactus-web/src/Divider/Divider.test.tsx
+++ b/modules/cactus-web/src/Divider/Divider.test.tsx
@@ -5,9 +5,10 @@ import Divider from './Divider'
 
 describe('component: Divider', () => {
   test('Should render HR element', () => {
-    const { container } = renderWithTheme(<Divider />)
+    const { container } = renderWithTheme(<Divider margin="6.493px" />)
     const divider = container.firstElementChild
 
     expect(divider?.tagName).toBe('HR')
+    expect(divider).toHaveStyle({ margin: '6.493px' })
   })
 })

--- a/modules/cactus-web/src/Divider/Divider.tsx
+++ b/modules/cactus-web/src/Divider/Divider.tsx
@@ -1,8 +1,11 @@
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-export const Divider = styled.hr<MarginProps>`
-  ${margin}
+import { withStyles } from '../helpers/styled'
+
+export const Divider = withStyles('hr', {
+  displayName: 'Divider',
+  styles: [margin],
+})<MarginProps>`
   border: none;
   height: ${(p) => (p.theme.border === 'thin' ? '1px' : '2px')};
   color: ${(p) => p.theme.colors.lightContrast};

--- a/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
+++ b/modules/cactus-web/src/FieldWrapper/FieldWrapper.tsx
@@ -1,7 +1,6 @@
 import { margin, MarginProps } from 'styled-system'
 
-import { flexItem, FlexItemProps } from '../helpers/flexItem'
-import { withStyles } from '../helpers/styled'
+import { flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 
 type StyleProps = MarginProps & FlexItemProps & { $gap?: number }
 export const FieldWrapper = withStyles('div', {

--- a/modules/cactus-web/src/FileInput/FileInput.test.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.test.tsx
@@ -119,6 +119,26 @@ describe('component: FileInput', () => {
     expect(changeTarget).toEqual({ name: 'controlled', value: [] })
   })
 
+  test('should support style props', () => {
+    const { getByTestId } = renderWithTheme(
+      <FileInput
+        name="no"
+        data-testid="style"
+        margin={5}
+        width="50%"
+        maxWidth="333px"
+        flexGrow="1"
+      />
+    )
+    const input = getByTestId('style')
+    expect(input).toHaveStyle({
+      margin: '24px',
+      width: '50%',
+      maxWidth: '333px',
+      flexGrow: '1',
+    })
+  })
+
   /** TODO: Add integration tests to theme-components example using puppeteer. We can't put them here because
    * @types/puppeteer brings in @types/node and sets everything else on fire
    * */

--- a/modules/cactus-web/src/FileInput/FileInput.tsx
+++ b/modules/cactus-web/src/FileInput/FileInput.tsx
@@ -9,7 +9,7 @@ import { border, color, colorStyle, radius, textStyle } from '@repay/cactus-them
 import PropTypes, { Validator } from 'prop-types'
 import React, { useRef } from 'react'
 import styled, { css } from 'styled-components'
-import { margin, MarginProps, maxWidth, MaxWidthProps, width, WidthProps } from 'styled-system'
+import { margin, MarginProps } from 'styled-system'
 
 import Avatar, { AvatarStatus } from '../Avatar/Avatar'
 import Flex from '../Flex/Flex'
@@ -20,9 +20,10 @@ import {
   CactusFocusEvent,
   isFocusOut,
 } from '../helpers/events'
-import { omitProps, split } from '../helpers/omit'
+import { split } from '../helpers/omit'
 import { useRenderTrigger } from '../helpers/react'
 import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
+import { allWidth, AllWidthProps, flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import useId from '../helpers/useId'
 import { IconButton } from '../IconButton/IconButton'
 import Spinner from '../Spinner/Spinner'
@@ -49,7 +50,7 @@ type InputProps = Pick<
   'disabled' | 'form' | 'required' | 'multiple' | 'capture'
 >
 
-interface CommonProps extends MarginProps, MaxWidthProps, WidthProps, InputProps, WrapperProps {
+interface CommonProps extends MarginProps, AllWidthProps, FlexItemProps, InputProps, WrapperProps {
   name: string
   status?: Status | null
   accept?: string[]
@@ -636,9 +637,11 @@ const FileInputBase = (props: InnerInputProps): React.ReactElement => {
   )
 }
 
-const InnerFileInput = styled(FileInputBase).withConfig(
-  omitProps<InnerInputProps>(margin, width, maxWidth, 'status')
-)`
+const InnerFileInput = withStyles('div', {
+  as: FileInputBase,
+  displayName: 'FileInput',
+  styles: [margin, allWidth, flexItem],
+})`
   box-sizing: border-box;
   border-radius: ${radius(8)};
   border: 2px dotted ${color('darkestContrast')};
@@ -693,10 +696,6 @@ const InnerFileInput = styled(FileInputBase).withConfig(
   input:focus ~ ${TextButton}, input:focus ~ * ${TextButton} {
     ${focusStyle}
   }
-
-  ${margin}
-  ${width}
-  ${maxWidth}
 `
 
 export default FileInput

--- a/modules/cactus-web/src/Header/Header.test.tsx
+++ b/modules/cactus-web/src/Header/Header.test.tsx
@@ -29,4 +29,20 @@ describe('component: Header', () => {
     expect(title.tagName).toBe('H1')
     expect(desc).toBeInTheDocument()
   })
+
+  test('should render style props', () => {
+    const { getByTestId } = renderWithTheme(
+      <Header data-testid="style" marginX="7.77em" marginBottom={4}>
+        <Header.Title>I Am a Title</Header.Title>
+      </Header>
+    )
+
+    const header = getByTestId('style')
+    expect(header).toHaveStyle({
+      marginTop: '',
+      marginRight: '7.77em',
+      marginBottom: '16px',
+      marginLeft: '7.77em',
+    })
+  })
 })

--- a/modules/cactus-web/src/Header/Header.tsx
+++ b/modules/cactus-web/src/Header/Header.tsx
@@ -4,6 +4,7 @@ import React, { Children, ComponentType, FC, HTMLAttributes, ReactElement } from
 import styled, { css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
+import { withStyles } from '../helpers/styled'
 import Text from '../Text/Text'
 
 export type BackgroundColorVariants = 'lightContrast' | 'white'
@@ -145,9 +146,11 @@ Header.propTypes = {
   bgColor: PropTypes.oneOf(['white', 'lightContrast']),
 }
 
-export const StyledHeader = styled.header<HeaderProps & { $hasDescription: boolean }>`
-  ${margin}
-
+export const StyledHeader = withStyles('header', {
+  displayName: 'Header',
+  styles: [margin],
+  transitiveProps: ['bgColor'],
+})<HeaderProps & { $hasDescription: boolean }>`
   align-items: center;
   background-color: ${(p) =>
     p.bgColor ? p.theme.colors[p.bgColor] : p.theme.colors['lightContrast']};

--- a/modules/cactus-web/src/IconButton/IconButton.tsx
+++ b/modules/cactus-web/src/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import { iconSizes } from '@repay/cactus-icons'
+import { IconProps, iconSizes } from '@repay/cactus-icons'
 import { border, CactusTheme, iconSize } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import { css, FlattenInterpolation, ThemeProps } from 'styled-components'
@@ -8,11 +8,9 @@ import { isIE } from '../helpers/constants'
 import { withStyles } from '../helpers/styled'
 
 export type IconButtonVariants = 'standard' | 'action' | 'danger' | 'warning' | 'success' | 'dark'
-export type IconButtonSizes = 'tiny' | 'small' | 'medium' | 'large'
 
-interface IconStyleProps extends MarginProps {
+interface IconStyleProps extends MarginProps, Pick<IconProps, 'iconSize'> {
   label?: string
-  iconSize?: IconButtonSizes
   variant?: IconButtonVariants
   disabled?: boolean
   display?: 'flex' | 'inline-flex'
@@ -145,7 +143,7 @@ const variantOrDisabled = (
 }
 
 const focusOutline = system({
-  iconSize: (value: IconButtonSizes) => {
+  iconSize: (value: keyof typeof focusOutlineSpacing) => {
     const offset = focusOutlineSpacing[value] || focusOutlineSpacing.medium
     const styles: Record<string, string> = {
       height: `calc(100% + ${offset}px)`,

--- a/modules/cactus-web/src/List/List.tsx
+++ b/modules/cactus-web/src/List/List.tsx
@@ -2,14 +2,13 @@ import icons from '@repay/cactus-icons'
 import { border } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
-import { compose, margin, MarginProps } from 'styled-system'
+import { margin, MarginProps } from 'styled-system'
 
 import Flex from '../Flex/Flex'
-import { flexItem, FlexItemProps } from '../helpers/styled'
+import { flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import Text, { TextProps } from '../Text/Text'
 
-interface ListProps extends MarginProps, FlexItemProps, React.HTMLAttributes<HTMLUListElement> {
+interface ListProps extends MarginProps, FlexItemProps {
   dividers?: boolean
 }
 
@@ -25,25 +24,25 @@ interface ItemHeaderProps extends Omit<TextProps, 'color'> {
 
 // Workaround for a styled-components bug when using `&` in a nested style.
 const nested = (): string => `
-  ${UL} {
+  ${List} {
     margin-top: 8px;
     margin-bottom: 8px;
     margin-left: 24px;
   }
 `
 
-const UL = styled.ul<{ $dividers: boolean }>`
+export const List = withStyles('ul', {
+  displayName: 'List',
+  styles: [margin, flexItem],
+  transitiveProps: ['dividers'],
+})<ListProps>`
   padding: 0;
   margin: 0;
   list-style-type: none;
   ${nested}
 
-  && {
-    ${compose(flexItem, margin)}
-  }
-
   ${(p) =>
-    p.$dividers &&
+    p.dividers &&
     `
     li {
       border-top: ${border(p, 'lightContrast')};
@@ -57,14 +56,6 @@ const UL = styled.ul<{ $dividers: boolean }>`
     cursor: pointer;
   }
 `
-
-export const List = React.forwardRef<HTMLUListElement, ListProps>(
-  ({ children, dividers = false, ...props }, ref) => (
-    <UL $dividers={dividers} {...props} ref={ref}>
-      {children}
-    </UL>
-  )
-)
 
 const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>(
   ({ icon, children, ...props }, ref) => {
@@ -90,7 +81,6 @@ const ItemHeader: React.FC<ItemHeaderProps> = ({ icon, ...props }) => {
   )
 }
 
-List.displayName = 'List'
 ListItem.displayName = 'List.Item'
 ItemHeader.displayName = 'List.ItemHeader'
 

--- a/modules/cactus-web/src/MenuButton/MenuButton.test.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.test.tsx
@@ -113,4 +113,15 @@ describe('With theme changes ', () => {
 
     expect(styles.borderWidth).toBe('2px')
   })
+
+  test('should support style props', () => {
+    const { container } = renderWithTheme(<MenuButton label="Demo" marginY={2} marginLeft="7px" />)
+    const menuButton = container.querySelector(String(MenuButton))
+    expect(menuButton).toHaveStyle({
+      marginTop: '4px',
+      marginBottom: '4px',
+      marginLeft: '7px',
+      marginRight: '',
+    })
+  })
 })

--- a/modules/cactus-web/src/MenuButton/MenuButton.tsx
+++ b/modules/cactus-web/src/MenuButton/MenuButton.tsx
@@ -14,8 +14,8 @@ import React from 'react'
 import styled, { createGlobalStyle, css } from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { extractMargins } from '../helpers/omit'
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
+import { withStyles } from '../helpers/styled'
 import { border, popupBoxShadow, popupShape, radius } from '../helpers/theme'
 
 const MenuButtonStyles = createGlobalStyle`
@@ -80,27 +80,28 @@ interface DropDownProps {
   children?: React.ReactNode
 }
 
-interface MenuButtonProps extends MarginProps {
+interface MenuButtonProps {
   label: React.ReactNode
   variant?: MenuButtonVariant
   /**
    * Must be a MenuButton.Item or MenuButton.Link
    */
-  children: React.ReactNode
+  children?: React.ReactNode
   disabled?: boolean
+  className?: string
+  style?: React.CSSProperties
 }
 
-type MenuButtonType = React.FC<MenuButtonProps> & {
+type MenuButtonType = React.FC<MenuButtonProps & MarginProps> & {
   Item: typeof ReachMenuItem
   Link: typeof ReachMenuLink
 }
 
-export const MenuButton: MenuButtonType = (props) => {
-  const { label, children, variant = 'filled', ...rest } = props
-  const marginProps = extractMargins(rest)
+const MenuButtonBase = (props: MenuButtonProps) => {
+  const { label, children, className, style, variant = 'filled', ...rest } = props
   const anchorRef = React.useRef<HTMLButtonElement>(null)
   return (
-    <Wrapper {...marginProps}>
+    <div className={className} style={style}>
       <ReachMenu>
         {({ isOpen }) => (
           <>
@@ -115,7 +116,7 @@ export const MenuButton: MenuButtonType = (props) => {
           </>
         )}
       </ReachMenu>
-    </Wrapper>
+    </div>
   )
 }
 
@@ -134,9 +135,6 @@ const DropDown: React.FC<DropDownProps> = ({ isOpen, variant, anchorRef, childre
     </StyledPopover>
   )
 }
-
-MenuButton.Item = ReachMenuItem
-MenuButton.Link = ReachMenuLink
 
 type VariantMap = { [K in MenuButtonVariant]: ReturnType<typeof css> }
 
@@ -222,21 +220,27 @@ const StyledButton = styled.button<MenuButtonProps>`
   }
 `
 
-const Wrapper = styled.div<MarginProps>`
+export const MenuButton: MenuButtonType = withStyles('div', {
+  as: MenuButtonBase,
+  displayName: 'MenuButton',
+  styles: [margin],
+})<MarginProps>`
   position: relative;
   display: inline-block;
   max-width: 100%;
-  ${margin}
-`
+` as any
 
 const StyledPopover = styled(ReachMenuPopover)`
   position: fixed;
   z-index: 1000;
 `
 
+MenuButton.Item = ReachMenuItem
+MenuButton.Link = ReachMenuLink
+
 MenuButton.propTypes = {
   label: PropTypes.node.isRequired,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   disabled: PropTypes.bool,
   variant: PropTypes.oneOf(['filled', 'unfilled']),
 }

--- a/modules/cactus-web/src/PrevNext/PrevNext.test.tsx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.test.tsx
@@ -37,4 +37,17 @@ describe('component: PrevNext', () => {
     expect(mockNavigate).toHaveBeenCalledTimes(2)
     expect(mockNavigate).toHaveBeenLastCalledWith('next')
   })
+
+  test('should support style props', () => {
+    const { getByTestId } = renderWithTheme(
+      <PrevNext marginY={1} marginLeft=".17vw" data-testid="style" />
+    )
+    const prevNext = getByTestId('style')
+    expect(prevNext).toHaveStyle({
+      marginTop: '2px',
+      marginRight: '',
+      marginBottom: '2px',
+      marginLeft: '.17vw',
+    })
+  })
 })

--- a/modules/cactus-web/src/PrevNext/PrevNext.tsx
+++ b/modules/cactus-web/src/PrevNext/PrevNext.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
 import { keyDownAsClick } from '../helpers/a11y'
-import { getOmittableProps } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 
 type NavDirection = 'prev' | 'next'
 
@@ -88,12 +88,11 @@ const PrevNextBase: React.FC<PrevNextProps> = ({
   </div>
 )
 
-const styleProps = getOmittableProps(margin)
-export const PrevNext = styled(PrevNextBase).withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
-})<MarginProps>(margin)
-
-PrevNext.displayName = 'PrevNext'
+export const PrevNext = withStyles('div', {
+  as: PrevNextBase,
+  displayName: 'PrevNext',
+  styles: [margin],
+})``
 
 const linkAsPropType = PropTypes.elementType as PropTypes.Validator<React.ElementType>
 

--- a/modules/cactus-web/src/Preview/Preview.tsx
+++ b/modules/cactus-web/src/Preview/Preview.tsx
@@ -7,7 +7,7 @@ import { height, HeightProps, margin, MarginProps, width, WidthProps } from 'sty
 import Dimmer from '../Dimmer/Dimmer'
 import Flex from '../Flex/Flex'
 import { keyDownAsClick, preventAction } from '../helpers/a11y'
-import { flexItem, FlexItemProps } from '../helpers/flexItem'
+import { flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import { boxShadow, radius } from '../helpers/theme'
 import IconButton from '../IconButton/IconButton'
 
@@ -158,7 +158,11 @@ const ImageBackground = styled.div`
   background-color: ${(p) => p.theme.colors.white};
 `
 
-const PreviewBox = styled.div<{ justify: 'space-between' | 'center' }>`
+const PreviewBox = withStyles('div', {
+  displayName: 'Preview',
+  styles: [width, height, margin, flexItem],
+  transitiveProps: ['justify'],
+})<{ justify: 'space-between' | 'center' }>`
   box-sizing: border-box;
   padding-left: ${(p) => p.theme.space[7]}px;
   padding-right: ${(p) => p.theme.space[7]}px;
@@ -168,13 +172,9 @@ const PreviewBox = styled.div<{ justify: 'space-between' | 'center' }>`
   min-width: 50%;
   width: 50%;
   height: 440px;
-  ${width}
-  ${height}
   display: flex;
   justify-content: ${(p) => p.justify};
   align-items: center;
-  ${margin}
-  ${flexItem}
 
   img {
     display: inline;

--- a/modules/cactus-web/src/RadioButton/RadioButton.tsx
+++ b/modules/cactus-web/src/RadioButton/RadioButton.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { omitMargins } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 
 export interface RadioButtonProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
   id?: string
@@ -17,10 +17,9 @@ interface StyledRadioButtonProps extends React.HTMLProps<HTMLSpanElement> {
 }
 
 const RadioButtonBase = React.forwardRef<HTMLInputElement, RadioButtonProps>((props, ref) => {
-  const componentProps = omitMargins(props) as Omit<RadioButtonProps, keyof MarginProps>
-  const { id, className, ...radioButtonProps } = componentProps
+  const { id, className, style, ...radioButtonProps } = props
   return (
-    <label className={className} htmlFor={id}>
+    <label className={className} style={style} htmlFor={id}>
       <HiddenRadioButton ref={ref} id={id} {...radioButtonProps} />
       <StyledRadioButton aria-hidden={true} />
     </label>
@@ -57,7 +56,11 @@ const StyledRadioButton = styled.span<StyledRadioButtonProps>`
   }
 `
 
-export const RadioButton = styled(RadioButtonBase)`
+export const RadioButton = withStyles('input', {
+  as: RadioButtonBase,
+  displayName: 'RadioButton',
+  styles: [margin],
+})`
   position: relative;
   display: inline-block;
   vertical-align: -1px;
@@ -84,8 +87,6 @@ export const RadioButton = styled(RadioButtonBase)`
       background-color: ${color('lightGray')};
     }
   }
-
-  ${margin}
 `
 
 RadioButton.propTypes = {

--- a/modules/cactus-web/src/Select/Select.test.tsx
+++ b/modules/cactus-web/src/Select/Select.test.tsx
@@ -38,7 +38,7 @@ describe('component: Select', () => {
         minWidth="101px"
       />
     )
-    const selectComponent = container.querySelector('[id="test-id"]')?.parentElement?.parentElement
+    const selectComponent = container.querySelector(String(Select))
     const styles = window.getComputedStyle(selectComponent as Element)
 
     expect(styles.minWidth).toBe('101px')
@@ -56,7 +56,7 @@ describe('component: Select', () => {
         flexBasis="auto"
       />
     )
-    const selectComponent = container.querySelector('[id="test-id"]')?.parentElement?.parentElement
+    const selectComponent = container.querySelector(String(Select))
     const styles = window.getComputedStyle(selectComponent as Element)
 
     expect(styles.flexGrow).toBe('4')

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -68,7 +68,7 @@ export interface SelectProps
       React.HTMLAttributes<HTMLButtonElement>,
       'onChange' | 'onBlur' | 'onFocus' | 'placeholder'
     > {
-  options?: (OptionType | string | number | undefined | null)[]
+  options?: ReadonlyArray<OptionType | string | number | undefined | null>
   id: string
   name: string
   value?: SelectValueType

--- a/modules/cactus-web/src/Select/Select.tsx
+++ b/modules/cactus-web/src/Select/Select.tsx
@@ -3,7 +3,7 @@ import { BorderSize, CactusTheme, ColorStyle, fontSize, textStyle } from '@repay
 import PropTypes from 'prop-types'
 import React, { useLayoutEffect, useRef, useState } from 'react'
 import styled, { css, ThemeContext, withTheme } from 'styled-components'
-import { compose, margin, MarginProps } from 'styled-system'
+import { margin, MarginProps } from 'styled-system'
 
 import CheckBox from '../CheckBox/CheckBox'
 import Flex from '../Flex/Flex'
@@ -15,12 +15,18 @@ import {
   isFocusOut,
 } from '../helpers/events'
 import KeyCodes from '../helpers/keyCodes'
-import { omitMargins } from '../helpers/omit'
 import { positionDropDown, usePositioning } from '../helpers/positionPopover'
 import { isPurelyEqual, useMergedRefs } from '../helpers/react'
 import { useScrollTrap } from '../helpers/scroll'
 import { getStatusStyles, Status, StatusPropType } from '../helpers/status'
-import { allWidth, AllWidthProps, flexItem, FlexItemProps } from '../helpers/styled'
+import {
+  allWidth,
+  AllWidthProps,
+  flexItem,
+  FlexItemProps,
+  Styled,
+  withStyles,
+} from '../helpers/styled'
 import { boxShadow, isResponsiveTouchDevice, radius } from '../helpers/theme'
 import Tag from '../Tag/Tag'
 import TextButton from '../TextButton/TextButton'
@@ -1130,8 +1136,6 @@ const getValidValue = (
 }
 
 class SelectBase extends React.Component<SelectPropsWithTheme, SelectState> {
-  public static Option = SelectOption
-
   public state: SelectState = {
     isOpen: false,
     value: NO_SELECTION,
@@ -1519,6 +1523,7 @@ class SelectBase extends React.Component<SelectPropsWithTheme, SelectState> {
       id,
       disabled,
       className,
+      style,
       placeholder,
       width,
       status,
@@ -1534,7 +1539,7 @@ class SelectBase extends React.Component<SelectPropsWithTheme, SelectState> {
       noOptionsText = 'No options available',
       onDropdownToggle,
       ...rest
-    } = omitMargins(this.props) as Omit<SelectProps, keyof MarginProps>
+    } = this.props
     const { isOpen, searchValue, activeDescendant } = this.state
     const options = this.getExtOptions()
     const noOptsDisable =
@@ -1543,7 +1548,7 @@ class SelectBase extends React.Component<SelectPropsWithTheme, SelectState> {
     // Added `tabIndex=-1` on the wrapper element to compensate for
     // the fact that Safari cannot focus buttons on click.
     return (
-      <div className={className}>
+      <div className={className} style={style}>
         <div
           ref={this.triggerRef}
           tabIndex={-1}
@@ -1622,7 +1627,15 @@ class SelectBase extends React.Component<SelectPropsWithTheme, SelectState> {
 
 const SelectWithTheme = withTheme(SelectBase)
 
-const Select = styled(SelectWithTheme)`
+type SelectType = Styled<SelectProps> & {
+  Option: typeof SelectOption
+}
+
+const Select: SelectType = withStyles('select', {
+  as: SelectWithTheme,
+  displayName: 'Select',
+  styles: [margin, allWidth, flexItem],
+})`
   max-width: 100%;
   display: inline-block;
   & button:disabled {
@@ -1633,10 +1646,8 @@ const Select = styled(SelectWithTheme)`
     background-color: ${(p) => p.theme.colors.white};
     ${getStatusStyles}
   }
-  &&& {
-    ${compose(margin, allWidth, flexItem)}
-  }
-`
+` as any
+Select.Option = SelectOption
 
 export { Select }
 
@@ -1687,4 +1698,4 @@ Select.defaultProps = {
   noOptionsText: 'No options available',
 }
 
-export default Select as typeof Select & { Option: typeof SelectOption }
+export default Select

--- a/modules/cactus-web/src/StatusMessage/StatusMessage.story.tsx
+++ b/modules/cactus-web/src/StatusMessage/StatusMessage.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { Flex, StatusMessage } from '../'
-import { HIDE_CONTROL, Story } from '../helpers/storybook'
+import { HIDE_CONTROL, SPACE, Story } from '../helpers/storybook'
 
 export default {
   title: 'StatusMessage',
@@ -36,6 +36,7 @@ export const BasicUsage: Story<
 }
 BasicUsage.argTypes = {
   status: HIDE_CONTROL,
+  marginX: SPACE,
   error: { name: 'error message' },
   warning: { name: 'warning message' },
   info: { name: 'info message' },

--- a/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
+++ b/modules/cactus-web/src/StatusMessage/StatusMessage.tsx
@@ -8,11 +8,10 @@ import {
 import { colorStyle, ColorVariant, textStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { omitMargins } from '../helpers/omit'
 import { Status as BaseStatus } from '../helpers/status'
+import { withStyles } from '../helpers/styled'
 
 type Status = BaseStatus | 'info'
 
@@ -42,17 +41,21 @@ const iconMap: IconMap = {
 const Noop = (): null => null
 
 const StatusMessageBase: React.FC<StatusMessageProps> = (props) => {
-  const { status, className, children, ...rest } = omitMargins(props)
+  const { status, children, ...rest } = props
   const StatusIcon: React.ElementType<any> = iconMap[status as Status] || Noop
   return (
-    <div {...rest} role="alert" className={className}>
+    <div {...rest} role="alert">
       <StatusIcon aria-hidden="true" mr={2} verticalAlign="-2px" />
       <span>{children}</span>
     </div>
   )
 }
 
-const StatusMessage = styled(StatusMessageBase)`
+const StatusMessage = withStyles('div', {
+  as: StatusMessageBase,
+  displayName: 'StatusMessage',
+  styles: [margin],
+})`
   padding: 2px 4px;
   position: relative;
   box-sizing: border-box;
@@ -60,7 +63,6 @@ const StatusMessage = styled(StatusMessageBase)`
   display: inline-block;
   ${textStyle('small')};
   ${(p) => colorStyle(p, statusMap[p.status])}
-  ${margin}
 `
 
 StatusMessage.propTypes = {

--- a/modules/cactus-web/src/Tabs/Tabs.story.tsx
+++ b/modules/cactus-web/src/Tabs/Tabs.story.tsx
@@ -2,9 +2,9 @@ import { Page } from 'puppeteer'
 import React from 'react'
 
 import { Tab, TabController, TabList, TabPanel } from '../'
-import { FlexItemProps } from '../helpers/flexItem'
 import { split } from '../helpers/omit'
 import { Story } from '../helpers/storybook'
+import { FlexItemProps } from '../helpers/styled'
 
 const LABELS = [
   'Ready!',

--- a/modules/cactus-web/src/Tabs/Tabs.test.tsx
+++ b/modules/cactus-web/src/Tabs/Tabs.test.tsx
@@ -11,7 +11,9 @@ describe('component: TabController', () => {
     const { getByText } = renderWithTheme(
       <TabController initialTabId="sorcerer-tab">
         <TabList>
-          <Tab name="knight">Alanna</Tab>
+          <Tab name="knight" flex="5 4 321px">
+            Alanna
+          </Tab>
           <Tab name="sorcerer">Thom</Tab>
         </TabList>
         <TabPanel tab="knight">The Good Twin</TabPanel>
@@ -25,6 +27,7 @@ describe('component: TabController', () => {
     expect(knightTab).toHaveAttribute('role', 'tab')
     expect(knightTab).toHaveAttribute('aria-selected', 'false')
     expect(knightTab).toHaveAttribute('aria-controls', 'knight-panel')
+    expect(knightTab).toHaveStyle({ flex: '5 4 321px' })
     expect(knightPanel).toHaveAttribute('role', 'tabpanel')
     expect(knightPanel).toHaveAttribute('hidden')
     expect(knightPanel).toHaveAttribute('aria-labelledby', 'knight-tab')

--- a/modules/cactus-web/src/Tabs/Tabs.tsx
+++ b/modules/cactus-web/src/Tabs/Tabs.tsx
@@ -7,11 +7,10 @@ import Box, { BoxProps } from '../Box/Box'
 import Flex, { JustifyContent } from '../Flex/Flex'
 import { keyDownAsClick, preventAction } from '../helpers/a11y'
 import { AsProps, GenericComponent } from '../helpers/asProps'
-import { flexItem, FlexItemProps } from '../helpers/flexItem'
 import { FocusSetter, useFocusControl } from '../helpers/focus'
-import { omitProps } from '../helpers/omit'
 import { useValue } from '../helpers/react'
 import { BUTTON_WIDTH, GetScrollInfo, ScrollButton, useScroll } from '../helpers/scroll'
+import { flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 import { border, insetBorder, isResponsiveTouchDevice } from '../helpers/theme'
 
 interface TabListProps extends Omit<React.HTMLAttributes<HTMLElement>, 'role'> {
@@ -280,13 +279,10 @@ const StyledTabList = styled(Flex)`
   }
 `
 
-const StyledTab = styled.div.withConfig(omitProps<TabProps>(flexItem))`
+const StyledTab = withStyles('div', { styles: [flexItem] })<TabProps>`
   display: block;
   position: relative;
   padding: 8px 16px;
-  && {
-    ${flexItem}
-  }
 
   &:focus::after {
     content: '';

--- a/modules/cactus-web/src/Tag/Tag.test.tsx
+++ b/modules/cactus-web/src/Tag/Tag.test.tsx
@@ -39,4 +39,19 @@ describe('component: Tag', () => {
     const icon = container.querySelector('svg')
     expect(icon).not.toBeInTheDocument()
   })
+
+  test('should support style props', () => {
+    const { getByTestId } = renderWithTheme(
+      <Tag marginX={7} marginTop="3em" data-testid="style">
+        Test label
+      </Tag>
+    )
+    const tag = getByTestId('style')
+    expect(tag).toHaveStyle({
+      marginTop: '3em',
+      marginRight: '40px',
+      marginBottom: '',
+      marginLeft: '40px',
+    })
+  })
 })

--- a/modules/cactus-web/src/Tag/Tag.tsx
+++ b/modules/cactus-web/src/Tag/Tag.tsx
@@ -2,10 +2,9 @@ import { NavigationClose } from '@repay/cactus-icons'
 import { color, colorStyle, lineHeight, radius, space, textStyle } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { getOmittableProps } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 import { IconButton } from '../IconButton/IconButton'
 
 const closeTypes = ['no-button', 'button'] as const
@@ -37,9 +36,10 @@ const TagBase = React.forwardRef<HTMLSpanElement, TagProps>(
   }
 )
 
-const styleProps = getOmittableProps(margin)
-export const Tag = styled(TagBase).withConfig({
-  shouldForwardProp: (p) => !styleProps.has(p),
+export const Tag = withStyles('span', {
+  as: TagBase,
+  displayName: 'Tag',
+  styles: [margin],
 })<MarginProps>`
   ${colorStyle('standard')};
   box-sizing: border-box;
@@ -54,8 +54,6 @@ export const Tag = styled(TagBase).withConfig({
   ${IconButton} {
     padding: 4px;
   }
-
-  ${margin}
 `
 
 Tag.propTypes = {

--- a/modules/cactus-web/src/TextArea/TextArea.tsx
+++ b/modules/cactus-web/src/TextArea/TextArea.tsx
@@ -2,18 +2,16 @@ import { mediaGTE, radius, textStyle } from '@repay/cactus-theme'
 import { Property } from 'csstype'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled from 'styled-components'
-import { compose, margin, MarginProps, ResponsiveValue, system } from 'styled-system'
+import { margin, MarginProps, ResponsiveValue, system } from 'styled-system'
 
 import { StatusProps, StatusPropType } from '../helpers/status'
 import {
-  allHeight,
-  AllHeightProps,
-  allWidth,
-  AllWidthProps,
   flexItem,
   FlexItemProps,
+  sizing,
+  SizingProps,
   styledProp,
+  withStyles,
 } from '../helpers/styled'
 import { commonInputStyles } from '../TextInput/TextInput'
 
@@ -23,13 +21,16 @@ export interface TextAreaProps
     StatusProps,
     FlexItemProps,
     MarginProps,
-    AllHeightProps,
-    AllWidthProps {
+    SizingProps {
   resize?: ResponsiveValue<Property.Resize>
 }
 const resizeSS = system({ resize: true })
 
-const TextArea = styled.textarea<TextAreaProps>`
+const TextArea = withStyles('textarea', {
+  displayName: 'TextArea',
+  styles: [margin, sizing, flexItem, resizeSS],
+  transitiveProps: ['status'],
+})<TextAreaProps>`
   border-radius: ${radius(8)};
   height: 100px;
   ${mediaGTE('small')} {
@@ -40,9 +41,6 @@ const TextArea = styled.textarea<TextAreaProps>`
   position: relative;
   resize: none;
   ${commonInputStyles}
-  &&& {
-    ${compose(margin, allHeight, allWidth, flexItem, resizeSS)}
-  }
 `
 
 TextArea.propTypes = {

--- a/modules/cactus-web/src/TextInput/TextInput.tsx
+++ b/modules/cactus-web/src/TextInput/TextInput.tsx
@@ -8,11 +8,11 @@ import defaultTheme, {
 } from '@repay/cactus-theme'
 import PropTypes from 'prop-types'
 import React from 'react'
-import styled, { css } from 'styled-components'
-import { compose, margin, MarginProps } from 'styled-system'
+import { css } from 'styled-components'
+import { margin, MarginProps } from 'styled-system'
 
 import { getStatusStyles, StatusProps, StatusPropType } from '../helpers/status'
-import { allWidth, AllWidthProps, flexItem, FlexItemProps } from '../helpers/styled'
+import { allWidth, AllWidthProps, flexItem, FlexItemProps, withStyles } from '../helpers/styled'
 
 type TextStyleKey = keyof TextStyleCollection
 export const textStyles = Object.keys(defaultTheme.textStyles) as TextStyleKey[]
@@ -55,13 +55,14 @@ export const commonInputStyles = css<StatusProps>`
   ${getStatusStyles}
 `
 
-const TextInput = styled.input<TextInputProps>`
+const TextInput = withStyles('input', {
+  displayName: 'TextInput',
+  styles: [margin, allWidth, flexItem],
+  transitiveProps: ['textStyle', 'status'],
+})<TextInputProps>`
   border-radius: ${radius(20)};
   padding: 3px 15px;
   ${(p) => textStyle(p, p.textStyle || 'body')};
-  &&& {
-    ${compose(margin, allWidth, flexItem)}
-  }
   ${commonInputStyles}
 `
 

--- a/modules/cactus-web/src/Toggle/Toggle.tsx
+++ b/modules/cactus-web/src/Toggle/Toggle.tsx
@@ -5,23 +5,22 @@ import React from 'react'
 import styled from 'styled-components'
 import { margin, MarginProps } from 'styled-system'
 
-import { extractMargins } from '../helpers/omit'
+import { withStyles } from '../helpers/styled'
 
 export interface ToggleProps extends React.InputHTMLAttributes<HTMLInputElement>, MarginProps {
   checked?: boolean
   disabled?: boolean
 }
 
-export const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
-  ({ className, ...props }, ref) => {
-    const marginProps = extractMargins(props)
+const ToggleBase = React.forwardRef<HTMLInputElement, ToggleProps>(
+  ({ className, style, ...props }, ref) => {
     return (
-      <Wrapper {...marginProps} className={className} role="none">
+      <div className={className} style={style} role="none">
         <Checkbox {...props} role="switch" aria-checked={props.checked} ref={ref} />
         <Switch aria-hidden />
         <StyledX aria-hidden color="white" />
         <StyledCheck aria-hidden color="white" />
-      </Wrapper>
+      </div>
     )
   }
 )
@@ -70,7 +69,11 @@ const StyledCheck = styled(StatusCheck)`
   }
 `
 
-const Wrapper = styled.div`
+export const Toggle = withStyles('div', {
+  as: ToggleBase,
+  displayName: 'Toggle',
+  styles: [margin],
+})`
   display: inline-block;
   position: relative;
   width: 51px;
@@ -79,7 +82,6 @@ const Wrapper = styled.div`
   padding: 0;
   border: none;
   outline: none;
-  ${margin}
 `
 
 const Switch = styled.div`
@@ -125,9 +127,5 @@ Toggle.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
 }
-
-// Enable use of `Toggle` as a styled-components CSS class.
-Toggle.toString = Wrapper.toString
-Toggle.displayName = 'Toggle'
 
 export default Toggle

--- a/modules/cactus-web/src/ToggleField/ToggleField.tsx
+++ b/modules/cactus-web/src/ToggleField/ToggleField.tsx
@@ -44,7 +44,7 @@ const ToggleFieldWrapper = styled(FieldWrapper)<{ $disabled?: boolean }>`
     ${(p) => p.$disabled && `color: ${p.theme.colors.mediumGray}`};
   }
 
-  ${Toggle.toString()} {
+  ${Toggle} {
     vertical-align: middle;
   }
 `

--- a/modules/cactus-web/src/Tooltip/Tooltip.test.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.test.tsx
@@ -85,4 +85,15 @@ describe('component: Tooltip', () => {
     const popup = document.querySelector('div[role=tooltip]') as Element
     expect(popup).toHaveStyle({ top: '25px', left: '150px', borderRadius: '0px' })
   })
+
+  test('should support style props', () => {
+    const { container } = renderWithTheme(<Tooltip label="cow tipping" marginX={6} marginTop={3} />)
+    const label = container.querySelector(String(Tooltip))
+    expect(label).toHaveStyle({
+      marginLeft: '32px',
+      marginRight: '32px',
+      marginTop: '8px',
+      marginBottom: '',
+    })
+  })
 })

--- a/modules/cactus-web/src/Tooltip/Tooltip.tsx
+++ b/modules/cactus-web/src/Tooltip/Tooltip.tsx
@@ -7,6 +7,7 @@ import { margin, MarginProps, TextColorProps } from 'styled-system'
 
 import { getDataProps } from '../helpers/omit'
 import { PositionCallback, usePositioning } from '../helpers/positionPopover'
+import { withStyles } from '../helpers/styled'
 import usePopup from '../helpers/usePopup'
 import Modal from '../Modal/Modal'
 
@@ -18,6 +19,7 @@ export interface TooltipProps extends MarginProps, TextColorProps {
   maxWidth?: string
   disabled?: boolean
   className?: string
+  style?: React.CSSProperties
   id?: string
   forceVisible?: boolean
 }
@@ -131,6 +133,7 @@ const StyledInfo = styled(({ forceVisible, ...props }) => (
 const TooltipBase = (props: TooltipProps): React.ReactElement => {
   const {
     className,
+    style,
     color: colorProp,
     disabled,
     label,
@@ -215,6 +218,7 @@ const TooltipBase = (props: TooltipProps): React.ReactElement => {
         id={triggerProps.id}
         ref={triggerRef}
         className={className}
+        style={style}
         onClick={() => {
           setStayOpen(true)
         }}
@@ -253,9 +257,11 @@ export const TooltipPopup = styled.div<{ $visible: boolean }>`
   }
 `
 
-export const Tooltip = styled(TooltipBase)`
-  ${margin}
-`
+export const Tooltip = withStyles('span', {
+  as: TooltipBase,
+  displayName: 'Tooltip',
+  styles: [margin],
+})``
 
 Tooltip.propTypes = {
   label: PropTypes.node.isRequired,

--- a/modules/cactus-web/src/helpers/flexItem.ts
+++ b/modules/cactus-web/src/helpers/flexItem.ts
@@ -1,5 +1,0 @@
-import { FlexboxProps, system } from 'styled-system'
-
-export type FlexItemProps = Pick<FlexboxProps, 'flex' | 'flexBasis' | 'flexGrow' | 'flexShrink'>
-
-export const flexItem = system({ flex: true, flexBasis: true, flexGrow: true, flexShrink: true })

--- a/modules/cactus-web/src/helpers/omit.ts
+++ b/modules/cactus-web/src/helpers/omit.ts
@@ -1,33 +1,9 @@
 import omit from 'lodash/omit'
-import { StyledConfig } from 'styled-components'
 import { margin, MarginProps, width, WidthProps } from 'styled-system'
 
-import { flexItem, FlexItemProps } from './flexItem'
+import { flexItem, FlexItemProps } from './styled'
 
 export default omit
-
-export const omitMargins = <Obj extends { [k: string]: any }>(
-  obj: Obj,
-  ...undesired: string[]
-): Partial<Obj> =>
-  omit<Obj>(
-    obj,
-    'm',
-    'margin',
-    'mt',
-    'marginTop',
-    'mr',
-    'marginRight',
-    'mb',
-    'marginBottom',
-    'ml',
-    'marginLeft',
-    'mx',
-    'marginX',
-    'my',
-    'marginY',
-    ...undesired
-  )
 
 function extractor<T>(keys: string[]) {
   return (props: Record<string, any>) => split(props, keys) as Partial<T>
@@ -62,40 +38,6 @@ export const split: Split = (
     }
     return extracted
   }, {} as Record<string, any>)
-}
-
-type Omittable = string | string[] | { propNames?: string[] }
-
-/*
- * Intended for use in the `shouldForwardProp` function:
- *
- * const styleProps = getOmittableProps(margin)
- * const X = styled.div.withConfig({ shouldForwardProp: (p) => !styleProps.has(p) })``
- *
- * I'd rather cut a little boilerplate and return the entire function or config
- * object, but for some reason Typescript refuses to infer the type correctly,
- * even if I explicitly set the type to what Typescript infers in the above code.
- */
-export const getOmittableProps = (...args: Omittable[]): Set<string> => {
-  const omittableProps = new Set<string>()
-  const add = (x: string) => omittableProps.add(x)
-  for (const arg of args) {
-    if (typeof arg === 'string') {
-      add(arg)
-    } else if (Array.isArray(arg)) {
-      arg.forEach(add)
-    } else if (arg.propNames) {
-      arg.propNames.forEach(add)
-    }
-  }
-  return omittableProps
-}
-
-// 3rd party type constraint, have to just ignore it.
-// eslint-disable-next-line @typescript-eslint/ban-types
-export const omitProps = <P extends object>(...args: Omittable[]): StyledConfig<P> => {
-  const excludedProps = getOmittableProps(...args) as Set<any>
-  return { shouldForwardProp: (p) => !excludedProps.has(p) }
 }
 
 export const getDataProps = <T>(props: T): any =>

--- a/modules/cactus-web/src/helpers/styled.ts
+++ b/modules/cactus-web/src/helpers/styled.ts
@@ -12,30 +12,6 @@ import { isIE } from './constants'
 // This file exists, in part, because styled-components types are a PAIN.
 export type Styled<P> = StyledComponent<React.FC<P>, CactusTheme>
 
-// This works around the `babel-plugin-styled-components` `displayName` setting,
-// so we can specify the CSS class of the resulting component.
-export const styledWithClass = <C extends React.ElementType>(
-  component: C,
-  className: string
-): ThemedStyledFunction<C, CactusTheme> => {
-  const tag: any = styled(component)
-  return tag.withConfig({ componentId: className })
-}
-
-// This gives us a styled component without the polymorphic behavior: the `as`
-// attr overrides any `as` prop passed in. Unfortunately I can't think of a way
-// to make Typescript consider it an invalid prop as well.
-export const styledUnpoly = <C extends React.ElementType, F extends React.ElementType = C>(
-  component: C,
-  fixed: F = component as any
-): ThemedStyledFunction<F, CactusTheme> => {
-  let tag: any = styled(component).attrs({ as: fixed } as any)
-  if ('displayName' in fixed) {
-    tag = tag.withConfig({ displayName: (fixed as any).displayName })
-  }
-  return tag
-}
-
 type Attrs = { [k: string]: any } | ((props: any) => any)
 
 // `ElementType` is more correct, but using `ComponentType` internally works better.


### PR DESCRIPTION
https://repayonline.atlassian.net/browse/CACTUS-1093

I rather "heroically" restrained my impulse to refactor everything I didn't like, and thus managed to get all the remaining components done in a reasonable time frame, so we don't need a third ticket. A few cropped up that were not quite as straightforward:
- Modal required an extra "post-processing" step to convert percent-based styles to viewport-based styles. The way it was doing it before wouldn't work with inline styles parsing.
- I did have to do a bit of extra refactoring on DateInput, and recommend you look at that particular diff ignoring whitespace changes.
- There was also a bit of weirdness where the type of the `iconSize` prop for `IconButton` didn't match the one from `cactus-icons`, so I fixed that as well.
- For those that didn't already have tests covering the style props, I added some.