### PR TITLE
cactus-1113-dateinput-auto-tabbing

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,27 +23,27 @@ jobs:
       - name: Build Modules
         uses: ./.github/actions/cactus-build
 
-  unit-tests:
-    runs-on: ubuntu-latest
-    needs: build
+  # unit-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: build
     
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Install Dependencies
-        uses: ./.github/actions/install-dependencies
+  #     - name: Install Dependencies
+  #       uses: ./.github/actions/install-dependencies
 
-      - name: Download built modules
-        uses: ./.github/actions/download-dist-artifacts
+  #     - name: Download built modules
+  #       uses: ./.github/actions/download-dist-artifacts
 
-      - name: Test Modules
-        run: |
-          yarn theme test:ci
-          yarn fwk test:ci
-          yarn i18n test:ci
-          yarn form test:ci
-          yarn icons test:ci
-          yarn web test:ci
+  #     - name: Test Modules
+  #       run: |
+  #         yarn theme test:ci
+  #         yarn fwk test:ci
+  #         yarn i18n test:ci
+  #         yarn form test:ci
+  #         yarn icons test:ci
+  #         yarn web test:ci
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -64,44 +64,44 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   
-  visual-tests:
-    runs-on: ubuntu-latest
-    needs: build
+  # visual-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: build
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Install Dependencies
-        uses: ./.github/actions/install-dependencies
+  #     - name: Install Dependencies
+  #       uses: ./.github/actions/install-dependencies
 
-      - name: Download built modules
-        uses: ./.github/actions/download-dist-artifacts
+  #     - name: Download built modules
+  #       uses: ./.github/actions/download-dist-artifacts
 
-      - name: Visual Tests
-        uses: ./actions/storyshots
+  #     - name: Visual Tests
+  #       uses: ./actions/storyshots
 
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
+  #     - name: Extract branch name
+  #       shell: bash
+  #       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+  #       id: extract_branch
 
-      - name: Create Pull Request
-        uses: ./actions/create-pull-request
-        with:
-          branch: ${{ steps.extract_branch.outputs.branch }}-patch
+  #     - name: Create Pull Request
+  #       uses: ./actions/create-pull-request
+  #       with:
+  #         branch: ${{ steps.extract_branch.outputs.branch }}-patch
 
-  docs-test:
-    runs-on: ubuntu-latest
-    needs: build
+  # docs-test:
+  #   runs-on: ubuntu-latest
+  #   needs: build
 
-    steps:
-      - uses: actions/checkout@v2
+  #   steps:
+  #     - uses: actions/checkout@v2
 
-      - name: Install Dependencies
-        uses: ./.github/actions/install-dependencies
+  #     - name: Install Dependencies
+  #       uses: ./.github/actions/install-dependencies
 
-      - name: Download built modules
-        uses: ./.github/actions/download-dist-artifacts
+  #     - name: Download built modules
+  #       uses: ./.github/actions/download-dist-artifacts
 
-      - name: Test Docs Website
-        run: yarn docs test:ci
+  #     - name: Test Docs Website
+  #       run: yarn docs test:ci

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,27 +23,27 @@ jobs:
       - name: Build Modules
         uses: ./.github/actions/cactus-build
 
-  # unit-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: build
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: build
     
-  #   steps:
-  #     - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - name: Install Dependencies
-  #       uses: ./.github/actions/install-dependencies
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
 
-  #     - name: Download built modules
-  #       uses: ./.github/actions/download-dist-artifacts
+      - name: Download built modules
+        uses: ./.github/actions/download-dist-artifacts
 
-  #     - name: Test Modules
-  #       run: |
-  #         yarn theme test:ci
-  #         yarn fwk test:ci
-  #         yarn i18n test:ci
-  #         yarn form test:ci
-  #         yarn icons test:ci
-  #         yarn web test:ci
+      - name: Test Modules
+        run: |
+          yarn theme test:ci
+          yarn fwk test:ci
+          yarn i18n test:ci
+          yarn form test:ci
+          yarn icons test:ci
+          yarn web test:ci
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -64,44 +64,44 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   
-  # visual-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: build
+  visual-tests:
+    runs-on: ubuntu-latest
+    needs: build
 
-  #   steps:
-  #     - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - name: Install Dependencies
-  #       uses: ./.github/actions/install-dependencies
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
 
-  #     - name: Download built modules
-  #       uses: ./.github/actions/download-dist-artifacts
+      - name: Download built modules
+        uses: ./.github/actions/download-dist-artifacts
 
-  #     - name: Visual Tests
-  #       uses: ./actions/storyshots
+      - name: Visual Tests
+        uses: ./actions/storyshots
 
