### PR TITLE
revert node version in ci + master pipelines

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: NodeJS Version
         shell: bash
@@ -29,6 +32,9 @@ jobs:
     
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -51,6 +57,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -70,6 +79,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
@@ -96,6 +108,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies

--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
 
     - name: Decrypt secrets
       env:


### PR DESCRIPTION
The CI / master pipelines were failing because something updated the node version. Node was reverted to 16 so everything would pass again


Previous failing pipelines: 

1. https://github.com/repaygithub/cactus/actions/runs/4326887317
2. https://github.com/repaygithub/cactus/actions/runs/4326887323