### PR TITLE
CACTUS-1161 :: Fix Snyk Scan

### DIFF
--- a/modules/cactus-form/package.json
+++ b/modules/cactus-form/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.6.2"
   },
   "dependencies": {
-    "final-form": "^4.20.4",
+    "final-form": "^4.20.6",
     "react-final-form": "^6.5.8"
   },
   "peerDependencies": {

--- a/modules/cactus-form/package.json
+++ b/modules/cactus-form/package.json
@@ -59,13 +59,11 @@
     "@types/jest": "^27.4.1",
     "@types/react": "^17.0.40",
     "babel-jest": "^27.5.1",
-    "final-form": "^4.20.6",
     "jest": "^27.5.1",
     "jest-sonar": "^0.2.12",
     "prop-types": "^15.8.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-final-form": "^6.5.8",
     "typescript": "~4.6.2"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5106,7 +5106,7 @@ __metadata:
     "@types/jest": ^27.4.1
     "@types/react": ^17.0.40
     babel-jest: ^27.5.1
-    final-form: ^4.20.6
+    final-form: ^4.20.4
     jest: ^27.5.1
     jest-sonar: ^0.2.12
     prop-types: ^15.8.1
@@ -15398,6 +15398,15 @@ __metadata:
   peerDependencies:
     final-form: ^4.18.2
   checksum: bed684815967fa3e5b2cc91eb69e5d88e1048a5dbe421e2eb61b90434c634a09fec877ce52c85add8d009c20c052b6f2a884277d7ca80e9a628944a012d20205
+  languageName: node
+  linkType: hard
+
+"final-form@npm:^4.20.4":
+  version: 4.20.9
+  resolution: "final-form@npm:4.20.9"
+  dependencies:
+    "@babel/runtime": ^7.10.0
+  checksum: 2235a41864e0b8aa24a358b8896a02764735d3660cd8ee30b9cea9e6d3a6239e74d1b6bc5dea0e663a5b90393045783c7714ceea13bceffe10811915c88a8d60
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5106,7 +5106,7 @@ __metadata:
     "@types/jest": ^27.4.1
     "@types/react": ^17.0.40
     babel-jest: ^27.5.1
-    final-form: ^4.20.4
+    final-form: ^4.20.6
     jest: ^27.5.1
     jest-sonar: ^0.2.12
     prop-types: ^15.8.1
@@ -15401,21 +15401,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"final-form@npm:^4.20.4":
+"final-form@npm:^4.20.6":
   version: 4.20.9
   resolution: "final-form@npm:4.20.9"
   dependencies:
     "@babel/runtime": ^7.10.0
   checksum: 2235a41864e0b8aa24a358b8896a02764735d3660cd8ee30b9cea9e6d3a6239e74d1b6bc5dea0e663a5b90393045783c7714ceea13bceffe10811915c88a8d60
-  languageName: node
-  linkType: hard
-
-"final-form@npm:^4.20.6":
-  version: 4.20.7
-  resolution: "final-form@npm:4.20.7"
-  dependencies:
-    "@babel/runtime": ^7.10.0
-  checksum: 0e2a9a9cf70814e1099da38e8a79ff6dc2862f07217dae041ba70c5a4bcc8284c74b0500f00b4935331f5fbe7dc119f63ca4776495ecc8c486c939daa23598ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Ticket](https://repayonline.atlassian.net/browse/CACTUS-1161)

This was a little tricky to figure out. The error message in the action was telling me the problem was that there was no `node_modules` folder in `cactus-form`, so I thought I'd just need to install before running the scan. But even after installing, it was still failing. After going and finding the PR that started the failures, I noticed that it was the one where `final-form` and `react-final-form` were removed from `peerDependencies` and added as `dependencies`. Upon further inspection, I found that those two dependencies were still listed as `devDependencies`, which seems to be what was causing the issue -- even locally, installing wasn't creating a `node_modules` folder. Removing them from `devDependencies` caused them to be installed properly, fixing the problem with the Snyk scans.

The scans are set up to run only on master, but [here](https://github.com/repaygithub/cactus/actions/runs/4167038782) is a passing build from my testing so you can see that this fixes it.