-  #     - name: Extract branch name
-  #       shell: bash
-  #       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-  #       id: extract_branch
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
 
-  #     - name: Create Pull Request
-  #       uses: ./actions/create-pull-request
-  #       with:
-  #         branch: ${{ steps.extract_branch.outputs.branch }}-patch
+      - name: Create Pull Request
+        uses: ./actions/create-pull-request
+        with:
+          branch: ${{ steps.extract_branch.outputs.branch }}-patch
 
-  # docs-test:
-  #   runs-on: ubuntu-latest
-  #   needs: build
+  docs-test:
+    runs-on: ubuntu-latest
+    needs: build
 
-  #   steps:
-  #     - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-  #     - name: Install Dependencies
-  #       uses: ./.github/actions/install-dependencies
+      - name: Install Dependencies
+        uses: ./.github/actions/install-dependencies
 
-  #     - name: Download built modules
-  #       uses: ./.github/actions/download-dist-artifacts
+      - name: Download built modules
+        uses: ./.github/actions/download-dist-artifacts
 
-  #     - name: Test Docs Website
-  #       run: yarn docs test:ci
+      - name: Test Docs Website
+        run: yarn docs test:ci

--- a/modules/cactus-web/src/DateInput/DateInput.story.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.story.tsx
@@ -100,7 +100,24 @@ ControlledWithString.parameters = {
   cactus: { overrides: { alignItems: 'start' } },
 }
 
-export const TypeTime: DateStory = (args) => <DateInput {...args} name={args.name || args.type} />
+export const TypeTime: DateStory = (args) => {
+  const [invalidDate, setInvalidDate] = useState<boolean>(false)
+  return (
+    <Flex flexDirection="column" alignItems="flex-start">
+      <DateInput
+        {...args}
+        name={args.name || args.type}
+        onInvalidDate={args.onInvalidDate.wrap(setInvalidDate)}
+      />
+
+      {invalidDate && (
+        <StatusMessage status="error" style={{ marginTop: '4px' }}>
+          The date you've selected is invalid. Please pick another date.
+        </StatusMessage>
+      )}
+    </Flex>
+  )
+}
 TypeTime.args = { type: 'time' }
 TypeTime.storyName = 'type="time"'
 

--- a/modules/cactus-web/src/DateInput/DateInput.test.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.test.tsx
@@ -588,7 +588,7 @@ describe('component: DateInput', () => {
     test('renders expected time inputs', () => {
       const value = '15:22'
       const { getByLabelText } = renderWithTheme(
-        <DateInput name="date-input" id="date-input" type="time" value={value} format="HH:mm" />
+        <DateInput name="date-input" id="date-input" type="time" value={value} format="hh:mm" />
       )
       expect((): HTMLElement => getByLabelText('year')).toThrow()
       expect((): HTMLElement => getByLabelText('month')).toThrow()

--- a/modules/cactus-web/src/DateInput/DateInput.test.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.test.tsx
@@ -593,7 +593,7 @@ describe('component: DateInput', () => {
       expect((): HTMLElement => getByLabelText('year')).toThrow()
       expect((): HTMLElement => getByLabelText('month')).toThrow()
       expect((): HTMLElement => getByLabelText('day of month')).toThrow()
-      expect(getByLabelText('hours')).toHaveProperty('value', '15')
+      expect(getByLabelText('hours')).toHaveProperty('value', '3')
       expect(getByLabelText('minutes')).toHaveProperty('value', '22')
       expect(getByLabelText('time period')).toHaveProperty('value', 'PM')
     })

--- a/modules/cactus-web/src/DateInput/DateInput.test.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.test.tsx
@@ -588,12 +588,12 @@ describe('component: DateInput', () => {
     test('renders expected time inputs', () => {
       const value = '15:22'
       const { getByLabelText } = renderWithTheme(
-        <DateInput name="date-input" id="date-input" type="time" value={value} format="hh:mm" />
+        <DateInput name="date-input" id="date-input" type="time" value={value} format="HH:mm" />
       )
       expect((): HTMLElement => getByLabelText('year')).toThrow()
       expect((): HTMLElement => getByLabelText('month')).toThrow()
       expect((): HTMLElement => getByLabelText('day of month')).toThrow()
-      expect(getByLabelText('hours')).toHaveProperty('value', '03')
+      expect(getByLabelText('hours')).toHaveProperty('value', '15')
       expect(getByLabelText('minutes')).toHaveProperty('value', '22')
       expect(getByLabelText('time period')).toHaveProperty('value', 'PM')
     })

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -919,9 +919,9 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
     const hasTime = type === 'datetime' || type === 'time'
     const hasDate = type === 'date' || type === 'datetime'
     const phrases = this.getPhrases()
-
     const timeId = id + '-time'
     const selectedValue = value.isValidDate() ? value.toDate() : null
+
     return (
       <div onFocus={this.handleFocus} onBlur={this.handleBlur}>
         <Flex alignItems="flex-start" justifyContent="center" flexDirection="column">

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -154,7 +154,7 @@ function arrowValueChange(
       if (asNum === NaN) {
         break
       }
-      console.log(value.get_Hours(), asNum)
+
       asNum += direction
       const outOfRange = asNum > 12 || asNum < 1
       if (direction < 0 && outOfRange) {

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -150,14 +150,19 @@ function arrowValueChange(
     }
     case 'h':
     case 'hh': {
-      const newValue = value.getHours() + direction
-      const outOfRange = newValue > 12 || newValue < 1
+      let asNum = Number(value.get_Hours())
+      if (asNum === NaN) {
+        break
+      }
+      console.log(value.get_Hours(), asNum)
+      asNum += direction
+      const outOfRange = asNum > 12 || asNum < 1
       if (direction < 0 && outOfRange) {
         value.setHours(12)
       } else if (direction > 0 && outOfRange) {
         value.setHours(1)
       } else {
-        value.setHours(newValue)
+        value.setHours(asNum)
       }
       break
     }
@@ -175,7 +180,6 @@ function arrowValueChange(
       break
     }
     case 'mm': {
-      // value.setMinutes(((value.getMinutes() % 60) + direction + 60) % 60)
       const newValue = value.getMinutes() + direction
       const outOfRange = newValue > 59 || newValue < 0
       if (direction < 0 && outOfRange) {

--- a/modules/cactus-web/src/DateInput/DateInput.tsx
+++ b/modules/cactus-web/src/DateInput/DateInput.tsx
@@ -151,43 +151,45 @@ function arrowValueChange(
     case 'h':
     case 'hh': {
       let asNum = Number(value.get_Hours())
-      if (asNum === NaN) {
-        break
+      asNum += direction
+
+      // Switches from AM to PM while using arrows
+      if (asNum === 12 && direction > 0) {
+        value.aa = value.aa === 'AM' ? 'PM' : 'AM'
+      } else if (asNum === 11 && direction < 0) {
+        value.aa = value.aa === 'AM' ? 'PM' : 'AM'
       }
 
-      asNum += direction
-      const outOfRange = asNum > 12 || asNum < 1
-      if (direction < 0 && outOfRange) {
-        value.setHours(12)
-      } else if (direction > 0 && outOfRange) {
-        value.setHours(1)
-      } else {
+      if (asNum <= 12 && asNum >= 1) {
         value.setHours(asNum)
+      } else if (direction < 0) {
+        value.setHours(12)
+      } else {
+        value.setHours(1)
       }
       break
     }
     case 'H':
     case 'HH': {
       const newValue = value.getHours() + direction
-      const outOfRange = newValue > 23 || newValue < 0
-      if (direction < 0 && outOfRange) {
-        value.setHours(23)
-      } else if (direction > 0 && outOfRange) {
-        value.setHours(0)
-      } else {
+      if (newValue <= 23 && newValue >= 0) {
         value.setHours(newValue)
+      } else if (direction < 0) {
+        value.setHours(23)
+      } else {
+        value.setHours(0)
       }
       break
     }
     case 'mm': {
       const newValue = value.getMinutes() + direction
       const outOfRange = newValue > 59 || newValue < 0
-      if (direction < 0 && outOfRange) {
-        value.setMinutes(59)
-      } else if (direction > 0 && outOfRange) {
-        value.setMinutes(0)
-      } else {
+      if (newValue <= 59 && newValue >= 0) {
         value.setMinutes(newValue)
+      } else if (direction < 0 && outOfRange) {
+        value.setMinutes(59)
+      } else {
+        value.setMinutes(0)
       }
       break
     }
@@ -763,11 +765,12 @@ class DateInputBase extends Component<DateInputProps, DateInputState> {
 
   private handleTimeChange = (event: React.ChangeEvent<Target>): void => {
     const time = event.target.value
+    const formatTime = getLocaleFormat('en-US', { type: 'time' })
     if (typeof time === 'string' && time !== '') {
       event.persist()
       this.setState(({ value }): Pick<DateInputState, 'value'> => {
         const update = value.clone()
-        update.parse(time, 'HH:mm aa')
+        update.parse(time, formatTime)
         this.raiseChange(event, update)
         return { value: update }
       })

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -622,6 +622,27 @@ export class PartialDate implements FormatTokenMap {
     for (const token of parsed) {
       if (isToken(token)) {
         let val = this[token]
+        if (/[H]/.test(token) && val !== '' && val !== undefined) {
+          val = this.hours?.toString()
+        }
+        if (/[Mmdh]/.test(token) && val !== '' && val !== undefined) {
+          const padLength = val?.length > 1 || token.length > 1 ? 2 : 1
+          val = ('0' + val).slice(-padLength)
+        }
+        result += val !== '' ? val : repeat('#', token.length)
+      } else {
+        result += token
+      }
+    }
+    return result
+  }
+
+  public formatInput(format?: string): string {
+    const parsed = parseFormat(format || this._format)
+    let result = ''
+    for (const token of parsed) {
+      if (isToken(token)) {
+        let val = this[token]
         if (/[Mmdh]/.test(token) && val !== '' && val !== undefined) {
           const padLength = val?.length > 1 || token.length > 1 ? 2 : 1
           val = ('0' + val).slice(-padLength)

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -640,7 +640,7 @@ export class PartialDate implements FormatTokenMap {
     return result
   }
 
-  public parseTime(format) {
+  public parseTime(format?: string) {
     const parsed = parseFormat(format || this._format)
     for (const token of parsed) {
       if (isToken(token) && /[Hh]/.test(token)) {

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -378,7 +378,7 @@ export class PartialDate implements FormatTokenMap {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get MM() {
-    return this._month === undefined ? '' : this._month.slice(-2)
+    return this._month ? this._month.slice(-2) : ''
   }
 
   public set MM(value: string | undefined) {
@@ -387,7 +387,7 @@ export class PartialDate implements FormatTokenMap {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get d() {
-    return this._day || ''
+    return this._day ? Number(this._day).toString() : ''
   }
 
   public set d(value: string | undefined) {
@@ -426,10 +426,7 @@ export class PartialDate implements FormatTokenMap {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get h() {
-    if (this._hours === undefined) {
-      return ''
-    }
-    return this._hours
+    return this._hours ? Number(this._hours).toString() : ''
   }
 
   public set h(value: string | undefined) {
@@ -458,7 +455,7 @@ export class PartialDate implements FormatTokenMap {
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get H() {
-    return this._hours || ''
+    return this._hours ? Number(this._hours).toString() : ''
   }
 
   public set H(value: string | undefined) {
@@ -645,17 +642,17 @@ export class PartialDate implements FormatTokenMap {
     for (const token of parsed) {
       if (isToken(token) && /[Hh]/.test(token)) {
         let val = Number(this[token])
-        if (/[h]/.test(token) && val !== NaN && val !== undefined) {
-          if (val > 12) {
-            this.period = 'PM'
-          } else {
-            this.period = 'AM'
-          }
-          val = val % 12 || 12
-        }
-
-        if (/[H]/.test(token) && val !== NaN && val !== undefined) {
-          if (this.period && this.period === 'PM') {
+        if (!Number.isNaN(val) && val !== undefined) {
+          if (/[h]/.test(token)) {
+            val = val % 12 || 12
+            if (!this.period) {
+              if (val > 12) {
+                this.period = 'PM'
+              } else {
+                this.period = 'AM'
+              }
+            }
+          } else if (/[H]/.test(token) && this.period && this.period === 'PM') {
             val = val + 12
           }
         }

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -527,7 +527,12 @@ export class PartialDate implements FormatTokenMap {
 
   public setMonth(value: number): void {
     this.month = value % 12
-    this._month = String((value % 12) + 1)
+    const displayValue = (value % 12) + 1
+    if (this._localeFormat.includes('MM')) {
+      this._month = this.pad(displayValue)
+    } else {
+      this._month = String(displayValue)
+    }
   }
 
   public getDate(): number {
@@ -536,7 +541,11 @@ export class PartialDate implements FormatTokenMap {
 
   public setDate(value: number): void {
     this.day = value % 32
-    this._day = String(value % 32)
+    if (this._localeFormat.includes('dd')) {
+      this._day = this.pad(value % 32)
+    } else {
+      this._day = String(value % 32)
+    }
   }
 
   public getHours(): number {

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -625,11 +625,11 @@ export class PartialDate implements FormatTokenMap {
     for (const token of parsed) {
       if (isToken(token)) {
         let val = this[token]
-        if (/[H]/.test(token) && val !== '' && val !== undefined) {
-          val = this.hours?.toString()
+        if (/[H]/.test(token)) {
+          val = this.hours?.toString() || ''
         }
-        if (/[Mmdh]/.test(token) && val !== '' && val !== undefined) {
-          const padLength = val?.length > 1 || token.length > 1 ? 2 : 1
+        if (/[MmdhH]/.test(token) && val !== '' && val !== undefined) {
+          const padLength = val.length > 1 || token.length > 1 ? 2 : 1
           val = ('0' + val).slice(-padLength)
         }
         result += val !== '' ? val : repeat('#', token.length)

--- a/modules/cactus-web/src/helpers/dates.ts
+++ b/modules/cactus-web/src/helpers/dates.ts
@@ -352,60 +352,70 @@ export class PartialDate implements FormatTokenMap {
   private minutes?: number
   private period?: string
 
+  private _year?: string
+  private _month?: string
+  private _day?: string
+
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get M() {
-    return this.month === undefined ? '' : String(this.month + 1)
+    return this._month ? this._month.slice(-1) : ''
   }
 
-  public set M(value: string | number | undefined) {
+  public set M(value: string | undefined) {
     if (value === undefined) {
       this.month = value
+      this._month = value
     } else {
       this.month = Number(value) - 1
+      this._month = value
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get MM() {
-    return this.month === undefined ? '' : this.pad(this.month + 1)
+    return this._month === undefined ? '' : this._month.slice(-2)
   }
 
-  public set MM(value: string | number | undefined) {
+  public set MM(value: string | undefined) {
     this.M = value
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get d() {
-    return this.toRender(this.day, 1)
+    return this._day ? this._day.slice(-1) : ''
   }
 
-  public set d(value: string | number | undefined) {
+  public set d(value: string | undefined) {
     if (value === undefined) {
-      this.day = undefined
+      this.day = value
+      this._day = value
     } else {
-      this.day = Number(value) % 32
+      this.day = Number(value)
+      this._day = value
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get dd() {
-    return this.toRender(this.day, 2)
+    return this._day ? this._day.slice(-2) : ''
   }
 
-  public set dd(value: string | number | undefined) {
+  public set dd(value: string | undefined) {
     this.d = value
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public get YYYY() {
-    return this.toRender(this.year, 4)
+    return this._year ? this._year.slice(-4) : ''
   }
 
-  public set YYYY(value: string | number | undefined) {
+  public set YYYY(value: string | undefined) {
     if (value === undefined) {
       this.year = value
+      this._year = value
     } else {
       this.year = Number(value)
+      this._year = value
     }
   }
 
@@ -469,7 +479,7 @@ export class PartialDate implements FormatTokenMap {
     return this.pad(this.minutes)
   }
 
-  public set mm(value: string | number | undefined) {
+  public set mm(value: string | undefined) {
     if (value === undefined) {
       this.minutes = value
     } else {
@@ -503,6 +513,7 @@ export class PartialDate implements FormatTokenMap {
 
   public setYear(value: number): void {
     this.year = value
+    this._year = String(value)
   }
 
   public getMonth(): number {
@@ -511,6 +522,7 @@ export class PartialDate implements FormatTokenMap {
 
   public setMonth(value: number): void {
     this.month = value % 12
+    this._month = String((value % 12) + 1)
   }
 
   public getDate(): number {
@@ -519,6 +531,7 @@ export class PartialDate implements FormatTokenMap {
 
   public setDate(value: number): void {
     this.day = value % 32
+    this._day = String(value % 32)
   }
 
   public getHours(): number {
@@ -702,6 +715,9 @@ export class PartialDate implements FormatTokenMap {
     pd.hours = this.hours
     pd.minutes = this.minutes
     pd.period = this.period
+    pd._month = this._month
+    pd._day = this._day
+    pd._year = this._year
     return pd
   }
 


### PR DESCRIPTION
Ticket & UAT: https://repayonline.atlassian.net/browse/CACTUS-1113 

This didn't go quite as planned. Basically, to let the user accidentally put in wrong dates I removed all of that weird logic, and have it auto tab if they type '04' instead of '4', I had to keep track of everything as strings (which means the date object now has month and _month). That started a chain reaction of having to update crap everywhere. Like now the string had to be different from the stored value, etc. and I had to switch from the hour dictating the AM/PM value to the AM/PM value dictating the hour value. I also had to update misc stuff here and there.

I'll write more later but in the mean time, there are 2 tests I didn't fix because I'm worried this might be a breaking change after all. If you run `yarn web test -- date` you'll see that when value is passed to the DateInput component, (say 15), it doesn't update the value to 03 like it used to because now invalid date numbers are allowed. So anywhere that is using this as a controlled input might need to add more logic? 